### PR TITLE
Remove unnecessary parentheses from require('os').homedir()

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -50,7 +50,7 @@ function parseXauth( buf )
     return auth;
 }
 
-var homedir = require('os').homedir();
+var homedir = require('os').homedir;
 var path = require('path');
 
 function readXauthority(cb) {


### PR DESCRIPTION
I got this error because of this parentheses:
```
/PATH/TO/REPO/node-x11/lib/auth.js:57
  var filename = process.env.XAUTHORITY || path.join(homedir(), '.Xauthority');
                                                     ^

TypeError: homedir is not a function
```