### PR TITLE
Xauth fixes

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -5,6 +5,19 @@ var Buffer = require('buffer').Buffer;
 // add 'unpack' method for buffer
 require('./unpackbuffer').addUnpack(Buffer);
 
+var typeToName = {
+    256: 'Local',
+  65535: 'Wild',
+    254: 'Netname',
+    253: 'Krb5Principal',
+    252: 'LocalHost',
+      0: 'Internet',
+      1: 'DECnet',
+      2: 'Chaos',
+      5: 'ServerInterpreted',
+      6: 'InternetV6'
+};
+
 function parseXauth( buf )
 {
     var offset = 0;
@@ -14,20 +27,7 @@ function parseXauth( buf )
     while (offset < buf.length)
     {
         var cookie = {};
-        var typeToName = {
-            256: 'Local',
-          65535: 'Wild',
-            254: 'Netname',
-            253: 'Krb5Principal',
-            252: 'LocalHost',
-              0: 'Internet',
-              1: 'DECnet',
-              2: 'Chaos',
-              5: 'ServerInterpreted',
-              6: 'InternetV6'
-        };
         cookie.type = buf.readUInt16LE(offset);
-        console.log('Cookie type: ');
         if (!typeToName[cookie.type]) {
             console.warn('Unknown address type');
         }
@@ -76,7 +76,8 @@ module.exports = function( display, host, cb )
     for (var cookieNum in auth)
     {
       var cookie = auth[cookieNum];
-      if (cookie.display === display && cookie.address === host)
+      if ((typeToName[cookie.family] === 'Wild' || cookie.address === host) &&
+          (cookie.display.length === 0 || cookie.display === display))
         return cb( null, cookie );
     }
     cb(new Error('No auth cookie matching display=' + display + ' and  host=' + host));

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -60,7 +60,13 @@ function readXauthority(cb) {
     if(err.code == 'ENOENT') {
       // Xming/windows uses %HOME%/Xauthority ( .Xauthority with no dot ) - try with this name
       filename = process.env.XAUTHORITY || path.join(homedir(), 'Xauthority');
-      return fs.readFile(filename, cb);
+      fs.readFile(filename, function (err, data) {
+        if (err.code == 'ENOENT') {
+          cb(null, null);
+        } else {
+          cb(err);
+        }
+      });
     } else {
       cb(err);
     }
@@ -71,6 +77,13 @@ module.exports = function( display, host, cb )
 {
   readXauthority(function(err, data) {
     if(err) return cb(err);
+
+    if (!data) {
+      return cb(null, {
+        authName: '',
+        authData: ''
+      });
+    }
 
     var auth = parseXauth(data);
     for (var cookieNum in auth)

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -49,17 +49,17 @@ function parseXauth( buf )
     return auth;
 }
 
-var os   = require('os');
+var homedir = require('os-homedir');
 var path = require('path');
 
 function readXauthority(cb) {
-  var filename = process.env.XAUTHORITY || path.join(os.homedir(), '.Xauthority');
+  var filename = process.env.XAUTHORITY || path.join(homedir(), '.Xauthority');
   fs.readFile(filename, function(err, data) {
     if (!err)
       return cb(null, data);
     if(err.code == 'ENOENT') {
       // Xming/windows uses %HOME%/Xauthority ( .Xauthority with no dot ) - try with this name
-      filename = process.env.XAUTHORITY || path.join(os.homedir(), 'Xauthority');
+      filename = process.env.XAUTHORITY || path.join(homedir(), 'Xauthority');
       return fs.readFile(filename, cb);
     } else {
       cb(err);

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -192,7 +192,9 @@ function getByteOrder() {
 function writeClientHello(stream, displayNum, authHost)
 {
     getAuthString( displayNum, authHost, function( err, cookie ) {
-        debugger;
+        if (err) {
+            throw err;
+        }
         var byte_order = getByteOrder();
         var protocol_major = 11; // TODO: config? env?
         var protocol_minor = 0;

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   "scripts": {
     "test": "node test-runner.js",
     "prepublish": "npm prune"
+  },
+  "dependencies": {
+    "os-homedir": "^1.0.1"
   }
 }


### PR DESCRIPTION
Handles auth cookies with empty address as well as circumstances where there is no .Xauthority file at all. The logic for finding the cookie is based on libXau's [XauGetAuthByAddr](http://cgit.freedesktop.org/xorg/lib/libXau/tree/AuGetAddr.c#n87).

Also uses os-homedir to support versions of Node.js older than v2.3.0.