### PR TITLE
Add LowerWindow method

### DIFF
--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -396,6 +396,11 @@ var templates = {
         }
    ],
 
+   LowerWindow: [
+        function(win) {
+            return module.exports.ConfigureWindow[0](win, { stackMode : 1 });
+        }
+   ],
 
    QueryTree: [
         ['CxSL', [15, 2]],

--- a/test/configure-window.js
+++ b/test/configure-window.js
@@ -72,6 +72,16 @@ describe('ConfigureWindow', function() {
         this.X.RaiseWindow(this.wid);
     });
 
+    it('should LowerWindow correctly', function(done) {
+        var self = this;
+        this.X.once('event', function(ev) {
+            ev.type.should.equal(22); /* ConfigureNotify */
+            ev.aboveSibling.should.equal(0); /* 0 -> no window below this */
+            done();
+        });
+        this.X.LowerWindow(this.wid);
+    });
+
     after(function(done) {
         this.X.DestroyWindow(this.wid);
         this.X.DestroyWindow(this.wid_helper);


### PR DESCRIPTION
The LowerWindow method is the opposite of the RaiseWindow method. Instead of the above value (0) it uses the below value (1) as described here:

http://tronche.com/gui/x/xlib/window/configure.html#XWindowChanges

The value can be seen in the `X.h` file itself (e.g. `/usr/include/x11/X.h`) in line 460 ff.:

```
/* Window stacking method (in configureWindow) */

#define Above                   0
#define Below                   1
#define TopIf                   2
#define BottomIf                3
#define Opposite                4

```
