### PR TITLE
Added ShapeNotify event parsing

### DIFF
--- a/lib/ext/shape.js
+++ b/lib/ext/shape.js
@@ -112,5 +112,31 @@ exports.requireExt = function(display, callback)
             callback(null, ext);
         });
         */
+
+        ext.events = {
+            ShapeNotify: 0
+        }
+
+        X.eventParsers[ext.firstEvent + ext.events.ShapeNotify] = function(type, seq, extra, code, raw)
+        {
+            var event = {};
+            event.type = type;
+            event.kind = code;
+            event.seq = seq;
+
+            event.window = extra;
+
+            var values = raw.unpack('ssSSLC');
+
+            event.x = values[0];
+            event.y = values[1];
+            event.width = values[2];
+            event.height = values[3];
+            event.time = values[4];
+            event.shaped = values[5];
+            event.name = 'ShapeNotify';
+
+            return event;
+        };
     });
 }


### PR DESCRIPTION
In #149 I mentioned how the Shape extension does not include parsing for the event ShapeNotify. Thanks to the help of @santigimeno I was able to implement it.