### PR TITLE
Edit requrie pathes in examples

### DIFF
--- a/examples/screenshot.js
+++ b/examples/screenshot.js
@@ -1,4 +1,4 @@
-var x11 = require('../../lib/x11');
+var x11 = require('../lib/x11');
 var wid = process.argv[2];
 console.log(wid);
 

--- a/examples/simple/alloccolor.js
+++ b/examples/simple/alloccolor.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var Exposure = x11.eventMask.Exposure;
 

--- a/examples/simple/creategc.js
+++ b/examples/simple/creategc.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var PointerMotion = x11.eventMask.PointerMotion;
 x11.createClient(function(display) {

--- a/examples/smoketest/atoms.js
+++ b/examples/smoketest/atoms.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 x11.createClient(function(display) {
     var X = display.client;
     var hello = 'Hello, node.js';

--- a/examples/smoketest/benchmarks/atom_benchmark_buffered.js
+++ b/examples/smoketest/benchmarks/atom_benchmark_buffered.js
@@ -6,7 +6,7 @@
 // 0.4.9pre: 23300 +/-200 
 
 
-var x11 = require('../lib/x11');
+var x11 = require('../../../lib/x11');
 
 var xclient = x11.createClient();
 var counter = 0;

--- a/examples/smoketest/benchmarks/atom_benchmark_parallel.js
+++ b/examples/smoketest/benchmarks/atom_benchmark_parallel.js
@@ -9,7 +9,7 @@
 // 0.4.9pre:  16700 +/-300
 
 
-var x11 = require('../lib/x11');
+var x11 = require('../../../lib/x11');
 
 var xclient = x11.createClient();
 var reqcounter = 0;

--- a/examples/smoketest/benchmarks/query_pointer_benchmark_parallel.js
+++ b/examples/smoketest/benchmarks/query_pointer_benchmark_parallel.js
@@ -13,7 +13,7 @@
 // x11perf -sync -pointer  :
 // x11perf -pointer        :
 
-var x11 = require('../lib/x11');
+var x11 = require('../../../lib/x11');
 var X = x11.createClient();
 
 var total = 50000;

--- a/examples/smoketest/benchmarks/query_pointer_benchmark_sync.js
+++ b/examples/smoketest/benchmarks/query_pointer_benchmark_sync.js
@@ -13,7 +13,7 @@
 // x11perf -sync -pointer  :
 // x11perf -pointer        :
 
-var x11 = require('../lib/x11');
+var x11 = require('../../../lib/x11');
 var X = x11.createClient();
 
 var total = 50000;

--- a/examples/smoketest/bmp.js
+++ b/examples/smoketest/bmp.js
@@ -4,7 +4,7 @@
 var fs = require('fs');
 var Pixmap = require('./pixmap').Pixmap;
 var Buffer = require('buffer').Buffer;
-require('../lib/x11/unpackbuffer').addUnpack(Buffer);
+require('../../lib/x11/unpackbuffer').addUnpack(Buffer);
 
 var reversed = new Buffer(256);
 for (var i=0; i < 256; ++i)

--- a/examples/smoketest/changeprop.js
+++ b/examples/smoketest/changeprop.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var PointerMotion = x11.eventMask.PointerMotion;
 x11.createClient(function(display) {

--- a/examples/smoketest/copyarea.js
+++ b/examples/smoketest/copyarea.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var Window = require('./wndwrap');
 
 x11.createClient(function(display) {

--- a/examples/smoketest/damagetest.js
+++ b/examples/smoketest/damagetest.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 x11.createClient(function(display) {
     var X = display.client;

--- a/examples/smoketest/getkeyboardmapping.js
+++ b/examples/smoketest/getkeyboardmapping.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var ks = x11.keySyms;
 var ks2Name = {};

--- a/examples/smoketest/listext.js
+++ b/examples/smoketest/listext.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var X = x11.createClient();
 X.on('connect', function(display) {
     X.ListExtensions(function(err, list) {

--- a/examples/smoketest/map_unmap.js
+++ b/examples/smoketest/map_unmap.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var xclient = x11.createClient();
 var PointerMotion = x11.eventMask.PointerMotion;

--- a/examples/smoketest/polyfillrect.js
+++ b/examples/smoketest/polyfillrect.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var xclient = x11.createClient();
 var Exposure = x11.eventMask.Exposure;

--- a/examples/smoketest/polyline.js
+++ b/examples/smoketest/polyline.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var Exposure = x11.eventMask.Exposure;
 var PointerMotion = x11.eventMask.PointerMotion;

--- a/examples/smoketest/polypoint.js
+++ b/examples/smoketest/polypoint.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var Exposure = x11.eventMask.Exposure;
 var PointerMotion = x11.eventMask.PointerMotion;

--- a/examples/smoketest/polytext8.js
+++ b/examples/smoketest/polytext8.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var xclient = x11.createClient();
 var Exposure = x11.eventMask.Exposure;

--- a/examples/smoketest/putimage.js
+++ b/examples/smoketest/putimage.js
@@ -1,5 +1,5 @@
 var Buffer = require('buffer').Buffer;
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var fs = require('fs');
 var logo1bit = fs.readFileSync('./nodejs-black.bmp');
 var pixmap = require('./bmp').decodeBuffer(logo1bit);

--- a/examples/smoketest/putimage1.js
+++ b/examples/smoketest/putimage1.js
@@ -1,5 +1,5 @@
 var Buffer = require('buffer').Buffer;
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var xclient = x11.createClient();
 var Exposure = x11.eventMask.Exposure;

--- a/examples/smoketest/query_ext.js
+++ b/examples/smoketest/query_ext.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var X = x11.createClient();
 var numExt = 0;
 X.on('connect', function(display) {

--- a/examples/smoketest/query_pointer.js
+++ b/examples/smoketest/query_pointer.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 x11.createClient(function(display) {
     var X = display.client; 
     var screen = display.screen[0];

--- a/examples/smoketest/querytree.js
+++ b/examples/smoketest/querytree.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var wid = process.argv[2];
 console.log(wid);
 var wids = [];

--- a/examples/smoketest/sendevent.js
+++ b/examples/smoketest/sendevent.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var xclient = x11.createClient();
 var Exposure = x11.eventMask.Exposure;

--- a/examples/smoketest/shapetest.js
+++ b/examples/smoketest/shapetest.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 x11.createClient(function(display) {
     var X = display.client;

--- a/examples/smoketest/subwindows.js
+++ b/examples/smoketest/subwindows.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var Window = require('./wndwrap');
 
 x11.createClient(function(display) {

--- a/examples/smoketest/testwnd.js
+++ b/examples/smoketest/testwnd.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var Window = require('./wndwrap');
 
 var width = 700;

--- a/examples/smoketest/transpwindow.js
+++ b/examples/smoketest/transpwindow.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 x11.createClient(function(display) {
     var visual;

--- a/examples/smoketest/warppointer.js
+++ b/examples/smoketest/warppointer.js
@@ -1,5 +1,5 @@
 var angle = 0;
-var x11 = require('../lib/x11').createClient(function(display) {
+var x11 = require('../../lib/x11').createClient(function(display) {
     setInterval(function() {
         var x = 500 + 100*Math.cos(angle);
         var y = 500 + 100*Math.sin(angle);

--- a/examples/smoketest/wndwrap.js
+++ b/examples/smoketest/wndwrap.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 var Exposure = x11.eventMask.Exposure;
 var PointerMotion = x11.eventMask.PointerMotion;
 var ButtonPress = x11.eventMask.ButtonPress;

--- a/examples/smoketest/xcmisc.js
+++ b/examples/smoketest/xcmisc.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 x11.createClient(function(display) {
     var X = display.client;

--- a/examples/smoketest/xtesttest.js
+++ b/examples/smoketest/xtesttest.js
@@ -1,4 +1,4 @@
-var x11 = require('../lib/x11');
+var x11 = require('../../lib/x11');
 
 var xclient = x11.createClient(function(display) {
     var X = display.client;


### PR DESCRIPTION
I made tested with:

``` bash
Xephyr -screen 600x600 -br :1 
DISPLAY=:1 node appltwm.js
```

The pathes now look OK.

During my editing, I found some error like `bad drawable` `bad window`.
I don't what to do with them or if they need parameters. So I didn't record them.

Related: https://github.com/sidorares/node-x11/issues/17#issuecomment-10907024
