### PR TITLE
Adds missed AltGr keycode

### DIFF
--- a/lib/keysyms.js
+++ b/lib/keysyms.js
@@ -1,4 +1,5 @@
 // TODO: add more XF86XK_* codes from http://codesearch.google.com/#FIqYkqGz-i8/classlib/modules/awt/src/main/java/unix/org/apache/harmony/awt/nativebridge/linux/X11Defs.java
+// or from http://cgit.freedesktop.org/xorg/proto/xproto/tree/keysymdef.h
 module.exports = {
     XK_VoidSymbol: 0xFFFFFF,
     XK_BackSpace: 0xFF08,
@@ -993,5 +994,7 @@ module.exports = {
     XK_hebrew_shin: 0xcf9,
     XK_hebrew_taw: 0xcfa,
     XK_hebrew_taf: 0xcfa,
-    XK_Hebrew_switch: 0xFF7E
+    XK_Hebrew_switch: 0xFF7E,
+    XK_ISO_Level3_Shift: 0xFE03,
+    NoSymbol: 0
 };


### PR DESCRIPTION
`XK_ISO_Level3_Shift` is the code name for `AltGr`.

`NoSymbol` will help us to know when a keycode is meaningless or if it is unknown.

Also, i believe http://cgit.freedesktop.org/xorg/proto/xproto/tree/keysymdef.h is a better source to find keycodes. :-)