### PR TITLE
Propagate socket error when connecting to server

### DIFF
--- a/lib/x11/xcore.js
+++ b/lib/x11/xcore.js
@@ -59,6 +59,9 @@ function XClient(stream, displayNum, screenNum, options)
     stream.on('end', function() {
         client.emit('end');
     });
+    stream.on('error', function(err) {
+        client.emit('error', err);
+    });
 
     this.pack_stream = pack_stream;
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -28,3 +28,15 @@ describe('Client', function() {
      });
   });
 });
+
+describe('Create client to non existent display', function() {
+  it('should emit the corresponding connection error', function(done) {
+    var client = x11.createClient(function(dpy) {
+    }, ':44');
+    
+    client.on('error', function(err) {
+      err.errno.should.equal('ENOENT');
+      done();
+    });
+  })
+});


### PR DESCRIPTION
- Currently, if we had an error connecting to the X server, we had to catch it
  using process.on('uncaughtException', ...).
- Added a test case.
