### PR TITLE
Fix parsing of ConfigureRequest `mask`.

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -404,7 +404,7 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
         // in the request. The remaining values are filled in from the current geometry of the
         // window, except in the case of sibling and stack-mode, which are reported as None
         // and Above (respectively) if not given in the request.
-        event.mask = values[6];
+        event.mask = values[7];
         // 322, [ 12582925, 0, 0, 484, 316, 1, 12, 0
         //console.log([extra, code, values]);
     } else if (type == 28) {// PropertyNotify


### PR DESCRIPTION
`values[6]` was being assigned to both `borderWidth` and `mask`, leaving `mask` with an incorrect value.