### PR TITLE
WIP: Introduce eslint, and conform to its recommended rule set

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+    "env": {
+        "node": true,
+        "commonjs": true,
+        "es2021": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12
+    },
+    "rules": {
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,8 @@ module.exports = {
         "ecmaVersion": 12
     },
     "rules": {
-    }
+        // Allow unused function arguments with names beginning in an
+        // underscore, to document that is _could_ be used.
+        "no-unused-vars": ['error', { argsIgnorePattern: '^_' } ],
+    },
 };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -63,7 +63,7 @@ function readXauthority(cb) {
       filename = process.env.XAUTHORITY || path.join(homedir(), 'Xauthority');
       fs.readFile(filename, function (err, data) {
         if (err.code == 'ENOENT') {
-          cb(null, null);
+          cb(null, data);
         } else {
           cb(err);
         }

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -166,27 +166,27 @@ var valueMask = {
         mask: 0x000001,
         format: 'sxx'
       },
-    	y                       : {
+      y                       : {
         mask: 0x000002,
         format: 'sxx'
       },
-    	width                   : {
+      width                   : {
         mask: 0x000004,
         format: 'Sxx'
       },
-    	height                  : {
+      height                  : {
         mask: 0x000008,
         format: 'Sxx'
       },
-    	borderWidth             : {
+      borderWidth             : {
         mask: 0x000010,
         format: 'Sxx'
       },
-    	sibling                 : {
+      sibling                 : {
         mask: 0x000020,
         format: 'L'
       },
-    	stackMode               : {
+      stackMode               : {
         mask: 0x000040,
         format: 'Cxxx'
       }
@@ -921,7 +921,7 @@ var templates = {
        [ 'CxSLSSSxx', [84, 4] ], // params: colormap, red, green, blue
 
        function(buf) {
-	   var res = buf.unpack('SSSxL');
+       var res = buf.unpack('SSSxL');
            var color = {};
            color.red   = res[0];
            color.blue  = res[1];
@@ -938,7 +938,7 @@ var templates = {
        },
 
        function(buf) {
-	   var res = buf.unpack('CCCC');
+       var res = buf.unpack('CCCC');
            var ext = {};
            ext.present = res[0];
            ext.majorOpcode = res[1];
@@ -990,23 +990,23 @@ var templates = {
    ],
 
         // todo: move up to keep reque
-	GetGeometry: [
-		function(drawable){
-			return ['CxSL', [14, 2, drawable]]
-		},
-		function(buff, depth)
-		{
-			var res = buff.unpack('LssSSSx');
-			var ext = {};
-			ext.windowid = res[0]
-			ext.xPos = res[1];
-			ext.yPos = res[2];
-			ext.width = res[3];
-			ext.height = res[4];
-			ext.borderWidth = res[5];
-			ext.depth = depth;
-			return ext;
-		}
+    GetGeometry: [
+        function(drawable){
+            return ['CxSL', [14, 2, drawable]]
+        },
+        function(buff, depth)
+        {
+            var res = buff.unpack('LssSSSx');
+            var ext = {};
+            ext.windowid = res[0]
+            ext.xPos = res[1];
+            ext.yPos = res[2];
+            ext.width = res[3];
+            ext.height = res[4];
+            ext.borderWidth = res[5];
+            ext.depth = depth;
+            return ext;
+        }
    ],
 
    KillClient: [

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -1023,7 +1023,7 @@ var templates = {
    
    Bell: [
        function(percent) {
-           return ["CxCs",[108,1]];
+           return ["CCS",[104, percent, 1]];
        }
    ],
 

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -2,7 +2,7 @@
 // http://www.opensource.apple.com/source/X11server/X11server-106.7/kdrive/xorg-server-1.6.5-apple3/dix/protocol.txt
 
 var xutil = require('./xutil');
-var hexy = require('./hexy').hexy;
+//var hexy = require('./hexy').hexy;
 
 var valueMask = {
     CreateWindow: {
@@ -233,7 +233,7 @@ function packValueMask(reqname, values)
     var args = [];
     for (var i=0,length=masksList.length;i<length;i++)
     {
-        var value = masksList[i];
+        let value = masksList[i];
         var valueName = reqValueMaskName[value];
         format += reqValueMask[valueName].format
         args.push( values[valueName] );
@@ -735,13 +735,13 @@ var templates = {
 
    CreateCursor: [
        function(cid, source, mask, foreRGB, backRGB, x, y) {
-          foreR = foreRGB.R
-          foreG = foreRGB.G
-          foreB = foreRGB.B
+          const foreR = foreRGB.R
+          const foreG = foreRGB.G
+          const foreB = foreRGB.B
 
-          backR = backRGB.R
-          backG = backRGB.G
-          backB = backRGB.B
+          const backR = backRGB.R
+          const backG = backRGB.G
+          const backB = backRGB.B
           return [ 'CxSLLLSSSSSSSS', [93, 8, cid, source, mask, foreR, foreG, foreB, backR, backG, backB, x, y] ];
        }
    ],
@@ -881,7 +881,7 @@ var templates = {
           var numItems = items.length;
           var reqLen = 16;
           var args = [74, 0, drawable, gc, x, y];
-          for (var i=0; i < numItems; ++i)
+          for (let i=0; i < numItems; ++i)
           {
               var it = items[i];
               if (typeof it == 'string')
@@ -901,7 +901,7 @@ var templates = {
           var padLen = len4*4 - reqLen;
           args[1] = len4; // set request length to calculated value
           var pad = '';
-          for (var i=0; i < padLen; ++i)
+          for (let i=0; i < padLen; ++i)
              pad += String.fromCharCode(0);
           format += 'a';
           args.push(pad);

--- a/lib/ext/apple-wm.js
+++ b/lib/ext/apple-wm.js
@@ -2,7 +2,6 @@
 // http://opensource.apple.com/source/X11server/X11server-106.3/Xquartz/xorg-server-1.10.2/hw/xquartz/applewm.c
 // /usr/X11/include/X11/extensions/applewm.h
 
-var x11 = require('..');
 var xutil = require('../xutil');
 // TODO: move to templates
 
@@ -31,7 +30,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCS', [ext.majorOpcode, 0, 1]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('SSL');
                     return res;
                 },
@@ -51,7 +50,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCSSSSSSSSSSS', [ext.majorOpcode, 1, 6, frame_class, frame_rect, ix, iy, iw, ih, ox, oy, ow, oh, cb]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('SSSS');
                     return {
                         x: res[0],
@@ -70,7 +69,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCSSxxSSSSSSSSSS', [ext.majorOpcode, 2, 7, frame_class, px, py, ix, iy, iw, ih, ox, oy, ow, oh]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('L');
                     return res[0];
                 },
@@ -184,13 +183,14 @@ exports.requireExt = function(display, callback)
 
         // shortcut is single-byte ASCII (optional, 0=no shortcut)
         // items example: [ 'item1', 'some item', ['C', 'item with C shortcut'] ]
-        ext.SetWindowMenu = function(items)
+        ext.SetWindowMenu = function(_items)
         {
-           var reqlen = 8;
-           var extlength = 0;
-           items.forEach(function(i) {
+           // TODO
+           //var reqlen = 8;
+           //var extlength = 0;
+           //items.forEach(function(i) {
 
-           });
+           //});
         }
 
         // https://developer.apple.com

--- a/lib/ext/composite.js
+++ b/lib/ext/composite.js
@@ -24,7 +24,7 @@ exports.requireExt = function(display, callback)
 
         ext.Redirect = {
             Automatic: 0,
-	    Manual: 1
+        Manual: 1
         };
 
         ext.QueryVersion = function(clientMaj, clientMin, callback)

--- a/lib/ext/damage.js
+++ b/lib/ext/damage.js
@@ -11,9 +11,9 @@ exports.requireExt = function(display, callback)
         if (!ext.present)
             return callback(new Error('extension not available'));
 
-        ext.ReportLevel	= {
+        ext.ReportLevel = {
             RawRectangles: 0,
-	    DeltaRectangles: 1,
+        DeltaRectangles: 1,
             BoundingBox: 2,
             NonEmpty: 3
         };

--- a/lib/ext/damage.js
+++ b/lib/ext/damage.js
@@ -1,6 +1,5 @@
 // http://www.x.org/releases/X11R7.6/doc/damageproto/damageproto.txt
 
-var x11 = require('..');
 // TODO: move to templates
 
 exports.requireExt = function(display, callback)
@@ -23,7 +22,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCSLL', [ext.majorOpcode, 0, 3, clientMaj, clientMin]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('LL');
                     return res;
                 },

--- a/lib/ext/glx.js
+++ b/lib/ext/glx.js
@@ -297,27 +297,27 @@ exports.requireExt = function(display, callback)
             return require('./glxrender')(this, ctx);
         }
 
-	var errors = [
-	  "context",
-	  "contect state",
-	  "drawable",
-	  "pixmap",
-	  "context tag",
-	  "current window",
-	  "Render request",
-	  "RenderLarge request",
-	  "(unsupported) VendorPrivate request",
-	  "FB config",
-	  "pbuffer",
-	  "current drawable",
-	  "window"
+        var errors = [
+            "context",
+            "contect state",
+            "drawable",
+            "pixmap",
+            "context tag",
+            "current window",
+            "Render request",
+            "RenderLarge request",
+            "(unsupported) VendorPrivate request",
+            "FB config",
+            "pbuffer",
+            "current drawable",
+            "window"
         ];
 
-	errors.forEach(function(message, code) {
-  	  X.errorParsers[ext.firstError + code] = function(err) {
-	    err.message = "GLX: Bad " + message;
-	  };
-	});
+        errors.forEach(function(message, code) {
+            X.errorParsers[ext.firstError + code] = function(err) {
+                err.message = "GLX: Bad " + message;
+            };
+        });
 
         callback(null, ext);
     });

--- a/lib/ext/randr.js
+++ b/lib/ext/randr.js
@@ -233,7 +233,7 @@ exports.requireExt = function(display, callback)
                     format = Array(res[9] + 1).join('L');
                     info.clones = buf.unpack(format, pos);
                     pos +=  res[9] << 2;
-                    info.name = buf.slice(pos, pos + res_modes[10]).toString('binary');
+                    info.name = buf.slice(pos, pos + res[10]).toString('binary');
                     return info;
                 },
                 cb

--- a/lib/ext/randr.js
+++ b/lib/ext/randr.js
@@ -1,6 +1,5 @@
 // http://www.x.org/releases/X11R7.6/doc/randrproto/randrproto.txt
 
-var x11 = require('..');
 // TODO: move to templates
 
 exports.requireExt = function(display, callback)
@@ -19,7 +18,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCSLL', [ext.majorOpcode, 0, 3, clientMaj, clientMin]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('LL');
                     return res;
                 },
@@ -88,7 +87,6 @@ exports.requireExt = function(display, callback)
                     }
                 },
                 function(err, res) {
-                    var err;
                     if (res.status !== 0) {
                         err = new Error('SetScreenConfig error');
                         err.code = res.status;
@@ -113,7 +111,7 @@ exports.requireExt = function(display, callback)
             X.pack_stream.pack('CCSL', [ext.majorOpcode, 5, 2, win]);
             X.replies[X.seq_num] = [
                 function(buf, opt) {
-                    var i, j;
+                    var i;
                     var res = buf.unpack('LLLSSSSSS');
                     var info = {
                         rotations : opt,
@@ -157,7 +155,7 @@ exports.requireExt = function(display, callback)
             X.seq_num ++;
             X.pack_stream.pack('CCSL', [ext.majorOpcode, 8, 2, win]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var i;
                     var pos = 0;
                     var res = buf.unpack('LLSSSSxxxxxxxx');
@@ -175,7 +173,7 @@ exports.requireExt = function(display, callback)
                     resources.outputs = buf.unpack(format, pos);
                     pos +=  res[3] << 2;
                     format = Array(res[4] + 1).join('LSSLSSSSSSSSL');
-                    res_modes = buf.unpack(format, pos);
+                    const res_modes = buf.unpack(format, pos);
                     pos +=  res[4] << 5;
                     for (i = 0; i < res[4]; i+= 13) {
                         resources.modeinfos.push({
@@ -209,8 +207,7 @@ exports.requireExt = function(display, callback)
             X.seq_num ++;
             X.pack_stream.pack('CCSLL', [ext.majorOpcode, 9, 3, output, ts ]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
-                    var i;
+                function(buf, _opt) {
                     var pos = 0;
                     var res = buf.unpack('LLLLCCSSSSS');
                     var info = {

--- a/lib/ext/render.js
+++ b/lib/ext/render.js
@@ -1,4 +1,7 @@
-var x11 = require('..');
+// Eslint is fussy about sparse arrays, but they're much clearer than the
+// alternative here.
+/* eslint-disable no-sparse-arrays */
+
 var xutil = require('../xutil');
 
 // adding XRender functions manually from
@@ -16,7 +19,7 @@ exports.requireExt = function(display, callback) {
       X.seq_num++;
       X.pack_stream.pack('CCSLL', [ext.majorOpcode, 0, 3, clientMaj, clientMin]);
       X.replies[X.seq_num] = [
-        function(buf, opt) {
+        function(buf, _opt) {
           var res = buf.unpack('LL');
           return res;
         },
@@ -29,7 +32,7 @@ exports.requireExt = function(display, callback) {
       X.pack_stream.pack('CCS', [ext.majorOpcode, 1, 1]);
       X.seq_num++;
       X.replies[X.seq_num] = [
-        function(buf, opt) {
+        function(buf, _opt) {
           var res = {};
           var res1 = buf.unpack('LLLLL');
           var num_formats = res1[0];
@@ -41,7 +44,6 @@ exports.requireExt = function(display, callback) {
           var offset = 24;
           res.formats = [];
           for (var i = 0; i < num_formats; ++i) {
-            var format = {};
             var f = buf.unpack('LCCxxSSSSSSSSL', offset);
             res.formats.push(f);
             offset += 28;
@@ -57,18 +59,18 @@ exports.requireExt = function(display, callback) {
       X.pack_stream.pack('CCSL', [ext.majorOpcode, 29, 2, display.screen[0].root]);
       X.seq_num++;
       X.replies[X.seq_num] = [
-        function(buf, opt) {
+        function(buf, _opt) {
           var h = buf.unpack('LL');
           var num_aliases = h[0];
           var num_filters = h[1];
           var aliases = [];
           var offset = 24; // LL + 16 bytes pad
-          for (var i = 0; i < num_aliases; ++i) {
+          for (let i = 0; i < num_aliases; ++i) {
             aliases.push(buf.unpack('S', offset)[0]);
             offset += 2;
           }
           var filters = [];
-          for (var i = 0; i < num_filters; ++i) {
+          for (let i = 0; i < num_filters; ++i) {
             var len = buf.unpack('C', offset)[0];
             //if (!len) break;
             offset++;
@@ -127,7 +129,7 @@ exports.requireExt = function(display, callback) {
         }
         var pad4 = (valuesLength + 3) >> 2;
         var toPad = (pad4 << 2) - valuesLength;
-        for (var i = 0; i < toPad; ++i) format += 'x';
+        for (let i = 0; i < toPad; ++i) format += 'x';
         reqLen += pad4;
         params[2] = reqLen;
         params[6] = mask;
@@ -247,15 +249,15 @@ exports.requireExt = function(display, callback) {
 
       // [ [float stopDist, [float r, g, b, a] ], ...]
       // stop distances
-      for (var i = 0; i < stops.length; ++i) {
+      for (let i = 0; i < stops.length; ++i) {
         format += 'L';
         // TODO: we know total params length in advance. ? params[index] =
         params.push(floatToFix(stops[i][0]));
       }
       // colors
-      for (var i = 0; i < stops.length; ++i) {
+      for (let i = 0; i < stops.length; ++i) {
         format += 'SSSS';
-        for (var j = 0; j < 4; ++j) params.push(colorToFix(stops[i][1][j]));
+        for (let j = 0; j < 4; ++j) params.push(colorToFix(stops[i][1][j]));
       }
       X.pack_stream.pack(format, params);
       X.pack_stream.flush();
@@ -275,15 +277,15 @@ exports.requireExt = function(display, callback) {
 
       // [ [float stopDist, [float r, g, b, a] ], ...]
       // stop distances
-      for (var i = 0; i < stops.length; ++i) {
+      for (let i = 0; i < stops.length; ++i) {
         format += 'L';
         // TODO: we know total params length in advance. ? params[index] =
         params.push(floatToFix(stops[i][0]));
       }
       // colors
-      for (var i = 0; i < stops.length; ++i) {
+      for (let i = 0; i < stops.length; ++i) {
         format += 'SSSS';
-        for (var j = 0; j < 4; ++j) params.push(colorToFix(stops[i][1][j]));
+        for (let j = 0; j < 4; ++j) params.push(colorToFix(stops[i][1][j]));
       }
       X.pack_stream.pack(format, params);
       X.pack_stream.flush();
@@ -302,13 +304,13 @@ exports.requireExt = function(display, callback) {
 
       // [ [float stopDist, [float r, g, b, a] ], ...]
       // stop distances
-      for (var i = 0; i < stops.length; ++i) {
+      for (let i = 0; i < stops.length; ++i) {
         format += 'L';
         // TODO: we know total params length in advance. ? params[index] =
         params.push(floatToFix(stops[i][0]));
       }
       // colors
-      for (var i = 0; i < stops.length; ++i) {
+      for (let i = 0; i < stops.length; ++i) {
         format += 'SSSS';
         for (var j = 0; j < 4; ++j) params.push(colorToFix(stops[i][1][j]));
       }
@@ -436,7 +438,6 @@ exports.requireExt = function(display, callback) {
       var imageBytes = 0;
       var glyphPaddedLength;
       var glyphLength;
-      var stride;
       var glyph;
       for (var i = 0; i < numGlyphs; i++) {
         glyph = glyphs[i];
@@ -463,11 +464,11 @@ exports.requireExt = function(display, callback) {
       X.pack_stream.pack('CCSLLL', [ext.majorOpcode, 20, 0, len + 1, gsid, glyphs.length]);
 
       // glyph ids
-      for (i = 0; i < numGlyphs; i++) {
+      for (let i = 0; i < numGlyphs; i++) {
         X.pack_stream.pack('L', [glyphs[i].id]);
       }
       // width + heiht + origin xy + advance xy
-      for (i = 0; i < numGlyphs; i++) {
+      for (let i = 0; i < numGlyphs; i++) {
         X.pack_stream.pack('SSssss', [
           glyphs[i].width,
           glyphs[i].height,
@@ -478,7 +479,7 @@ exports.requireExt = function(display, callback) {
         ]);
       }
       // image
-      for (i = 0; i < numGlyphs; i++) {
+      for (let i = 0; i < numGlyphs; i++) {
         X.pack_stream.write_queue.push(glyphs[i].image);
       }
       X.pack_stream.flush();
@@ -490,10 +491,10 @@ exports.requireExt = function(display, callback) {
     ext.AddGlyphsFromPicture = function(gsid, src, glyphs) {
       var len = 3 + glyphs.length * 5;
       X.pack_stream.pack('CCSLLL', [ext.majorOpcode, 21, 0, len + 1, gsid, src]);
-      for (i = 0; i < glyphs.length; i++) {
+      for (let i = 0; i < glyphs.length; i++) {
         X.pack_stream.pack('L', [glyphs[i].id]);
       }
-      for (i = 0; i < glyphs.length; i++) {
+      for (let i = 0; i < glyphs.length; i++) {
         X.pack_stream.pack('SSssssss', [
           glyphs[i].width,
           glyphs[i].height,
@@ -600,7 +601,6 @@ exports.requireExt = function(display, callback) {
       var charLength = bits / 8;
       var dataLength = s.length * charLength;
       var res = Buffer.alloc(xutil.padded_length(dataLength));
-      debugger;
       var write = res[bufferWriteBits[bits]];
       res.fill(0);
       for (var i = 0; i < s.length; i++) write.call(res, s.charCodeAt(i), i * charLength);
@@ -649,7 +649,7 @@ exports.requireExt = function(display, callback) {
       var length = 7;
       var glyphs_length_split = [];
       for (var i = 0; i < glyphs.length; ++i) {
-        var g = glyphs[i];
+        let g = glyphs[i];
         switch (typeof g) {
           case 'string':
             length += xutil.padded_length(g.length * charLength) / 4 + 2;
@@ -674,8 +674,8 @@ exports.requireExt = function(display, callback) {
         srcX,
         srcY
       ]);
-      for (var i = 0; i < glyphs.length; ++i) {
-        var g = glyphs[i];
+      for (let i = 0; i < glyphs.length; ++i) {
+        let g = glyphs[i];
         switch (typeof g) {
           case 'string':
             X.pack_stream.pack('Cxxxssa', [g.length, 0, 0, wstring(glyphBits, g)]);

--- a/lib/ext/screen-saver.js
+++ b/lib/ext/screen-saver.js
@@ -28,13 +28,13 @@ exports.requireExt = function(display, callback)
 
         ext.State = {
             Off: 0,
-	    On: 1,
+        On: 1,
             Disabled: 2
         };
 
         ext.Kind = {
             Blanked: 0,
-	    Internal: 1,
+        Internal: 1,
             External: 2
         };
 

--- a/lib/ext/screen-saver.js
+++ b/lib/ext/screen-saver.js
@@ -1,6 +1,5 @@
 // http://www.x.org/releases/X11R7.6/doc/scrnsaverproto/saver.pdf
 
-var x11 = require('..');
 // TODO: move to templates
 
 exports.requireExt = function(display, callback)
@@ -17,7 +16,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCSCCxx', [ext.majorOpcode, 0, 2, clientMaj, clientMin]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('CC');
                     return res;
                 },

--- a/lib/ext/shape.js
+++ b/lib/ext/shape.js
@@ -1,10 +1,11 @@
 // http://www.x.org/releases/X11R7.6/doc/xextproto/shape.pdf
 
-var x11 = require('..');
 // TODO: move to templates
 
 exports.requireExt = function(display, callback)
 {
+        // Shh eslint, this is for debugging.
+        // eslint-disable-next-line no-unused-vars
         function captureStack()
         {
             var err = new Error;
@@ -46,7 +47,7 @@ exports.requireExt = function(display, callback)
 //            captureStack();
             X.pack_stream.pack('CCSLL', [ext.majorOpcode, 0, 1]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('SS');
                     return res;
                 },

--- a/lib/ext/xc-misc.js
+++ b/lib/ext/xc-misc.js
@@ -1,6 +1,5 @@
 // http://www.x.org/releases/X11R7.6/doc/xcmiscproto/xc-misc.pdf
 
-var x11 = require('..');
 // TODO: move to templates
 
 exports.requireExt = function(display, callback)
@@ -16,7 +15,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCSSS', [ext.majorOpcode, 0, 2, clientMaj, clientMin]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('SS');
                     return res;
                 },
@@ -30,7 +29,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCS', [ext.majorOpcode, 1, 1]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var res = buf.unpack('LL');
                     return {
                         startId: res[0],
@@ -47,7 +46,7 @@ exports.requireExt = function(display, callback)
             X.seq_num++;
             X.pack_stream.pack('CCSL', [ext.majorOpcode, 2, 2, count]);
             X.replies[X.seq_num] = [
-                function(buf, opt) {
+                function(buf, _opt) {
                     var numIds = buf.unpack('L')[0];
                     var res = [];
                     for (var i = 0; i < numIds; ++i)

--- a/lib/ext/xtest.js
+++ b/lib/ext/xtest.js
@@ -1,6 +1,5 @@
 // http://www.x.org/releases/X11R7.6/doc/xextproto/xtest.pdf
 
-var x11 = require('..');
 // TODO: move to templates
 exports.requireExt = function(display, callback)
 {

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -22,8 +22,6 @@ function readVisuals(bl, visuals, n_visuals, cb)
         'xxxx'
     ],
     function() {
-         var vid = visual.vid;
-         // delete visual.vid;
          visuals[visual.vid] = visual;
          if (Object.keys(visuals).length == n_visuals)
              cb()

--- a/lib/hexy.js
+++ b/lib/hexy.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 //= hexy.js -- utility to create hex dumps 
 //
 // `hexy` is a javascript (node) library that's easy to use to create hex

--- a/lib/unpackstream.js
+++ b/lib/unpackstream.js
@@ -27,7 +27,7 @@ function ReadFixedRequest(length, callback)
     this.received_bytes = 0;
 }
 
-ReadFixedRequest.prototype.execute = function(bufferlist, aa, bb, cc, dd)
+ReadFixedRequest.prototype.execute = function(bufferlist)
 {
     // TODO: this is a brute force version
     // replace with Buffer.slice calls
@@ -42,7 +42,7 @@ ReadFixedRequest.prototype.execute = function(bufferlist, aa, bb, cc, dd)
     return true;
 }
 
-ReadFormatRequest.prototype.execute = function(bufferlist, tag1, tag2)
+ReadFormatRequest.prototype.execute = function(bufferlist)
 {
     while (this.current_arg < this.format.length)
     {
@@ -59,19 +59,21 @@ ReadFormatRequest.prototype.execute = function(bufferlist, tag1, tag2)
             this.data.push(bufferlist.getbyte());
             break;
         case 'S':
-        case 's':
-            var b1 = bufferlist.getbyte();
-            var b2 = bufferlist.getbyte();
+        case 's': {
+            let b1 = bufferlist.getbyte();
+            let b2 = bufferlist.getbyte();
             this.data.push(b2*256+b1);
             break;
+        }
         case 'l':
-        case 'L':
-            var b1 = bufferlist.getbyte();
-            var b2 = bufferlist.getbyte();
-            var b3 = bufferlist.getbyte();
-            var b4 = bufferlist.getbyte();
+        case 'L': {
+            let b1 = bufferlist.getbyte();
+            let b2 = bufferlist.getbyte();
+            let b3 = bufferlist.getbyte();
+            let b4 = bufferlist.getbyte();
             this.data.push(((b4*256+b3)*256 + b2)*256 + b1);
             break;
+        }
         case 'x':
             bufferlist.getbyte();
             break;
@@ -212,87 +214,96 @@ UnpackStream.prototype.pack = function(format, args)
 {
     var packetlength = 0;
 
-    var arg = 0;
-    for (var i = 0; i < format.length; ++i)
-    {
-        var f = format[i];
-        if (f == 'x')
+    { // Determine packet length
+        let arg = 0;
+        for (let i = 0; i < format.length; ++i)
         {
-            packetlength++;
-        } else if (f == 'p') {
-            packetlength += xutil.padded_length(args[arg++].length);
-        } else if (f == 'a') {
-            packetlength += args[arg].length;
-            arg++;
-        } else {
-            // this is a fixed-length format, get length from argument_length table
-            packetlength += argument_length[f];
-            arg++;
+            let f = format[i];
+            if (f == 'x')
+            {
+                packetlength++;
+            } else if (f == 'p') {
+                packetlength += xutil.padded_length(args[arg++].length);
+            } else if (f == 'a') {
+                packetlength += args[arg].length;
+                arg++;
+            } else {
+                // this is a fixed-length format, get length from argument_length table
+                packetlength += argument_length[f];
+                arg++;
+            }
         }
     }
 
-    var buf = Buffer.alloc(packetlength);
-    var offset = 0;
-    var arg = 0;
-    for (var i = 0; i < format.length; ++i)
+    let buf = Buffer.alloc(packetlength);
+    let offset = 0;
+    let arg = 0;
+    for (let i = 0; i < format.length; ++i)
     {
         switch(format[i])
         {
             case 'x':
                 buf[offset++] = 0;
                 break;
-            case 'C':
-                var n = args[arg++];
+            case 'C': {
+                let n = args[arg++];
                 buf[offset++] = n;
                 break;
-            case 's':
-                var n = args[arg++];
+            }
+            case 's': {
+                let n = args[arg++];
                 buf.writeInt16LE(n, offset);
                 offset += 2;
                 break;
+            }
 
-            case 'S':
-                var n = args[arg++];
+            case 'S': {
+                let n = args[arg++];
                 buf[offset++] = n & 0xff;
                 buf[offset++] = (n >> 8) & 0xff;
                 break;
-            case 'l':
-                var n = args[arg++];
+            }
+            case 'l': {
+                let n = args[arg++];
                 buf.writeInt32LE(n, offset);
                 offset += 4;
                 break;
+            }
 
-            case 'L':
-                var n = args[arg++];
+            case 'L': {
+                let n = args[arg++];
                 buf[offset++] = n & 0xff;
                 buf[offset++] = (n >> 8) & 0xff;
                 buf[offset++] = (n >> 16) & 0xff;
                 buf[offset++] = (n >> 24) & 0xff;
                 break;
-            case 'a':  // string, buffer, or array
-                var str = args[arg++];
+            }
+            case 'a': {  // string, buffer, or array
+                let str = args[arg++];
                 if (Buffer.isBuffer(str))
                 {
                     str.copy(buf, offset);
                     offset += str.length;
                 } else if(Array.isArray(str)) {
-                    for(var item of str) buf[offset++] = item;
+                    for(let item of str) buf[offset++] = item;
                 } else {
                     // TODO: buffer.write could be faster
-                    for (var c = 0; c < str.length; ++c)
+                    for (let c = 0; c < str.length; ++c)
                         buf[offset++] = str.charCodeAt(c);
                 }
                 break;
-            case 'p':  // padded string
-                var str = args[arg++];
-                var len = xutil.padded_length(str.length);
+            }
+            case 'p': {  // padded string
+                let str = args[arg++];
+                let len = xutil.padded_length(str.length);
                 // TODO: buffer.write could be faster
-                var c = 0;
+                let c = 0;
                 for (; c < str.length; ++c)
                     buf[offset++] = str.charCodeAt(c);
                 for (; c < len; ++c)
                     buf[offset++] = 0;
                 break;
+            }
         }
     }
     this.write_queue.push(buf);

--- a/lib/unpackstream.js
+++ b/lib/unpackstream.js
@@ -276,7 +276,7 @@ UnpackStream.prototype.pack = function(format, args)
                     str.copy(buf, offset);
                     offset += str.length;
                 } else if(Array.isArray(str)) {
-                	for(var item of str) buf[offset++] = item;
+                    for(var item of str) buf[offset++] = item;
                 } else {
                     // TODO: buffer.write could be faster
                     for (var c = 0; c < str.length; ++c)

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -107,7 +107,7 @@ XClient.prototype.init = function(stream)
           cli.seq2stack[client.seq_num] = err;
         },
         get: function() {
-	  return cli.seq_num_;
+          return cli.seq_num_;
         }
       });
     } else {
@@ -473,13 +473,13 @@ XClient.prototype.expectReplyHeader = function()
                 // unpack error packet (32 bytes for all error types, 8 of them in CCSL header)
                 client.pack_stream.get(24, function(buf) {
 
-		    var res = buf.unpack('SC');
-	   	    error.message = xerrors.errorText[error_code];
-		    error.badParam = bad_value;
-		    error.minorOpcode = res[0];
-		    error.majorOpcode = res[1];
+                var res = buf.unpack('SC');
+                error.message = xerrors.errorText[error_code];
+                error.badParam = bad_value;
+                error.minorOpcode = res[0];
+                error.majorOpcode = res[1];
 
-	            var extUnpacker = client.errorParsers[error_code];
+                var extUnpacker = client.errorParsers[error_code];
                     if (extUnpacker) {
                       extUnpacker(error, error_code, seq_num, bad_value, buf);
                     }
@@ -491,7 +491,7 @@ XClient.prototype.expectReplyHeader = function()
                         if (!handled)
                             client.emit('error', error);
                         // TODO: should we delete seq2stack and reply even if there is no handler?
-			if (client.options.debug)
+                    if (client.options.debug)
                           delete client.seq2stack[seq_num];
                         delete client.replies[seq_num];
                     } else
@@ -673,12 +673,12 @@ module.exports.createClient = function(options, initCb)
                         return initCb(err)
                     BigReq.Enable(function(err, maxLen) {
                         display.max_request_length = maxLen;
-	                cbCalled = true;
+                    cbCalled = true;
                         initCb(undefined, display);
                     });
                 });
             } else {
-	        cbCalled = true;
+            cbCalled = true;
                 initCb(undefined, display);
             }
         });

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -6,7 +6,7 @@ var handshake = require('./handshake');
 
 var EventEmitter = require('events').EventEmitter;
 var PackStream = require('./unpackstream');
-var hexy = require('./hexy').hexy;
+//var hexy = require('./hexy').hexy;
 
 var Buffer = require('buffer').Buffer;
 // add 'unpack' method for buffer
@@ -151,7 +151,7 @@ XClient.prototype.terminate = function()
 // 3 - id for shortest standard atom, "ARC"
 XClient.prototype.ping = function(cb) {
    var start = Date.now();
-   this.GetAtomName(3, function(err, str) {
+   this.GetAtomName(3, function(err, _str) {
       if (err) return cb(err);
       return cb(null, Date.now() - start);
    });
@@ -176,7 +176,7 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
         // r is request name
         target[r] = (function(reqName) {
 
-            var reqFunc = function req_proxy() {
+            let reqFunc = function req_proxy() {
 
             if (client._closing)
                throw new Error('client is in closing state');
@@ -189,16 +189,16 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                client.seq_num++;
 
             // is it fast?
-            var args = Array.prototype.slice.call(req_proxy.arguments);
+            let args = Array.prototype.slice.call(req_proxy.arguments);
 
-            var callback = args.length > 0 ? args[args.length - 1] : null;
+            let callback = args.length > 0 ? args[args.length - 1] : null;
             if (callback && callback.constructor.name != 'Function')
                 callback = null;
 
             // TODO: see how much we can calculate in advance (not in each request)
-            var reqReplTemplate = reqs[reqName];
-            var reqTemplate  = reqReplTemplate[0];
-            var templateType = typeof reqTemplate;
+            let reqReplTemplate = reqs[reqName];
+            let reqTemplate  = reqReplTemplate[0];
+            let templateType = typeof reqTemplate;
 
             if (templateType == 'object')
                 templateType = reqTemplate.constructor.name;
@@ -206,7 +206,7 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
             if (templateType == 'function')
             {
                  if (reqName === 'InternAtom') {
-                     var value = req_proxy.arguments[1];
+                     let value = req_proxy.arguments[1];
                      if (client.atoms[value]) {
                          -- client.seq_num;
                          return setImmediate(function() {
@@ -219,20 +219,19 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
 
                  // call template with input arguments (not including callback which is last argument TODO currently with callback. won't hurt)
                  //reqPack = reqTemplate.call(args);
-                 var reqPack = reqTemplate.apply(this, req_proxy.arguments);
-                 var format = reqPack[0];
-                 var requestArguments = reqPack[1];
+                 let reqPack = reqTemplate.apply(this, req_proxy.arguments);
+                 let format = reqPack[0];
+                 let requestArguments = reqPack[1];
 
                  if (callback)
                      this.replies[this.seq_num] = [reqReplTemplate[1], callback];
 
                  client.pack_stream.pack(format, requestArguments);
-                 var b = client.pack_stream.write_queue[0];
                  client.pack_stream.flush();
 
             } else if (templateType == 'Array'){
                  if (reqName === 'GetAtomName') {
-                     var atom = req_proxy.arguments[0];
+                     let atom = req_proxy.arguments[0];
                      if (client.atom_names[atom]) {
                          -- client.seq_num;
                          return setImmediate(function() {
@@ -243,12 +242,12 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                      }
                  }
 
-                 var format = reqTemplate[0];
-                 var requestArguments = [];
+                 let format = reqTemplate[0];
+                 let requestArguments = [];
 
-                 for (var a = 0; a < reqTemplate[1].length; ++a)
+                 for (let a = 0; a < reqTemplate[1].length; ++a)
                      requestArguments.push(reqTemplate[1][a]);
-                 for (var a in args)
+                 for (let a in args)
                      requestArguments.push(args[a]);
 
                  if (callback)
@@ -296,10 +295,10 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
     }
 
     if (type == 2 || type == 3 || type == 4 || type == 5 || type == 6) { // motion event
-        var values = raw.unpack('LLLssssSC');
+        let values = raw.unpack('LLLssssSC');
         //event.raw = values;
         // TODO: use unpackTo???
-        event.name = [,,'KeyPress', 'KeyRelease', 'ButtonPress', 'ButtonRelease', 'MotionNotify'][type]
+        event.name = [null, null, 'KeyPress', 'KeyRelease', 'ButtonPress', 'ButtonRelease', 'MotionNotify'][type]
         event.time = extra;
         event.keycode = code;
         event.root = values[0];
@@ -313,7 +312,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.sameScreen = values[8];
     } else if (type == 7 || type == 8) { //EnterNotify || LeaveNotify
         event.name = type === 7 ? 'EnterNotify' : 'LeaveNotify';
-        var values = raw.unpack('LLLssssSC');
+        let values = raw.unpack('LLLssssSC');
         event.root = values[0]
         event.wid = values[1]
         event.child = values[2];
@@ -324,7 +323,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.values = values
 
     } else if (type == 12) { // Expose
-        var values = raw.unpack('SSSSS');
+        let values = raw.unpack('SSSSS');
         event.name = 'Expose'
         event.wid = extra;
         event.x = values[0];
@@ -333,7 +332,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.height = values[3];
         event.count = values[4]; // TODO: ???
     } else if (type == 16) { // CreateNotify
-        var values = raw.unpack('LssSSSc');
+        let values = raw.unpack('LssSSSc');
         event.name = 'CreateNotify'
         event.parent = extra;
         event.wid = values[0];
@@ -345,29 +344,29 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.overrideRedirect = values[6] ? true : false;
         // x, y, width, height, border
     } else if (type == 17) { // destroy notify
-        var values = raw.unpack('L');
+        let values = raw.unpack('L');
         event.name = 'DestroyNotify'
         event.event = extra;
         event.wid = values[0];
     } else if (type == 18) { // UnmapNotify
-        var values = raw.unpack('LC');
+        let values = raw.unpack('LC');
         event.name = 'UnmapNotify'
         event.event = extra;
         event.wid = values[0];
         event.fromConfigure = values[1] ? true : false;
     } else if (type == 19) { // MapNotify
-        var values = raw.unpack('LC');
+        let values = raw.unpack('LC');
         event.name = 'MapNotify'
         event.event = extra;
         event.wid = values[0];
         event.overrideRedirect = values[1] ? true : false;
     } else if (type == 20) {
-        var values = raw.unpack('L');
+        let values = raw.unpack('L');
         event.name = 'MapRequest'
         event.parent = extra;
         event.wid = values[0];
     } else if (type == 22) {
-        var values = raw.unpack('LLssSSSC');
+        let values = raw.unpack('LLssSSSC');
         event.name = 'ConfigureNotify';
         event.wid = extra;
         // TODO rename
@@ -380,7 +379,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.borderWidth = values[6];
         event.overrideRedirect = values[7];
     } else if (type == 23) {
-        var values = raw.unpack('LLssSSSS');
+        let values = raw.unpack('LLssSSSS');
         event.name = 'ConfigureRequest';
         event.stackMode = code;
         event.parent = extra;
@@ -402,7 +401,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         //console.log([extra, code, values]);
     } else if (type == 28) {// PropertyNotify
         event.name = 'PropertyNotify';
-        var values = raw.unpack('LLC');
+        let values = raw.unpack('LLC');
         event.wid = extra;
         event.atom = values[0];
         event.time = values[1];
@@ -410,14 +409,14 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
     } else if (type == 29) {// SelectionClear
         event.name = 'SelectionClear';
         event.time = extra;
-        var values = raw.unpack('LL');
+        let values = raw.unpack('LL');
         event.owner = values[0];
         event.selection = values[1];
     } else if (type == 30) {// SelectionRequest
         event.name = 'SelectionRequest';
         // TODO check this
         event.time = extra;
-        var values = raw.unpack('LLLLL');
+        let values = raw.unpack('LLLLL');
         event.owner = values[0];
         event.requestor = values[1];
         event.selection = values[2];
@@ -427,7 +426,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.name = 'SelectionNotify';
         // TODO check this
         event.time = extra;
-        var values = raw.unpack('LLLL');
+        let values = raw.unpack('LLLL');
         event.requestor = values[0];
         event.selection = values[1];
         event.target = values[2];
@@ -437,7 +436,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         event.format = code;
         event.wid = extra;
         event.message_type = raw.unpack('L')[0];
-        var format = (code === 32) ? 'LLLLL' : (code === 16) ? 'SSSSSSSSSS' : 'CCCCCCCCCCCCCCCCCCCC';
+        let format = (code === 32) ? 'LLLLL' : (code === 16) ? 'SSSSSSSSSS' : 'CCCCCCCCCCCCCCCCCCCC';
         event.data = raw.unpack(format, 4);
     } else if (type == 34) {
         event.name = 'MappingNotify';

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "async": "^3.0.1",
+    "eslint": "^7.19.0",
     "mocha": "^7.1.2",
     "sax": "^1.2.4",
     "should": "^13.2.1",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    "env": {
+        "mocha": true,
+    },
+};


### PR DESCRIPTION
[We talked about maybe doing this in 2018](https://github.com/sidorares/node-x11/pull/163#issuecomment-359958791), and for some reason I woke up today wanting to eslint something.  :thinking:  Maybe it's because I've been playing Factorio for 2 days straight.

So I fired it up with `"eslint:recommended"`-settings and beat the red text with hammers until I got tired. Here's the progress so far.

I've fixed stuff that looked obvious (unused variables, mixed tabbing, `var`s overriding each other, …) but left eslint erroring if I felt unsure.  I mostly did only the minimum to resolve the eslint error, so for example while a full `var`→`const`/`let` replacement round would be a good idea, I've so far just been replacing them individually where they fix eslint errors.

- - -

Ones I'm unsure about that @sidorares should maybe check that they're no problem:

- [ ] `lib/unpackstream.js:323` → takes an unused `stream` argument, but the `stream.write` call is commented out; is that a bug, or a remnant from an old implementation?

- [ ] `lib/xcore.js:22` → `stash` isn't called anywhere, is it for debugging like `hexy`?  Seems like a no-op?

- [ ] `lib/ext/render.js:34` → the `num_*` stuff is extracted but not used.  Should they be in `res`?

- [ ] `lib/ext/render.js:99` → Unused function.  For debugging?

- [ ] `lib/ext/render.js:435` → Unused variable `glyphPaddedLength`.  Sounds meaningful but isn't used.  Is it a logical error?

- [ ] `lib/ext/render.js:647` → Unused variable `charFormat`.  Again sounds meaningful.  Check logic.

- [ ] `lib/ext/render.js:650` → as just above ↑

- [ ] `lib/ext/apple-wm.js:186` → `SetWindowMenu` only contains dead code, so I commented it out.  Probably in-progress and intentional?

- - -

Marked items either passed lint already, or I did a basic pass over them (adding notable issues to the above list for competent review):

- [ ] examples/opengl/test1.js
- [ ] examples/opengl/tp2.js
- [ ] examples/opengl/glxgears.js
- [ ] examples/opengl/triangle.js
- [ ] examples/smoketest/listext.js
- [ ] examples/smoketest/map_unmap.js
- [ ] examples/smoketest/xcmisc.js
- [x] examples/smoketest/xeyes.js
- [ ] examples/smoketest/keyboard/getkeyboardmapping.js
- [ ] examples/smoketest/changeprop.js
- [ ] examples/smoketest/trapezoids.js
- [ ] examples/smoketest/query_ext.js
- [x] examples/smoketest/cleararea.js
- [ ] examples/smoketest/polypoint.js
- [x] examples/smoketest/putimage1.js
- [x] examples/smoketest/testwnd.js
- [x] examples/smoketest/sstest.js
- [ ] examples/smoketest/bmp.js
- [x] examples/smoketest/polytext8.js
- [x] examples/smoketest/applewm.js
- [ ] examples/smoketest/copyarea.js
- [ ] examples/smoketest/wndwrap.js
- [x] examples/smoketest/polyfillarc.js
- [ ] examples/smoketest/putimage.js
- [ ] examples/smoketest/warppointer.js
- [ ] examples/smoketest/sendevent.js
- [x] examples/smoketest/query_pointer.js
- [ ] examples/smoketest/compositetest.js
- [ ] examples/smoketest/atoms.js
- [ ] examples/smoketest/xtesttest.js
- [ ] examples/smoketest/damagetest.js
- [x] examples/smoketest/fixestest.js
- [ ] examples/smoketest/benchmarks/atom_benchmark_buffered.js
- [ ] examples/smoketest/benchmarks/query_pointer_benchmark_sync.js
- [ ] examples/smoketest/benchmarks/atom_benchmark_parallel.js
- [ ] examples/smoketest/benchmarks/query_pointer_benchmark_parallel.js
- [x] examples/smoketest/shapetest.js
- [ ] examples/smoketest/subwindows.js
- [x] examples/smoketest/polyfillrect.js
- [x] examples/smoketest/blur-convolution.js
- [ ] examples/smoketest/shape-rectangles.js
- [x] examples/smoketest/randr.js
- [ ] examples/smoketest/transpwindow.js
- [x] examples/smoketest/pixmap.js
- [ ] examples/smoketest/listfonts.js
- [ ] examples/smoketest/selections.js
- [ ] examples/smoketest/querytree.js
- [ ] examples/smoketest/listproperties.js
- [ ] examples/smoketest/polyline.js
- [ ] examples/vncviewer/d3des.js
- [x] examples/vncviewer/constants.js
- [ ] examples/vncviewer/hexy.js
- [ ] examples/vncviewer/rfbclient.js
- [ ] examples/vncviewer/rfbserver.js
- [ ] examples/vncviewer/unpackstream.js
- [ ] examples/vncviewer/vncgui.js
- [ ] examples/simple/hello.js
- [x] examples/simple/gcinvert.js
- [x] examples/simple/createwindow.js
- [ ] examples/simple/render.js
- [x] examples/simple/xembed.js
- [ ] examples/simple/embed.js
- [ ] examples/simple/creategc.js
- [x] examples/simple/lsatoms.js
- [x] examples/simple/events.js
- [ ] examples/simple/text/render-glyph.js
- [ ] examples/simple/alloccolor.js
- [x] examples/simple/lsatomsp.js
- [ ] examples/simple/getprop.js
- [x] examples/simple/resizewindow.js
- [ ] examples/simple/gradients.js
- [ ] examples/key-recognition.js
- [ ] examples/screenshot.js
- [ ] examples/xpm/test.js
- [ ] examples/xpm/node-xpm.js
- [ ] examples/png/test1.js
- [ ] examples/png/node-png.js
- [x] examples/png/png-decoder.js
- [ ] examples/png/test.js
- [ ] examples/tetris.js
- [ ] examples/kbdheatmap/kbdheatmap.js
- [ ] examples/kbdheatmap/node-jpg.js
- [x] examples/windowmanager/wm.js
- [ ] examples/paint.js
- [ ] autogen/generate.js
- [ ] autogen/makeindex.js
- [ ] autogen/dependency_list.js
- [x] lib/corereqs.js
- [x] lib/ext/xc-misc.js
- [x] lib/ext/shape.js
- [ ] lib/ext/glxconstants.js
- [ ] lib/ext/glx.js
- [x] lib/ext/render.js
- [ ] lib/ext/composite.js
- [ ] lib/ext/fixes.js
- [ ] lib/ext/dpms.js
- [ ] lib/ext/big-requests.js
- [x] lib/ext/xtest.js
- [x] lib/ext/damage.js
- [ ] lib/ext/glxrender.js
- [x] lib/ext/randr.js
- [x] lib/ext/screen-saver.js
- [x] lib/ext/apple-wm.js
- [x] lib/auth.js
- [x] lib/hexy.js
- [x] lib/unpackbuffer.js
- [x] lib/xerrors.js
- [x] lib/index.js
- [x] lib/xutil.js
- [x] lib/xserver.js
- [x] lib/keysyms.js
- [x] lib/stdatoms.js
- [x] lib/xcore.js
- [x] lib/unpackstream.js
- [x] lib/handshake.js
- [x] lib/eventmask.js
- [x] lib/gcfunction.js
- [ ] test/configure-window.js
- [ ] test/connect.js
- [x] test/cache-extensions.js
- [ ] test/client-message.js
- [ ] test/sequence-overflow.js
- [ ] test/smoke-require-ext.js
- [ ] test/dpms.js
- [ ] test/core-properties.js
- [ ] test/createGC.js
- [x] test/change-property.js
- [x] test/core-KillKlient.js
- [ ] test/connection-utils.js
- [ ] test/xtest.js
- [ ] test/errors.js
- [x] test/core-ForceScreenSaver.js
- [ ] test/allow-events.js
- [ ] test/changeGC.js
- [ ] test/randr.js
- [x] test/configure-request.js
- [x] test/core-CreateWindow.js
- [ ] test/atoms-cache.js
- [x] test-runner.js
