### PR TITLE
src: fix CreateNotify parsing and add new test

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -301,7 +301,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.height = values[3];
         event.count = values[4]; // TODO: ???
     } else if (type == 16) { // CreateNotify
-        var values = raw.unpack('LLssSSSc');
+        var values = raw.unpack('LssSSSc');
         event.name = 'CreateNotify'
         event.parent = extra;
         event.wid = values[0];

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -313,24 +313,24 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.overrideRedirect = values[6] ? true : false;
         // x, y, width, height, border
     } else if (type == 17) { // destroy notify
-        var values = raw.unpack('LL');
+        var values = raw.unpack('L');
         event.name = 'DestroyNotify'
         event.event = extra;
         event.wid = values[0];
     } else if (type == 18) { // UnmapNotify
-        var values = raw.unpack('LLC');
+        var values = raw.unpack('LC');
         event.name = 'UnmapNotify'
         event.event = extra;
         event.wid = values[0];
         event.fromConfigure = values[1] ? true : false;
     } else if (type == 19) { // MapNotify
-        var values = raw.unpack('LLC');
+        var values = raw.unpack('LC');
         event.name = 'MapNotify'
         event.event = extra;
         event.wid = values[0];
         event.overrideRedirect = values[1] ? true : false;
     } else if (type == 20) {
-        var values = raw.unpack('LL');
+        var values = raw.unpack('L');
         event.name = 'MapRequest'
         event.parent = extra;
         event.wid = values[0];

--- a/test/core-CreateWindow.js
+++ b/test/core-CreateWindow.js
@@ -57,4 +57,24 @@ describe('CreateWindow request', function() {
           done();
       });
   });
+
+  it('should emit CreateNotify event when', function(done) {
+      var wid = X.AllocID();
+      var root = display.screen[0].root;
+      X.ChangeWindowAttributes(root, { eventMask: x11.eventMask.SubstructureNotify });
+      X.on('event', function(ev) {
+        ev.name.should.equal('CreateNotify');
+        ev.parent.should.equal(root);
+        ev.wid.should.equal(wid);
+        ev.x.should.equal(0);
+        ev.y.should.equal(0);
+        ev.width.should.equal(1);
+        ev.height.should.equal(1);
+        ev.borderWidth.should.equal(0);
+        ev.overrideRedirect.should.equal(false);
+        done();
+      });
+
+      X.CreateWindow(wid, root, 0, 0, 1, 1); // 1x1 pixel window
+  })
 });

--- a/test/core-CreateWindow.js
+++ b/test/core-CreateWindow.js
@@ -63,18 +63,41 @@ describe('CreateWindow request', function() {
       var root = display.screen[0].root;
       X.ChangeWindowAttributes(root, { eventMask: x11.eventMask.SubstructureNotify });
       X.on('event', function(ev) {
-        ev.name.should.equal('CreateNotify');
-        ev.parent.should.equal(root);
-        ev.wid.should.equal(wid);
-        ev.x.should.equal(0);
-        ev.y.should.equal(0);
-        ev.width.should.equal(1);
-        ev.height.should.equal(1);
-        ev.borderWidth.should.equal(0);
-        ev.overrideRedirect.should.equal(false);
-        done();
+        switch (ev.name) {
+          case 'CreateNotify':
+            ev.parent.should.equal(root);
+            ev.wid.should.equal(wid);
+            ev.x.should.equal(0);
+            ev.y.should.equal(0);
+            ev.width.should.equal(1);
+            ev.height.should.equal(1);
+            ev.borderWidth.should.equal(0);
+            ev.overrideRedirect.should.equal(false);
+          break;
+
+          case 'MapNotify':
+            ev.event.should.equal(root);
+            ev.wid.should.equal(wid);
+            ev.overrideRedirect.should.equal(false);
+            X.UnmapWindow(wid);
+          break;
+
+          case 'UnmapNotify':
+            ev.event.should.equal(root);
+            ev.wid.should.equal(wid);
+            ev.fromConfigure.should.equal(false);
+            X.DestroyWindow(wid);
+          break;
+
+          case 'DestroyNotify':
+            ev.event.should.equal(root);
+            ev.wid.should.equal(wid);
+            done();
+          break;
+        }
       });
 
       X.CreateWindow(wid, root, 0, 0, 1, 1); // 1x1 pixel window
+      X.MapWindow(wid);
   })
 });


### PR DESCRIPTION
- The first 4 fields in an event 'CCSL' are already unpacked in
  expectReplyHeader. No need to get the L field again: it is already in the
  'extra' variable.