### PR TITLE
feat: fix format of LeaveNotify event

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -275,8 +275,8 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.y = values[6];
         event.buttons = values[7];
         event.sameScreen = values[8];
-    } else if (type == 7) { //EnterNotify
-        event.name = 'EnterNotify'
+    } else if (type == 7 || type == 8) { //EnterNotify || LeaveNotify
+        event.name = type === 7 ? 'EnterNotify' : 'LeaveNotify';
         var values = raw.unpack('LLLssssSC');
         event.root = values[0]
         event.wid = values[1]


### PR DESCRIPTION
The LeaveNotify event has the same structure as the EnterNotify event (see https://github.com/sidorares/node-x11/blob/master/autogen/proto/xproto.xml#L536) so they can use the same event structure.
The LeaveNotify event didn't had any special handling beforehand so the event was empty.