### PR TITLE
Fix the parsing of the type field in Event msgs

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -235,7 +235,9 @@ XClient.prototype.AllocID = function()
 XClient.prototype.unpackEvent = function(type, seq, extra, code, raw)
 {
     var event = {}; // TODO: constructor & base functions
-    event.type = type;
+    // Remove the most significant bit. See Chapter 1, Event Format section in X11 protocol
+    // specification
+    event.type = type && 0x7F; 
     event.seq = seq;
 
     var extUnpacker = this.eventParsers[type];


### PR DESCRIPTION
- According to the standard, the most significant bit of the 8-bit type code is
  used to flag if the event was generated from a SendEvent request. See Event
  Format section in Chapter 1 of the specification.
