### PR TITLE
Fix null-reference errors from extension-tests

### DIFF
--- a/test-runner.js
+++ b/test-runner.js
@@ -2,7 +2,6 @@ var x11 = require('./lib');
 var Mocha = require('mocha');
 var fs = require('fs');
 var path = require('path');
-var util = require('util');
 var async = require('async');
 
 var mocha = new Mocha({
@@ -16,7 +15,7 @@ var mocha = new Mocha({
 // 3 - to be dpms capable.
 var run_dpms_test = function(X, cb) {
     X.require('dpms', function(err, ext) {
-        if (!util.isError(err)) {
+        if (!err) {
             var dpms = ext;
             dpms.GetVersion(undefined, undefined, function(err, version) {
                 if (!err && version[0] === 1 && version[1] === 1) {
@@ -36,14 +35,14 @@ var run_dpms_test = function(X, cb) {
 
 var run_xtest_test = function(X, cb) {
     X.require('xtest', function(err) {
-        if (!util.isError(err)) cb(true);
+        if (!err) cb(true);
         else cb(false);
     });
 };
 
 var run_randr_test = function(X, cb) {
     X.require('randr', function(err, ext) {
-        if (!util.isError(err)) {
+        if (!err) {
             var randr = ext;
             randr.QueryVersion(1, 2, function(err, version) {
                 if (err) {


### PR DESCRIPTION
I was getting errors when running the tests with `npm test` which seemed to indicate a null reference issue. Did some digging:

The callback functions in the extension tests were assuming they get either an `Error` or the extension object as a first parameter, but were being called with a possible error on first parameter, then extension as second.

Made some variables local while I was in there.
