### PR TITLE
Replaced os-homedir (deprecated) with os.homedir()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.log
+yarn.lock
+package-lock.json
+node_modules

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -50,7 +50,7 @@ function parseXauth( buf )
     return auth;
 }
 
-var homedir = require('os-homedir');
+var homedir = require('os').homedir();
 var path = require('path');
 
 function readXauthority(cb) {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,5 @@
     "test": "node test-runner.js",
     "prepublish": "npm prune"
   },
-  "dependencies": {
-    "os-homedir": "^1.0.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
[os-homedir](https://www.npmjs.com/package/os-homedir) was deprecated in 2018, in favor of `require('os').homedir()` which is built into node.js.

Also, I'm working on a project using this package and there's a chance I may find something to improve - for example I'm working on creating TypeScript definitions for X11 - would you be interested in receiving those improvements as PRs?