### PR TITLE
Unpack handshake error

### DIFF
--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -116,9 +116,14 @@ bl.unpack('C', function(res) {
      if (res[0] == 0)
      {
          // conection time error
-         // unpack error (? TODO)
-         var err = new Error;
-         cb(err); // TODO: detect that this is error on xcore side
+         // unpack error
+         bl.unpack('Cxxxxxx', function (rlen) {
+             bl.get(rlen[0], function (reason) {
+                 var err = new Error;
+                 err.message = 'X server connection failed: ' + reason.toString();
+                 cb(err);
+             });
+         });
          // TODO: do we need to close stream from our side?
          // TODO: api to close source stream via attached unpackstream
          return;


### PR DESCRIPTION
Unpack the handshake error so we can populate the Error message with the reason for failure.