### PR TITLE
Declare cookieNum with var so it is not global

### DIFF
--- a/lib/x11/auth.js
+++ b/lib/x11/auth.js
@@ -80,7 +80,7 @@ module.exports = function( display, host, cb )
         }
 
         var auth = parseXauth(data);
-        for (cookieNum in auth)
+        for (var cookieNum in auth)
         {
             var cookie = auth[cookieNum];
             if (cookie.display == display && cookie.address == host)


### PR DESCRIPTION
Found this 'leak' while performing some tests with the library
