### PR TITLE
Remove debug messages from MappingNotify

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -408,9 +408,6 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.request = headerBuf[4];
         event.firstKeyCode = headerBuf[5];
         event.count = headerBuf[6];
-        // TODO cleanup
-        console.log(values);
-        console.log(raw);
     }
     return event;
 }


### PR DESCRIPTION
I have verified that MappingNotify works as expected, so I think these can be removed. I would create a test but `SetModifierMapping`, `ChangeKeyboardMapping` and `SetPointerMapping` are not implemented in node-x11.