### PR TITLE
Stop testing on Node 0.10 + 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
 
 language: node_js
 node_js:
-   - '0.10'
-   - '0.12'
    - '4.2'
    - '5'
    - '6'


### PR DESCRIPTION
As watchers may have noticed from greenkeeper-bot's misguided spam on #158, something is breaking the build.  It is in fact not sinon, but [Node.js versions 0.10 and 0.12, because they don't support modern JS features](https://travis-ci.org/sidorares/node-x11/jobs/332470797#L531-L533) that Mocha has started using—stuff like `const`.

[Newer Node.js versions pass.](https://travis-ci.org/sidorares/node-x11/builds/332470795)

Anyone still use 0.10 or 0.12?

I don't think supporting them is worth it.