### PR TITLE
Really fix the parsing of the event type field

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -237,7 +237,8 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw)
     var event = {}; // TODO: constructor & base functions
     // Remove the most significant bit. See Chapter 1, Event Format section in X11 protocol
     // specification
-    event.type = type && 0x7F; 
+    type = type & 0x7F; 
+    event.type = type; 
     event.seq = seq;
 
     var extUnpacker = this.eventParsers[type];


### PR DESCRIPTION
- Typo: use the bitwise operator and not the comparison operator
