### PR TITLE
Cookies and byte order

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,6 +9,14 @@ function parseXauth( buf )
 {
     var offset = 0;
     var auth = [];
+    var cookieProperties = ['address', 'display', 'authName', 'authData'];
+
+    function handleCookieProperty(property) {
+        var length = buf.unpack('n', offset)[0];
+        offset += 2;
+        cookie[property] = buf.unpackString(length, offset);
+        offset += length; 
+    }
 
     while (offset < buf.length)
     {
@@ -25,20 +33,13 @@ function parseXauth( buf )
               5: 'ServerInterpreted', 
               6: 'InternetV6'
         };
-        var cookieFields = [
-            'address',
-            'display',
-            'authName',
-            'authData'
-        ];
         cookie.type = buf.unpack('n')[0];
-        offset += 2;
-        for (var i = 0; i < 4; i += 1) {
-            var length = buf.unpack('n', offset)[0];
-            offset += 2;
-            cookie[cookieFields[i]] = buf.unpackString(length, offset);
-            offset += length;
+        if (!typeToName[cookie.type]) {
+            console.warn('Unknown address type');
         }
+        offset += 2;
+        //JSHint becomes angry when handleCookieProperty is declared inside loop
+        cookieProperties.forEach(handleCookieProperty);
         auth.push(cookie);
     }
     return auth;

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -180,10 +180,19 @@ bl.unpack('C', function(res) {
 
 }
 
+function getByteOrder() {
+    var isLittleEndian = ((new Uint32Array((new Uint8Array([1,2,3,4])).buffer))[0] === 0x04030201);
+    if (isLittleEndian) {
+        return 'l'.charCodeAt(0);
+    } else {
+        return 'B'.charCodeAt(0);
+    }
+}
+
 function writeClientHello(stream, displayNum, authHost)
 {
     getAuthString( displayNum, authHost, function( authType, authData ) {
-        var byte_order = 'l'.charCodeAt(0); // TODO: byteorder!!!
+        var byte_order = getByteOrder();
         var protocol_major = 11; // TODO: config? env?
         var protocol_minor = 0;
         stream.pack(


### PR DESCRIPTION
Cookies properties are extracted using a loop.
The client byte ordering is derived by checking the system's endianness (currently there's no distinction between middle and big endianness).
