### PR TITLE
Complete core X11 protocol coverage: all 120 requests, all 34 events

### DIFF
--- a/autogen/generate-events.js
+++ b/autogen/generate-events.js
@@ -56,7 +56,14 @@ const EVENT_FIELD_ALIAS = {
   ConfigureRequest: { window: 'wid', value_mask: 'mask', stack_mode: 'stackMode' },
   PropertyNotify: { window: 'wid' },
   ClientMessage: { window: 'wid' },
-  MappingNotify: { first_keycode: 'firstKeyCode' }
+  MappingNotify: { first_keycode: 'firstKeyCode' },
+  VisibilityNotify: { window: 'wid' },
+  ReparentNotify: { event: 'event', window: 'wid' },
+  GravityNotify: { event: 'event', window: 'wid' },
+  ResizeRequest: { window: 'wid' },
+  CirculateNotify: { event: 'event', window: 'wid' },
+  CirculateRequest: { event: 'event', window: 'wid' },
+  ColormapNotify: { window: 'wid' }
 };
 
 const TYPE_SIZE = {
@@ -225,7 +232,7 @@ function readExpr(typedefs, f, bufExpr, offset) {
 function genEventParser(typedefs, ev) {
   // Special-case ClientMessage (format-dependent data) and MappingNotify / KeymapNotify
   if (ev.name === 'KeymapNotify')
-    return null;
+    return genKeymapNotify();
   if (ev.name === 'ClientMessage')
     return genClientMessage();
   if (ev.name === 'MappingNotify')
@@ -357,6 +364,18 @@ function genMappingNotify() {
   return { name: 'MappingNotify', number: 34, code: lines.join('\n') };
 }
 
+function genKeymapNotify() {
+  // no-sequence-number event: bytes 1..31 are the key bit vector
+  // (keys for keycodes 8..255; QueryKeymap byte K corresponds to keys[K-1])
+  const lines = [];
+  lines.push('function parseKeymapNotify(type, seq, extra, code, raw, headerBuf) {');
+  lines.push('  const event = { type: type & 0x7F, name: \'KeymapNotify\' };');
+  lines.push('  event.keys = Buffer.concat([headerBuf.slice(1, 8), raw]);');
+  lines.push('  return event;');
+  lines.push('}');
+  return { name: 'KeymapNotify', number: 11, code: lines.join('\n') };
+}
+
 function main() {
   parseProto((err, { typedefs, events }) => {
     if (err)
@@ -365,11 +384,13 @@ function main() {
     // Generate parsers for events we currently handle in xcore + common ones
     const wanted = [
       'KeyPress', 'KeyRelease', 'ButtonPress', 'ButtonRelease', 'MotionNotify',
-      'EnterNotify', 'LeaveNotify', 'FocusIn', 'FocusOut',
-      'Expose', 'CreateNotify', 'DestroyNotify', 'UnmapNotify', 'MapNotify',
-      'MapRequest', 'ConfigureNotify', 'ConfigureRequest',
+      'EnterNotify', 'LeaveNotify', 'FocusIn', 'FocusOut', 'KeymapNotify',
+      'Expose', 'GraphicsExposure', 'NoExposure', 'VisibilityNotify',
+      'CreateNotify', 'DestroyNotify', 'UnmapNotify', 'MapNotify',
+      'MapRequest', 'ReparentNotify', 'ConfigureNotify', 'ConfigureRequest',
+      'GravityNotify', 'ResizeRequest', 'CirculateNotify', 'CirculateRequest',
       'PropertyNotify', 'SelectionClear', 'SelectionRequest', 'SelectionNotify',
-      'ClientMessage', 'MappingNotify'
+      'ColormapNotify', 'ClientMessage', 'MappingNotify'
     ];
 
     const parsers = [];

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -161,6 +161,40 @@ const valueMask = {
           kind: 'C'
         }
     },
+    ChangeKeyboardControl: {
+      keyClickPercent         : {
+        mask: 0x0001,
+        kind: 'c'
+      },
+      bellPercent             : {
+        mask: 0x0002,
+        kind: 'c'
+      },
+      bellPitch               : {
+        mask: 0x0004,
+        kind: 's'
+      },
+      bellDuration            : {
+        mask: 0x0008,
+        kind: 's'
+      },
+      led                     : {
+        mask: 0x0010,
+        kind: 'C'
+      },
+      ledMode                 : {
+        mask: 0x0020,
+        kind: 'C'
+      },
+      key                     : {
+        mask: 0x0040,
+        kind: 'C'
+      },
+      autoRepeatMode          : {
+        mask: 0x0080,
+        kind: 'C'
+      }
+    },
     ConfigureWindow: {
       x                       : {
         mask: 0x000001,
@@ -210,6 +244,9 @@ function writeValueSlot(buf, offset, kind, value)
         break;
     case 'C':
         buf[offset] = value & 0xff;
+        break;
+    case 'c':
+        buf.writeInt8(value, offset);
         break;
     case 'S':
         buf.writeUInt16LE(value & 0xffff, offset);
@@ -282,6 +319,45 @@ function packCCSL(opcode, byte1, length, id)
     b.writeUInt16LE(length, 2);
     b.writeUInt32LE(id >>> 0, 4);
     return b;
+}
+
+/* CHARINFO: 12 bytes (see QueryFont / ListFontsWithInfo replies) */
+function parseCharInfo(buf, off)
+{
+    return {
+        leftSideBearing  : buf.readInt16LE(off),
+        rightSideBearing : buf.readInt16LE(off + 2),
+        characterWidth   : buf.readInt16LE(off + 4),
+        ascent           : buf.readInt16LE(off + 6),
+        descent          : buf.readInt16LE(off + 8),
+        attributes       : buf.readUInt16LE(off + 10)
+    };
+}
+
+/* shared header of QueryFont and ListFontsWithInfo replies (body offsets) */
+function parseFontInfo(buf)
+{
+    const info = {
+        minBounds      : parseCharInfo(buf, 0),
+        maxBounds      : parseCharInfo(buf, 16),
+        minCharOrByte2 : buf.readUInt16LE(32),
+        maxCharOrByte2 : buf.readUInt16LE(34),
+        defaultChar    : buf.readUInt16LE(36),
+        drawDirection  : buf.readUInt8(40),
+        minByte1       : buf.readUInt8(41),
+        maxByte1       : buf.readUInt8(42),
+        allCharsExist  : !!buf.readUInt8(43),
+        fontAscent     : buf.readInt16LE(44),
+        fontDescent    : buf.readInt16LE(46)
+    };
+    const nProps = buf.readUInt16LE(38);
+    info.properties = [];
+    for (let i = 0; i < nProps; ++i)
+        info.properties.push({
+            name  : buf.readUInt32LE(52 + i * 8),
+            value : buf.readUInt32LE(56 + i * 8)
+        });
+    return info;
 }
 
 function packUInt16List(opcode, lengthPrefix, drawable, gc, coords)
@@ -392,6 +468,10 @@ const templates = {
        wid => packCxSL(4, 2, wid)
    ],
 
+   DestroySubwindows: [
+       wid => packCxSL(5, 2, wid)
+   ],
+
    ChangeSaveSet: [
       (isInsert, wid) => packCCSL(6, isInsert ? 0 : 1, 2, wid)
    ],
@@ -414,8 +494,16 @@ const templates = {
        wid => packCxSL(8, 2, wid)
    ],
 
+   MapSubwindows: [
+       wid => packCxSL(9, 2, wid)
+   ],
+
    UnmapWindow: [
        wid => packCxSL(10, 2, wid)
+   ],
+
+   UnmapSubwindows: [
+       wid => packCxSL(11, 2, wid)
    ],
 
    ConfigureWindow: [
@@ -460,6 +548,11 @@ const templates = {
 
    LowerWindow: [
         win => module.exports.ConfigureWindow[0](win, { stackMode : 1 })
+   ],
+
+   CirculateWindow: [
+       // direction: 0 RaiseLowest, 1 LowerHighest
+       (wid, direction) => packCCSL(13, direction, 2, wid)
    ],
 
    QueryTree: [
@@ -795,6 +888,31 @@ const templates = {
        coreReplies.QueryPointer
    ],
 
+   GetMotionEvents: [
+       // start/stop: timestamps, 0 for CurrentTime
+       (wid, start, stop) => {
+           const b = Buffer.alloc(16);
+           b[0] = 39;
+           b.writeUInt16LE(4, 2);
+           b.writeUInt32LE(wid >>> 0, 4);
+           b.writeUInt32LE(start >>> 0, 8);
+           b.writeUInt32LE(stop >>> 0, 12);
+           return b;
+       },
+
+       buf => {
+           const n = buf.readUInt32LE(0);
+           const events = [];
+           for (let i = 0; i < n; ++i)
+               events.push({
+                   time : buf.readUInt32LE(24 + 8 * i),
+                   x    : buf.readInt16LE(28 + 8 * i),
+                   y    : buf.readInt16LE(30 + 8 * i)
+               });
+           return events;
+       }
+   ],
+
    TranslateCoordinates: [
        (srcWid, dstWid, srcX, srcY) => {
            const b = Buffer.alloc(16);
@@ -854,6 +972,67 @@ const templates = {
       }
    ],
 
+   OpenFont: [
+       (fid, name) => {
+           const padded = xutil.padded_string(name);
+           const b = Buffer.alloc(12 + padded.length);
+           b[0] = 45;
+           b.writeUInt16LE(3 + padded.length / 4, 2);
+           b.writeUInt32LE(fid >>> 0, 4);
+           b.writeUInt16LE(name.length, 8);
+           padded.copy(b, 12);
+           return b;
+       }
+   ],
+
+   CloseFont: [
+       fid => packCxSL(46, 2, fid)
+   ],
+
+   QueryFont: [
+       fontable => packCxSL(47, 2, fontable),
+
+       buf => {
+           const font = parseFontInfo(buf);
+           const nCharInfos = buf.readUInt32LE(48);
+           const charsOffset = 52 + font.properties.length * 8;
+           font.charInfos = [];
+           for (let i = 0; i < nCharInfos; ++i)
+               font.charInfos.push(parseCharInfo(buf, charsOffset + i * 12));
+           return font;
+       }
+   ],
+
+   QueryTextExtents: [
+       // string is encoded as STRING16 (2 bytes per char)
+       (fontable, str) => {
+           const byteLen = 2 * str.length;
+           const padded = xutil.padded_length(byteLen);
+           const b = Buffer.alloc(8 + padded);
+           b[0] = 48;
+           b[1] = (padded - byteLen) === 2 ? 1 : 0; // odd length flag
+           b.writeUInt16LE(2 + padded / 4, 2);
+           b.writeUInt32LE(fontable >>> 0, 4);
+           for (let i = 0; i < str.length; ++i) {
+               const c = str.charCodeAt(i);
+               b[8 + i * 2] = (c >> 8) & 0xff;     // byte1
+               b[8 + i * 2 + 1] = c & 0xff;        // byte2
+           }
+           return b;
+       },
+
+       (buf, drawDirection) => ({
+           drawDirection,
+           fontAscent     : buf.readInt16LE(0),
+           fontDescent    : buf.readInt16LE(2),
+           overallAscent  : buf.readInt16LE(4),
+           overallDescent : buf.readInt16LE(6),
+           overallWidth   : buf.readInt32LE(8),
+           overallLeft    : buf.readInt32LE(12),
+           overallRight   : buf.readInt32LE(16)
+       })
+   ],
+
    ListFonts: [
       (pattern, max) => {
           const padded = xutil.padded_string(pattern);
@@ -866,6 +1045,58 @@ const templates = {
           padded.copy(b, 8);
           return b;
       },
+
+      buf => xutil.readStringList(buf, 24)
+   ],
+
+   ListFontsWithInfo: [
+      (pattern, max) => {
+          const padded = xutil.padded_string(pattern);
+          const reqLen = 2 + padded.length / 4;
+          const b = Buffer.alloc(8 + padded.length);
+          b[0] = 50;
+          b.writeUInt16LE(reqLen, 2);
+          b.writeUInt16LE(max, 4);
+          b.writeUInt16LE(pattern.length, 6);
+          padded.copy(b, 8);
+          return b;
+      },
+
+      // one reply per font; terminating reply has zero name length
+      (buf, nameLen) => {
+          if (nameLen === 0)
+              return; // undefined ends the multi-reply series
+          const font = parseFontInfo(buf);
+          font.repliesHint = buf.readUInt32LE(48);
+          font.name = xutil.readLatin1(buf, 52 + font.properties.length * 8, nameLen);
+          return font;
+      },
+
+      true // multi-reply
+   ],
+
+   SetFontPath: [
+      paths => {
+          let strsLen = 0;
+          for (const p of paths)
+              strsLen += 1 + p.length;
+          const padded = xutil.padded_length(strsLen);
+          const b = Buffer.alloc(8 + padded);
+          b[0] = 51;
+          b.writeUInt16LE(2 + padded / 4, 2);
+          b.writeUInt16LE(paths.length, 4);
+          let off = 8;
+          for (const p of paths) {
+              b[off++] = p.length;
+              b.write(p, off, p.length, 'latin1');
+              off += p.length;
+          }
+          return b;
+      }
+   ],
+
+   GetFontPath: [
+      () => packCxS(52, 1),
 
       buf => xutil.readStringList(buf, 24)
    ],
@@ -915,6 +1146,66 @@ const templates = {
        }
    ],
 
+   // opcode 94
+   CreateGlyphCursor: [
+       (cid, sourceFont, maskFont, sourceChar, maskChar, foreRGB, backRGB) => {
+          const b = Buffer.alloc(32);
+          b[0] = 94;
+          b.writeUInt16LE(8, 2);
+          b.writeUInt32LE(cid >>> 0, 4);
+          b.writeUInt32LE(sourceFont >>> 0, 8);
+          b.writeUInt32LE(maskFont >>> 0, 12);
+          b.writeUInt16LE(sourceChar, 16);
+          b.writeUInt16LE(maskChar, 18);
+          b.writeUInt16LE(foreRGB.R, 20);
+          b.writeUInt16LE(foreRGB.G, 22);
+          b.writeUInt16LE(foreRGB.B, 24);
+          b.writeUInt16LE(backRGB.R, 26);
+          b.writeUInt16LE(backRGB.G, 28);
+          b.writeUInt16LE(backRGB.B, 30);
+          return b;
+       }
+   ],
+
+   FreeCursor: [
+       cursor => packCxSL(95, 2, cursor)
+   ],
+
+   RecolorCursor: [
+       (cursor, foreRGB, backRGB) => {
+          const b = Buffer.alloc(20);
+          b[0] = 96;
+          b.writeUInt16LE(5, 2);
+          b.writeUInt32LE(cursor >>> 0, 4);
+          b.writeUInt16LE(foreRGB.R, 8);
+          b.writeUInt16LE(foreRGB.G, 10);
+          b.writeUInt16LE(foreRGB.B, 12);
+          b.writeUInt16LE(backRGB.R, 14);
+          b.writeUInt16LE(backRGB.G, 16);
+          b.writeUInt16LE(backRGB.B, 18);
+          return b;
+       }
+   ],
+
+   QueryBestSize: [
+       // _class: 0 Cursor, 1 Tile, 2 Stipple
+       (_class, drawable, width, height) => {
+          const b = Buffer.alloc(12);
+          b[0] = 97;
+          b[1] = _class;
+          b.writeUInt16LE(3, 2);
+          b.writeUInt32LE(drawable >>> 0, 4);
+          b.writeUInt16LE(width, 8);
+          b.writeUInt16LE(height, 10);
+          return b;
+       },
+
+       buf => ({
+           width  : buf.readUInt16LE(0),
+           height : buf.readUInt16LE(2)
+       })
+   ],
+
    // opcode 55
    CreateGC: [
        (cid, drawable, values) => {
@@ -943,6 +1234,65 @@ const templates = {
            vals.valuesBuf.copy(b, 12);
            return b;
         }
+   ],
+
+   CopyGC: [
+       // components: CARD32 bitmask or list of CreateGC value names
+       (srcGc, dstGc, components) => {
+           let mask = components;
+           if (Array.isArray(components)) {
+               mask = 0;
+               for (const name of components) {
+                   const v = valueMask.CreateGC[name];
+                   if (!v)
+                       throw new Error(`CopyGC: incorrect component ${name}`);
+                   mask |= v.mask;
+               }
+           }
+           const b = Buffer.alloc(16);
+           b[0] = 57;
+           b.writeUInt16LE(4, 2);
+           b.writeUInt32LE(srcGc >>> 0, 4);
+           b.writeUInt32LE(dstGc >>> 0, 8);
+           b.writeUInt32LE(mask >>> 0, 12);
+           return b;
+       }
+   ],
+
+   SetDashes: [
+       (gc, dashOffset, dashes) => {
+           const padded = xutil.padded_length(dashes.length);
+           const b = Buffer.alloc(12 + padded);
+           b[0] = 58;
+           b.writeUInt16LE(3 + padded / 4, 2);
+           b.writeUInt32LE(gc >>> 0, 4);
+           b.writeUInt16LE(dashOffset, 8);
+           b.writeUInt16LE(dashes.length, 10);
+           for (let i = 0; i < dashes.length; ++i)
+               b[12 + i] = dashes[i];
+           return b;
+       }
+   ],
+
+   SetClipRectangles: [
+       // ordering: 0 UnSorted, 1 YSorted, 2 YXSorted, 3 YXBanded
+       // rects: flat array [x, y, width, height, ...]
+       (gc, ordering, clipXOrigin, clipYOrigin, rects) => {
+           const b = Buffer.alloc(12 + 2 * rects.length);
+           b[0] = 59;
+           b[1] = ordering;
+           b.writeUInt16LE(3 + rects.length / 2, 2);
+           b.writeUInt32LE(gc >>> 0, 4);
+           b.writeInt16LE(clipXOrigin, 8);
+           b.writeInt16LE(clipYOrigin, 10);
+           for (let i = 0; i < rects.length; ++i)
+               b.writeUInt16LE(rects[i] & 0xffff, 12 + i * 2);
+           return b;
+       }
+   ],
+
+   FreeGC: [
+       gc => packCxSL(60, 2, gc)
    ],
 
    ClearArea: [
@@ -979,6 +1329,25 @@ const templates = {
        }
    ],
 
+   CopyPlane: [
+       (srcDrawable, dstDrawable, gc, srcX, srcY, dstX, dstY, width, height, bitPlane) => {
+           const b = Buffer.alloc(32);
+           b[0] = 63;
+           b.writeUInt16LE(8, 2);
+           b.writeUInt32LE(srcDrawable >>> 0, 4);
+           b.writeUInt32LE(dstDrawable >>> 0, 8);
+           b.writeUInt32LE(gc >>> 0, 12);
+           b.writeInt16LE(srcX, 16);
+           b.writeInt16LE(srcY, 18);
+           b.writeInt16LE(dstX, 20);
+           b.writeInt16LE(dstY, 22);
+           b.writeUInt16LE(width, 24);
+           b.writeUInt16LE(height, 26);
+           b.writeUInt32LE(bitPlane >>> 0, 28);
+           return b;
+       }
+   ],
+
 
    PolyPoint: [
        (coordMode, drawable, gc, points) => {
@@ -1008,6 +1377,39 @@ const templates = {
           return b;
        }
 
+   ],
+
+   PolySegment: [
+      // segments: flat array [x1, y1, x2, y2, ...]
+      (drawable, gc, segments) => packUInt16List(66, 3, drawable, gc, segments)
+   ],
+
+   PolyRectangle: [
+      // rects: flat array [x, y, width, height, ...]
+      (drawable, gc, rects) => packUInt16List(67, 3, drawable, gc, rects)
+   ],
+
+   PolyArc: [
+      // arcs: flat array [x, y, width, height, angle1, angle2, ...], angles in 1/64 degree
+      (drawable, gc, arcs) => packUInt16List(68, 3, drawable, gc, arcs)
+   ],
+
+   FillPoly: [
+      // shape: 0 Complex, 1 Nonconvex, 2 Convex
+      // coordMode: 0 Origin, 1 Previous
+      // points: flat array [x, y, ...]
+      (drawable, gc, shape, coordMode, points) => {
+          const b = Buffer.alloc(16 + 2 * points.length);
+          b[0] = 69;
+          b.writeUInt16LE(4 + points.length / 2, 2);
+          b.writeUInt32LE(drawable >>> 0, 4);
+          b.writeUInt32LE(gc >>> 0, 8);
+          b[12] = shape;
+          b[13] = coordMode;
+          for (let i = 0; i < points.length; ++i)
+              b.writeUInt16LE(points[i] & 0xffff, 16 + i * 2);
+          return b;
+      }
    ],
 
    PolyFillRectangle: [
@@ -1110,6 +1512,87 @@ const templates = {
        }
    ],
 
+   PolyText16: [
+       // items: strings encoded as STRING16 (2-byte CHAR2B per char)
+       (drawable, gc, x, y, items) => {
+          const numItems = items.length;
+          let reqLen = 16;
+          const chunks = [];
+          for (let i = 0; i < numItems; ++i)
+          {
+              const it = items[i];
+              if (typeof it == 'string')
+              {
+                  if (it.length > 254) // TODO: split string in set of items
+                      throw 'not supported yet';
+                  const chunk = Buffer.alloc(2 + 2 * it.length);
+                  chunk[0] = it.length;
+                  chunk[1] = 0; // delta
+                  for (let j = 0; j < it.length; ++j) {
+                      const c = it.charCodeAt(j);
+                      chunk[2 + j * 2] = (c >> 8) & 0xff;  // byte1
+                      chunk[3 + j * 2] = c & 0xff;         // byte2
+                  }
+                  chunks.push(chunk);
+                  reqLen += chunk.length;
+              } else {
+                  throw 'not supported yet';
+              }
+          }
+          const len4 = xutil.padded_length(reqLen) / 4;
+          const b = Buffer.alloc(len4 * 4);
+          b[0] = 75;
+          b.writeUInt16LE(len4, 2);
+          b.writeUInt32LE(drawable >>> 0, 4);
+          b.writeUInt32LE(gc >>> 0, 8);
+          b.writeInt16LE(x, 12);
+          b.writeInt16LE(y, 14);
+          let off = 16;
+          for (const chunk of chunks) {
+              chunk.copy(b, off);
+              off += chunk.length;
+          }
+          return b;
+       }
+   ],
+
+   ImageText8: [
+       (drawable, gc, x, y, text) => {
+          const padded = xutil.padded_length(text.length);
+          const b = Buffer.alloc(16 + padded);
+          b[0] = 76;
+          b[1] = text.length;
+          b.writeUInt16LE(4 + padded / 4, 2);
+          b.writeUInt32LE(drawable >>> 0, 4);
+          b.writeUInt32LE(gc >>> 0, 8);
+          b.writeInt16LE(x, 12);
+          b.writeInt16LE(y, 14);
+          b.write(text, 16, text.length, 'latin1');
+          return b;
+       }
+   ],
+
+   ImageText16: [
+       // text encoded as STRING16 (2-byte CHAR2B per char)
+       (drawable, gc, x, y, text) => {
+          const padded = xutil.padded_length(2 * text.length);
+          const b = Buffer.alloc(16 + padded);
+          b[0] = 77;
+          b[1] = text.length;
+          b.writeUInt16LE(4 + padded / 4, 2);
+          b.writeUInt32LE(drawable >>> 0, 4);
+          b.writeUInt32LE(gc >>> 0, 8);
+          b.writeInt16LE(x, 12);
+          b.writeInt16LE(y, 14);
+          for (let i = 0; i < text.length; ++i) {
+              const c = text.charCodeAt(i);
+              b[16 + i * 2] = (c >> 8) & 0xff;  // byte1
+              b[17 + i * 2] = c & 0xff;         // byte2
+          }
+          return b;
+       }
+   ],
+
    CreateColormap:
    [
        (cmid, wid, vid, alloc) => {
@@ -1121,6 +1604,41 @@ const templates = {
            b.writeUInt32LE(wid >>> 0, 8);
            b.writeUInt32LE(vid >>> 0, 12);
            return b;
+       }
+   ],
+
+   FreeColormap: [
+       cmap => packCxSL(79, 2, cmap)
+   ],
+
+   CopyColormapAndFree: [
+       (newCmid, srcCmap) => {
+           const b = Buffer.alloc(12);
+           b[0] = 80;
+           b.writeUInt16LE(3, 2);
+           b.writeUInt32LE(newCmid >>> 0, 4);
+           b.writeUInt32LE(srcCmap >>> 0, 8);
+           return b;
+       }
+   ],
+
+   InstallColormap: [
+       cmap => packCxSL(81, 2, cmap)
+   ],
+
+   UninstallColormap: [
+       cmap => packCxSL(82, 2, cmap)
+   ],
+
+   ListInstalledColormaps: [
+       wid => packCxSL(83, 2, wid),
+
+       buf => {
+           const n = buf.readUInt16LE(0);
+           const cmaps = [];
+           for (let i = 0; i < n; ++i)
+               cmaps.push(buf.readUInt32LE(24 + 4 * i));
+           return cmaps;
        }
    ],
 
@@ -1145,6 +1663,176 @@ const templates = {
            color.pixel = buf.readUInt32LE(8) >> 8; // 3 first bytes contain RGB value in response
            return color;
        }
+   ],
+
+   AllocNamedColor: [
+       (cmap, name) => {
+           const padded = xutil.padded_string(name);
+           const b = Buffer.alloc(12 + padded.length);
+           b[0] = 85;
+           b.writeUInt16LE(3 + padded.length / 4, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           b.writeUInt16LE(name.length, 8);
+           padded.copy(b, 12);
+           return b;
+       },
+
+       buf => ({
+           pixel       : buf.readUInt32LE(0),
+           exactRed    : buf.readUInt16LE(4),
+           exactGreen  : buf.readUInt16LE(6),
+           exactBlue   : buf.readUInt16LE(8),
+           visualRed   : buf.readUInt16LE(10),
+           visualGreen : buf.readUInt16LE(12),
+           visualBlue  : buf.readUInt16LE(14)
+       })
+   ],
+
+   AllocColorCells: [
+       (contiguous, cmap, colors, planes) => {
+           const b = Buffer.alloc(12);
+           b[0] = 86;
+           b[1] = contiguous ? 1 : 0;
+           b.writeUInt16LE(3, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           b.writeUInt16LE(colors, 8);
+           b.writeUInt16LE(planes, 10);
+           return b;
+       },
+
+       buf => {
+           const nPixels = buf.readUInt16LE(0);
+           const nMasks = buf.readUInt16LE(2);
+           const res = { pixels: [], masks: [] };
+           for (let i = 0; i < nPixels; ++i)
+               res.pixels.push(buf.readUInt32LE(24 + 4 * i));
+           for (let i = 0; i < nMasks; ++i)
+               res.masks.push(buf.readUInt32LE(24 + 4 * (nPixels + i)));
+           return res;
+       }
+   ],
+
+   AllocColorPlanes: [
+       (contiguous, cmap, colors, reds, greens, blues) => {
+           const b = Buffer.alloc(16);
+           b[0] = 87;
+           b[1] = contiguous ? 1 : 0;
+           b.writeUInt16LE(4, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           b.writeUInt16LE(colors, 8);
+           b.writeUInt16LE(reds, 10);
+           b.writeUInt16LE(greens, 12);
+           b.writeUInt16LE(blues, 14);
+           return b;
+       },
+
+       buf => {
+           const nPixels = buf.readUInt16LE(0);
+           const res = {
+               redMask   : buf.readUInt32LE(4),
+               greenMask : buf.readUInt32LE(8),
+               blueMask  : buf.readUInt32LE(12),
+               pixels    : []
+           };
+           for (let i = 0; i < nPixels; ++i)
+               res.pixels.push(buf.readUInt32LE(24 + 4 * i));
+           return res;
+       }
+   ],
+
+   FreeColors: [
+       (cmap, planeMask, pixels) => {
+           const b = Buffer.alloc(12 + 4 * pixels.length);
+           b[0] = 88;
+           b.writeUInt16LE(3 + pixels.length, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           b.writeUInt32LE(planeMask >>> 0, 8);
+           for (let i = 0; i < pixels.length; ++i)
+               b.writeUInt32LE(pixels[i] >>> 0, 12 + 4 * i);
+           return b;
+       }
+   ],
+
+   StoreColors: [
+       // items: [{ pixel, red, green, blue, doMask }], doMask: 1 red | 2 green | 4 blue (default all)
+       (cmap, items) => {
+           const b = Buffer.alloc(8 + 12 * items.length);
+           b[0] = 89;
+           b.writeUInt16LE(2 + 3 * items.length, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           for (let i = 0; i < items.length; ++i) {
+               const item = items[i];
+               const off = 8 + 12 * i;
+               b.writeUInt32LE(item.pixel >>> 0, off);
+               b.writeUInt16LE(item.red || 0, off + 4);
+               b.writeUInt16LE(item.green || 0, off + 6);
+               b.writeUInt16LE(item.blue || 0, off + 8);
+               b[off + 10] = item.doMask === undefined ? 7 : item.doMask;
+           }
+           return b;
+       }
+   ],
+
+   StoreNamedColor: [
+       // doMask: 1 red | 2 green | 4 blue
+       (cmap, pixel, name, doMask) => {
+           const padded = xutil.padded_string(name);
+           const b = Buffer.alloc(16 + padded.length);
+           b[0] = 90;
+           b[1] = doMask === undefined ? 7 : doMask;
+           b.writeUInt16LE(4 + padded.length / 4, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           b.writeUInt32LE(pixel >>> 0, 8);
+           b.writeUInt16LE(name.length, 12);
+           padded.copy(b, 16);
+           return b;
+       }
+   ],
+
+   QueryColors: [
+       (cmap, pixels) => {
+           const b = Buffer.alloc(8 + 4 * pixels.length);
+           b[0] = 91;
+           b.writeUInt16LE(2 + pixels.length, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           for (let i = 0; i < pixels.length; ++i)
+               b.writeUInt32LE(pixels[i] >>> 0, 8 + 4 * i);
+           return b;
+       },
+
+       buf => {
+           const n = buf.readUInt16LE(0);
+           const colors = [];
+           for (let i = 0; i < n; ++i)
+               colors.push({
+                   red   : buf.readUInt16LE(24 + 8 * i),
+                   green : buf.readUInt16LE(26 + 8 * i),
+                   blue  : buf.readUInt16LE(28 + 8 * i)
+               });
+           return colors;
+       }
+   ],
+
+   LookupColor: [
+       (cmap, name) => {
+           const padded = xutil.padded_string(name);
+           const b = Buffer.alloc(12 + padded.length);
+           b[0] = 92;
+           b.writeUInt16LE(3 + padded.length / 4, 2);
+           b.writeUInt32LE(cmap >>> 0, 4);
+           b.writeUInt16LE(name.length, 8);
+           padded.copy(b, 12);
+           return b;
+       },
+
+       buf => ({
+           exactRed    : buf.readUInt16LE(0),
+           exactGreen  : buf.readUInt16LE(2),
+           exactBlue   : buf.readUInt16LE(4),
+           visualRed   : buf.readUInt16LE(6),
+           visualGreen : buf.readUInt16LE(8),
+           visualBlue  : buf.readUInt16LE(10)
+       })
    ],
 
    QueryExtension: [
@@ -1179,7 +1867,7 @@ const templates = {
        (buff, listLength) => {
            const res = [];
            const rowBytes = 4 * listLength;
-           for (let offset = 24; offset < buff.length - rowBytes; offset += rowBytes) {
+           for (let offset = 24; offset + rowBytes <= buff.length; offset += rowBytes) {
                 const row = [];
                 for (let i = 0; i < listLength; ++i)
                     row.push(buff.readUInt32LE(offset + i * 4));
@@ -1194,8 +1882,169 @@ const templates = {
 		coreReplies.GetGeometry
    ],
 
+   ChangeKeyboardMapping: [
+       // keysyms: flat list of keycodeCount * keysymsPerKeycode KEYSYMs
+       (firstKeycode, keysymsPerKeycode, keysyms) => {
+           const keycodeCount = keysyms.length / keysymsPerKeycode;
+           const b = Buffer.alloc(8 + 4 * keysyms.length);
+           b[0] = 100;
+           b[1] = keycodeCount;
+           b.writeUInt16LE(2 + keysyms.length, 2);
+           b[4] = firstKeycode;
+           b[5] = keysymsPerKeycode;
+           for (let i = 0; i < keysyms.length; ++i)
+               b.writeUInt32LE(keysyms[i] >>> 0, 8 + 4 * i);
+           return b;
+       }
+   ],
+
+   ChangeKeyboardControl: [
+       /*
+        * values : {
+        *     keyClickPercent, bellPercent, bellPitch, bellDuration,
+        *     led, ledMode, key, autoRepeatMode
+        * }
+        */
+       values => {
+           const vals = packValueMask('ChangeKeyboardControl', values);
+           const nValues = vals.valuesBuf.length / 4;
+           const b = Buffer.alloc(8 + vals.valuesBuf.length);
+           b[0] = 102;
+           b.writeUInt16LE(2 + nValues, 2);
+           b.writeUInt32LE(vals.bitmask >>> 0, 4);
+           vals.valuesBuf.copy(b, 8);
+           return b;
+       }
+   ],
+
+   GetKeyboardControl: [
+       () => packCxS(103, 1),
+
+       (buf, globalAutoRepeat) => {
+           const control = {
+               globalAutoRepeat,
+               ledMask         : buf.readUInt32LE(0),
+               keyClickPercent : buf.readUInt8(4),
+               bellPercent     : buf.readUInt8(5),
+               bellPitch       : buf.readUInt16LE(6),
+               bellDuration    : buf.readUInt16LE(8),
+               autoRepeats     : buf.slice(12, 44)
+           };
+           return control;
+       }
+   ],
+
+   ChangePointerControl: [
+       (accelNumerator, accelDenominator, threshold, doAcceleration, doThreshold) => {
+           const b = Buffer.alloc(12);
+           b[0] = 105;
+           b.writeUInt16LE(3, 2);
+           b.writeInt16LE(accelNumerator, 4);
+           b.writeInt16LE(accelDenominator, 6);
+           b.writeInt16LE(threshold, 8);
+           b[10] = doAcceleration ? 1 : 0;
+           b[11] = doThreshold ? 1 : 0;
+           return b;
+       }
+   ],
+
+   GetPointerControl: [
+       () => packCxS(106, 1),
+
+       buf => ({
+           accelNumerator   : buf.readUInt16LE(0),
+           accelDenominator : buf.readUInt16LE(2),
+           threshold        : buf.readUInt16LE(4)
+       })
+   ],
+
+   GetScreenSaver: [
+       () => packCxS(108, 1),
+
+       buf => ({
+           timeout        : buf.readInt16LE(0),
+           interval       : buf.readInt16LE(2),
+           preferBlanking : buf.readUInt8(4),
+           allowExposures : buf.readUInt8(5)
+       })
+   ],
+
+   ChangeHosts: [
+       // mode: 0 Insert, 1 Delete
+       // family: 0 Internet, 1 DECnet, 2 Chaos, 5 ServerInterpreted, 6 InternetV6
+       // address: Buffer or byte array
+       (mode, family, address) => {
+           const addr = Buffer.isBuffer(address) ? address : Buffer.from(address);
+           const padded = xutil.padded_length(addr.length);
+           const b = Buffer.alloc(8 + padded);
+           b[0] = 109;
+           b[1] = mode;
+           b.writeUInt16LE(2 + padded / 4, 2);
+           b[4] = family;
+           b.writeUInt16LE(addr.length, 6);
+           addr.copy(b, 8);
+           return b;
+       }
+   ],
+
+   ListHosts: [
+       () => packCxS(110, 1),
+
+       (buf, mode) => {
+           const n = buf.readUInt16LE(0);
+           const res = { mode, hosts: [] }; // mode: 0 access control disabled, 1 enabled
+           let off = 24;
+           for (let i = 0; i < n; ++i) {
+               const family = buf.readUInt8(off);
+               const addrLen = buf.readUInt16LE(off + 2);
+               res.hosts.push({
+                   family,
+                   address: buf.slice(off + 4, off + 4 + addrLen)
+               });
+               off += 4 + xutil.padded_length(addrLen);
+           }
+           return res;
+       }
+   ],
+
+   SetAccessControl: [
+       // mode: 0 Disable, 1 Enable
+       mode => {
+           const b = Buffer.alloc(4);
+           b[0] = 111;
+           b[1] = mode;
+           b.writeUInt16LE(1, 2);
+           return b;
+       }
+   ],
+
+   SetCloseDownMode: [
+       // mode: 0 Destroy, 1 RetainPermanent, 2 RetainTemporary
+       mode => {
+           const b = Buffer.alloc(4);
+           b[0] = 112;
+           b[1] = mode;
+           b.writeUInt16LE(1, 2);
+           return b;
+       }
+   ],
+
    KillClient: [
        resource => packCxSL(113, 2, resource)
+   ],
+
+   RotateProperties: [
+       (wid, delta, atoms) => {
+           const b = Buffer.alloc(12 + 4 * atoms.length);
+           b[0] = 114;
+           b.writeUInt16LE(3 + atoms.length, 2);
+           b.writeUInt32LE(wid >>> 0, 4);
+           b.writeUInt16LE(atoms.length, 8);
+           b.writeInt16LE(delta, 10);
+           for (let i = 0; i < atoms.length; ++i)
+               b.writeUInt32LE(atoms[i] >>> 0, 12 + 4 * i);
+           return b;
+       }
    ],
 
    SetScreenSaver: [
@@ -1212,10 +2061,12 @@ const templates = {
    ],
 
    Bell: [
+       // percent: -100..100 relative to base bell volume
        percent => {
-           const b = Buffer.alloc(5);
-           b[0] = 108;
-           b[2] = 1;
+           const b = Buffer.alloc(4);
+           b[0] = 104;
+           b.writeInt8(percent || 0, 1);
+           b.writeUInt16LE(1, 2);
            return b;
        }
    ],
@@ -1228,6 +2079,74 @@ const templates = {
            b.writeUInt16LE(1, 2);
            return b;
        }
+   ],
+
+   SetPointerMapping: [
+       map => {
+           const padded = xutil.padded_length(map.length);
+           const b = Buffer.alloc(4 + padded);
+           b[0] = 116;
+           b[1] = map.length;
+           b.writeUInt16LE(1 + padded / 4, 2);
+           for (let i = 0; i < map.length; ++i)
+               b[4 + i] = map[i];
+           return b;
+       },
+
+       // status: 0 Success, 1 Busy
+       (buf, status) => status
+   ],
+
+   GetPointerMapping: [
+       () => packCxS(117, 1),
+
+       (buf, n) => {
+           const map = [];
+           for (let i = 0; i < n; ++i)
+               map.push(buf.readUInt8(24 + i));
+           return map;
+       }
+   ],
+
+   SetModifierMapping: [
+       // keycodesPerModifier keycodes for each of 8 modifiers (Shift, Lock,
+       // Control, Mod1-Mod5); rows shorter than keycodesPerModifier are zero-padded
+       rows => {
+           let n = 0;
+           for (const row of rows)
+               if (row.length > n)
+                   n = row.length;
+           const b = Buffer.alloc(4 + 8 * n);
+           b[0] = 118;
+           b[1] = n;
+           b.writeUInt16LE(1 + 2 * n, 2);
+           for (let mod = 0; mod < 8; ++mod)
+               for (let i = 0; i < rows[mod].length; ++i)
+                   b[4 + mod * n + i] = rows[mod][i];
+           return b;
+       },
+
+       // status: 0 Success, 1 Busy, 2 Failed
+       (buf, status) => status
+   ],
+
+   GetModifierMapping: [
+       () => packCxS(119, 1),
+
+       (buf, keycodesPerModifier) => {
+           const rows = [];
+           for (let mod = 0; mod < 8; ++mod) {
+               const row = [];
+               for (let i = 0; i < keycodesPerModifier; ++i)
+                   row.push(buf.readUInt8(24 + mod * keycodesPerModifier + i));
+               rows.push(row);
+           }
+           return rows;
+       }
+   ],
+
+   NoOperation: [
+       () => packCxS(127, 1)
    ]
 };
 

--- a/lib/generated/core-events.js
+++ b/lib/generated/core-events.js
@@ -134,6 +134,12 @@ function parseFocusOut(type, seq, extra, code, raw, headerBuf) {
   return event;
 }
 
+function parseKeymapNotify(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, name: 'KeymapNotify' };
+  event.keys = Buffer.concat([headerBuf.slice(1, 8), raw]);
+  return event;
+}
+
 function parseExpose(type, seq, extra, code, raw, headerBuf) {
   const event = { type: type & 0x7F, seq, name: 'Expose' };
   event.wid = extra;
@@ -142,6 +148,34 @@ function parseExpose(type, seq, extra, code, raw, headerBuf) {
   event.width = raw.readUInt16LE(4);
   event.height = raw.readUInt16LE(6);
   event.count = raw.readUInt16LE(8);
+  return event;
+}
+
+function parseGraphicsExposure(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'GraphicsExposure' };
+  event.drawable = extra;
+  event.x = raw.readUInt16LE(0);
+  event.y = raw.readUInt16LE(2);
+  event.width = raw.readUInt16LE(4);
+  event.height = raw.readUInt16LE(6);
+  event.minorOpcode = raw.readUInt16LE(8);
+  event.count = raw.readUInt16LE(10);
+  event.majorOpcode = raw.readUInt8(12);
+  return event;
+}
+
+function parseNoExposure(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'NoExposure' };
+  event.drawable = extra;
+  event.minorOpcode = raw.readUInt16LE(0);
+  event.majorOpcode = raw.readUInt8(2);
+  return event;
+}
+
+function parseVisibilityNotify(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'VisibilityNotify' };
+  event.wid = extra;
+  event.state = raw.readUInt8(0);
   return event;
 }
 
@@ -188,6 +222,17 @@ function parseMapRequest(type, seq, extra, code, raw, headerBuf) {
   return event;
 }
 
+function parseReparentNotify(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'ReparentNotify' };
+  event.event = extra;
+  event.wid = raw.readUInt32LE(0);
+  event.parent = raw.readUInt32LE(4);
+  event.x = raw.readInt16LE(8);
+  event.y = raw.readInt16LE(10);
+  event.overrideRedirect = !!raw.readUInt8(12);
+  return event;
+}
+
 function parseConfigureNotify(type, seq, extra, code, raw, headerBuf) {
   const event = { type: type & 0x7F, seq, name: 'ConfigureNotify' };
   event.wid = extra;
@@ -214,6 +259,39 @@ function parseConfigureRequest(type, seq, extra, code, raw, headerBuf) {
   event.height = raw.readUInt16LE(14);
   event.borderWidth = raw.readUInt16LE(16);
   event.mask = raw.readUInt16LE(18);
+  return event;
+}
+
+function parseGravityNotify(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'GravityNotify' };
+  event.event = extra;
+  event.wid = raw.readUInt32LE(0);
+  event.x = raw.readInt16LE(4);
+  event.y = raw.readInt16LE(6);
+  return event;
+}
+
+function parseResizeRequest(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'ResizeRequest' };
+  event.wid = extra;
+  event.width = raw.readUInt16LE(0);
+  event.height = raw.readUInt16LE(2);
+  return event;
+}
+
+function parseCirculateNotify(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'CirculateNotify' };
+  event.event = extra;
+  event.wid = raw.readUInt32LE(0);
+  event.place = raw.readUInt8(8);
+  return event;
+}
+
+function parseCirculateRequest(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'CirculateRequest' };
+  event.event = extra;
+  event.wid = raw.readUInt32LE(0);
+  event.place = raw.readUInt8(8);
   return event;
 }
 
@@ -255,6 +333,15 @@ function parseSelectionNotify(type, seq, extra, code, raw, headerBuf) {
   return event;
 }
 
+function parseColormapNotify(type, seq, extra, code, raw, headerBuf) {
+  const event = { type: type & 0x7F, seq, name: 'ColormapNotify' };
+  event.wid = extra;
+  event.colormap = raw.readUInt32LE(0);
+  event.new = raw.readUInt8(4);
+  event.state = raw.readUInt8(5);
+  return event;
+}
+
 function parseClientMessage(type, seq, extra, code, raw, headerBuf) {
   const event = { type: type & 0x7F, seq, name: 'ClientMessage' };
   event.format = code;
@@ -290,18 +377,28 @@ const parsers = {
   8: parseLeaveNotify,
   9: parseFocusIn,
   10: parseFocusOut,
+  11: parseKeymapNotify,
   12: parseExpose,
+  13: parseGraphicsExposure,
+  14: parseNoExposure,
+  15: parseVisibilityNotify,
   16: parseCreateNotify,
   17: parseDestroyNotify,
   18: parseUnmapNotify,
   19: parseMapNotify,
   20: parseMapRequest,
+  21: parseReparentNotify,
   22: parseConfigureNotify,
   23: parseConfigureRequest,
+  24: parseGravityNotify,
+  25: parseResizeRequest,
+  26: parseCirculateNotify,
+  27: parseCirculateRequest,
   28: parsePropertyNotify,
   29: parseSelectionClear,
   30: parseSelectionRequest,
   31: parseSelectionNotify,
+  32: parseColormapNotify,
   33: parseClientMessage,
   34: parseMappingNotify,
 };

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -214,7 +214,7 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                      throw new TypeError(`${reqName}: pack template must return a Buffer`);
 
                  if (callback)
-                     this.replies[this.seq_num] = [reqReplTemplate[1], callback];
+                     this.replies[this.seq_num] = [reqReplTemplate[1], callback, reqReplTemplate[2]];
 
                  client.pack_stream.put(packet);
                  client.pack_stream.flush();
@@ -348,9 +348,19 @@ XClient.prototype.expectReplyHeader = function()
 
                     const result = unpack.call(client, data, opt_data);
                     const callback = handler[1];
-                    callback(null, result);
-                    // TODO: add multiple replies flag and delete handler only after last reply (eg ListFontsWithInfo)
-                    delete client.replies[seq_num];
+                    if (handler[2]) {
+                        // multi-reply request (eg ListFontsWithInfo):
+                        // unpack returns undefined for the terminating reply
+                        if (result === undefined) {
+                            callback(null, handler[3] || []);
+                            delete client.replies[seq_num];
+                        } else {
+                            (handler[3] = handler[3] || []).push(result);
+                        }
+                    } else {
+                        callback(null, result);
+                        delete client.replies[seq_num];
+                    }
                 }
                 // wait for new packet from server
                 client.expectReplyHeader();

--- a/test/core-colormaps.js
+++ b/test/core-colormaps.js
@@ -1,0 +1,189 @@
+const x11 = require('../lib');
+const should = require('should');
+const assert = require('assert');
+
+describe('Colormap requests', () => {
+
+  let display;
+  let X;
+  let root;
+  let defaultCmap;
+  let writableVid; // visual with writable colormap (GrayScale/PseudoColor/DirectColor)
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          defaultCmap = display.screen[0].default_colormap;
+          writableVid = null;
+          const depths = display.screen[0].depths;
+          for (const depth in depths) {
+              for (const vid in depths[depth]) {
+                  const klass = depths[depth][vid].class;
+                  if (klass === 1 || klass === 3 || klass === 5)
+                      writableVid = depths[depth][vid].vid;
+              }
+          }
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  function createWritableCmap() {
+      // window param only selects the screen, visual can be any one it supports
+      const cmap = X.AllocID();
+      X.CreateColormap(cmap, root, writableVid, 0);
+      return cmap;
+  }
+
+  it('LookupColor should resolve named color "red"', done => {
+      X.LookupColor(defaultCmap, 'red', (err, color) => {
+          should.not.exist(err);
+          color.exactRed.should.equal(0xffff);
+          color.exactGreen.should.equal(0);
+          color.exactBlue.should.equal(0);
+          done();
+      });
+  });
+
+  it('AllocNamedColor should allocate named color "blue"', done => {
+      X.AllocNamedColor(defaultCmap, 'blue', (err, color) => {
+          should.not.exist(err);
+          color.exactBlue.should.equal(0xffff);
+          color.visualBlue.should.be.above(0);
+          X.QueryColors(defaultCmap, [color.pixel], (err2, colors) => {
+              should.not.exist(err2);
+              colors.length.should.equal(1);
+              colors[0].blue.should.equal(color.visualBlue);
+              colors[0].red.should.equal(color.visualRed);
+              done();
+          });
+      });
+  });
+
+  it('QueryColors should report white and black pixels', done => {
+      const white = display.screen[0].white_pixel;
+      const black = display.screen[0].black_pixel;
+      X.QueryColors(defaultCmap, [white, black], (err, colors) => {
+          should.not.exist(err);
+          colors.length.should.equal(2);
+          colors[0].red.should.equal(0xffff);
+          colors[0].green.should.equal(0xffff);
+          colors[0].blue.should.equal(0xffff);
+          colors[1].red.should.equal(0);
+          colors[1].green.should.equal(0);
+          colors[1].blue.should.equal(0);
+          done();
+      });
+  });
+
+  it('ListInstalledColormaps should include the default colormap', done => {
+      X.ListInstalledColormaps(root, (err, cmaps) => {
+          should.not.exist(err);
+          cmaps.should.containEql(defaultCmap);
+          done();
+      });
+  });
+
+  it('InstallColormap/UninstallColormap should toggle installed list', function(done) {
+      if (!writableVid)
+          return this.skip();
+      const cmap = createWritableCmap();
+      X.InstallColormap(cmap);
+      X.ListInstalledColormaps(root, (err, cmaps) => {
+          should.not.exist(err);
+          cmaps.should.containEql(cmap);
+          X.UninstallColormap(cmap);
+          X.ListInstalledColormaps(root, (err2, cmaps2) => {
+              should.not.exist(err2);
+              cmaps2.should.not.containEql(cmap);
+              X.FreeColormap(cmap);
+              done();
+          });
+      });
+  });
+
+  it('AllocColorCells + StoreColors should store readable values', function(done) {
+      if (!writableVid)
+          return this.skip();
+      const cmap = createWritableCmap();
+      X.AllocColorCells(0, cmap, 1, 0, (err, cells) => {
+          should.not.exist(err);
+          cells.pixels.length.should.equal(1);
+          const pixel = cells.pixels[0];
+          X.StoreColors(cmap, [{ pixel, red: 0xabab, green: 0x1212, blue: 0x7878 }]);
+          X.QueryColors(cmap, [pixel], (err2, colors) => {
+              should.not.exist(err2);
+              colors[0].red.should.equal(0xabab);
+              colors[0].green.should.equal(0x1212);
+              colors[0].blue.should.equal(0x7878);
+              X.FreeColors(cmap, 0, [pixel]);
+              X.FreeColormap(cmap);
+              done();
+          });
+      });
+  });
+
+  it('StoreNamedColor should store rgb of named color', function(done) {
+      if (!writableVid)
+          return this.skip();
+      const cmap = createWritableCmap();
+      X.AllocColorCells(0, cmap, 1, 0, (err, cells) => {
+          should.not.exist(err);
+          const pixel = cells.pixels[0];
+          X.StoreNamedColor(cmap, pixel, 'red');
+          X.QueryColors(cmap, [pixel], (err2, colors) => {
+              should.not.exist(err2);
+              colors[0].red.should.equal(0xffff);
+              colors[0].green.should.equal(0);
+              colors[0].blue.should.equal(0);
+              X.FreeColormap(cmap);
+              done();
+          });
+      });
+  });
+
+  it('AllocColorPlanes should return pixels and masks', function(done) {
+      if (!writableVid)
+          return this.skip();
+      const cmap = createWritableCmap();
+      X.AllocColorPlanes(0, cmap, 1, 1, 1, 1, (err, res) => {
+          should.not.exist(err);
+          res.pixels.length.should.equal(1);
+          res.redMask.should.be.above(0);
+          res.greenMask.should.be.above(0);
+          res.blueMask.should.be.above(0);
+          X.FreeColormap(cmap);
+          done();
+      });
+  });
+
+  it('CopyColormapAndFree should move allocations to new colormap', function(done) {
+      if (!writableVid)
+          return this.skip();
+      const cmap = createWritableCmap();
+      X.AllocColorCells(0, cmap, 1, 0, (err, cells) => {
+          should.not.exist(err);
+          const pixel = cells.pixels[0];
+          X.StoreColors(cmap, [{ pixel, red: 0x4242, green: 0x4242, blue: 0x4242 }]);
+          const cmap2 = X.AllocID();
+          X.CopyColormapAndFree(cmap2, cmap);
+          X.QueryColors(cmap2, [pixel], (err2, colors) => {
+              should.not.exist(err2);
+              colors[0].red.should.equal(0x4242);
+              X.FreeColormap(cmap2);
+              done();
+          });
+      });
+  });
+});

--- a/test/core-cursors.js
+++ b/test/core-cursors.js
@@ -1,0 +1,84 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('Cursor requests', () => {
+
+  let display;
+  let X;
+  let root;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  const red = { R: 0xffff, G: 0, B: 0 };
+  const white = { R: 0xffff, G: 0xffff, B: 0xffff };
+
+  function createLeftPtrCursor() {
+      const fid = X.AllocID();
+      X.OpenFont(fid, 'cursor');
+      const cid = X.AllocID();
+      // 68/69 - XC_left_ptr glyph and its mask in the standard cursor font
+      X.CreateGlyphCursor(cid, fid, fid, 68, 69, { R: 0, G: 0, B: 0 }, white);
+      X.CloseFont(fid);
+      return cid;
+  }
+
+  it('CreateGlyphCursor should create usable cursor', done => {
+      const cid = createLeftPtrCursor();
+      const wid = X.AllocID();
+      X.CreateWindow(wid, root, 0, 0, 10, 10, 0, 0, 0, 0, { cursor: cid });
+      // any of the above failing would error before this reply arrives
+      X.GetWindowAttributes(wid, (err, attrs) => {
+          should.not.exist(err);
+          X.DestroyWindow(wid);
+          X.FreeCursor(cid);
+          done();
+      });
+  });
+
+  it('RecolorCursor should be accepted by server', done => {
+      const cid = createLeftPtrCursor();
+      X.RecolorCursor(cid, red, white);
+      X.GetInputFocus(err => {
+          should.not.exist(err);
+          X.FreeCursor(cid);
+          done();
+      });
+  });
+
+  it('FreeCursor should make cursor id invalid', done => {
+      const cid = createLeftPtrCursor();
+      X.FreeCursor(cid);
+      X.removeAllListeners('error'); // drop the beforeEach done-listener
+      X.on('error', err => {
+          err.message.should.equal('Bad cursor');
+          done();
+      });
+      X.RecolorCursor(cid, red, white);
+  });
+
+  it('QueryBestSize should return non-zero cursor size', done => {
+      X.QueryBestSize(0, root, 16, 16, (err, size) => {
+          should.not.exist(err);
+          size.width.should.be.above(0);
+          size.height.should.be.above(0);
+          done();
+      });
+  });
+});

--- a/test/core-drawing.js
+++ b/test/core-drawing.js
@@ -1,0 +1,182 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('Drawing requests', () => {
+
+  const W = 20;
+  const H = 20;
+
+  let display;
+  let X;
+  let root;
+  let white;
+  let black;
+  let depth;
+  let pixmap;
+  let gc;
+  let bytesPP;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          white = display.screen[0].white_pixel;
+          black = display.screen[0].black_pixel;
+          depth = display.screen[0].root_depth;
+          bytesPP = depth <= 8 ? 1 : (depth <= 16 ? 2 : 4);
+          pixmap = X.AllocID();
+          X.CreatePixmap(pixmap, root, depth, W, H);
+          gc = X.AllocID();
+          X.CreateGC(gc, pixmap, { foreground: black, background: black });
+          X.PolyFillRectangle(pixmap, gc, [0, 0, W, H]); // black canvas
+          X.ChangeGC(gc, { foreground: white });
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.FreeGC(gc);
+      X.FreePixmap(pixmap);
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  function getPixel(imageData, x, y) {
+      const off = (y * W + x) * bytesPP;
+      let value = 0;
+      for (let i = 0; i < bytesPP; ++i)
+          value += imageData[off + i] << (8 * i);
+      return value >>> 0;
+  }
+
+  function countPixels(imageData, pixel) {
+      let count = 0;
+      for (let y = 0; y < H; ++y)
+          for (let x = 0; x < W; ++x)
+              if (getPixel(imageData, x, y) === (pixel >>> 0))
+                  ++count;
+      return count;
+  }
+
+  function readBack(cb) {
+      X.GetImage(2, pixmap, 0, 0, W, H, 0xffffffff, (err, img) => {
+          should.not.exist(err);
+          cb(img.data);
+      });
+  }
+
+  it('PolySegment should draw line segments', done => {
+      X.PolySegment(pixmap, gc, [0, 10, 19, 10, 5, 0, 5, 4]);
+      readBack(data => {
+          getPixel(data, 10, 10).should.equal(white >>> 0); // on segment 1
+          getPixel(data, 5, 2).should.equal(white >>> 0);   // on segment 2
+          getPixel(data, 10, 5).should.equal(black >>> 0);  // off both
+          done();
+      });
+  });
+
+  it('PolyRectangle should draw outlines only', done => {
+      X.PolyRectangle(pixmap, gc, [2, 2, 15, 15]);
+      readBack(data => {
+          getPixel(data, 2, 2).should.equal(white >>> 0);   // corner
+          getPixel(data, 17, 17).should.equal(white >>> 0); // opposite corner
+          getPixel(data, 10, 10).should.equal(black >>> 0); // inside not filled
+          done();
+      });
+  });
+
+  it('PolyArc should draw an ellipse outline', done => {
+      X.PolyArc(pixmap, gc, [2, 2, 16, 16, 0, 360 * 64]);
+      readBack(data => {
+          getPixel(data, 2, 10).should.equal(white >>> 0);  // leftmost point
+          getPixel(data, 18, 10).should.equal(white >>> 0); // rightmost point
+          getPixel(data, 10, 10).should.equal(black >>> 0); // center untouched
+          done();
+      });
+  });
+
+  it('FillPoly should fill a triangle', done => {
+      X.FillPoly(pixmap, gc, 2, 0, [0, 0, 19, 0, 10, 19]);
+      readBack(data => {
+          getPixel(data, 10, 5).should.equal(white >>> 0);  // inside
+          getPixel(data, 0, 19).should.equal(black >>> 0);  // outside
+          done();
+      });
+  });
+
+  it('CopyPlane should reproduce src through one bit-plane', done => {
+      X.PolyFillRectangle(pixmap, gc, [0, 0, W, H]); // all white
+      const dst = X.AllocID();
+      X.CreatePixmap(dst, root, depth, W, H);
+      const dstGC = X.AllocID();
+      // white has at least one bit set - pick lowest set bit as the plane
+      const plane = white & -white;
+      X.CreateGC(dstGC, dst, { foreground: white, background: black });
+      X.CopyPlane(pixmap, dst, dstGC, 0, 0, 0, 0, W, H, plane);
+      X.GetImage(2, dst, 0, 0, W, H, 0xffffffff, (err, img) => {
+          should.not.exist(err);
+          getPixel(img.data, 10, 10).should.equal(white >>> 0);
+          X.FreeGC(dstGC);
+          X.FreePixmap(dst);
+          done();
+      });
+  });
+
+  it('ImageText8 should draw text pixels', done => {
+      const fid = X.AllocID();
+      X.OpenFont(fid, 'fixed');
+      X.ChangeGC(gc, { font: fid });
+      X.ImageText8(pixmap, gc, 2, 15, 'X');
+      X.CloseFont(fid);
+      readBack(data => {
+          countPixels(data, white).should.be.above(0);
+          done();
+      });
+  });
+
+  it('ImageText16 should draw same pixels as ImageText8', done => {
+      const fid = X.AllocID();
+      X.OpenFont(fid, 'fixed');
+      X.ChangeGC(gc, { font: fid });
+      X.ImageText8(pixmap, gc, 2, 15, 'X');
+      readBack(data8 => {
+          const count8 = countPixels(data8, white);
+          count8.should.be.above(0);
+          X.ChangeGC(gc, { foreground: black });
+          X.PolyFillRectangle(pixmap, gc, [0, 0, W, H]); // reset to black
+          X.ChangeGC(gc, { foreground: white });
+          X.ImageText16(pixmap, gc, 2, 15, 'X');
+          X.CloseFont(fid);
+          readBack(data16 => {
+              countPixels(data16, white).should.equal(count8);
+              done();
+          });
+      });
+  });
+
+  it('PolyText16 should draw same pixels as PolyText8', done => {
+      const fid = X.AllocID();
+      X.OpenFont(fid, 'fixed');
+      X.ChangeGC(gc, { font: fid });
+      X.PolyText8(pixmap, gc, 2, 15, ['X1']);
+      readBack(data8 => {
+          const count8 = countPixels(data8, white);
+          count8.should.be.above(0);
+          X.ChangeGC(gc, { foreground: black });
+          X.PolyFillRectangle(pixmap, gc, [0, 0, W, H]); // reset to black
+          X.ChangeGC(gc, { foreground: white });
+          X.PolyText16(pixmap, gc, 2, 15, ['X1']);
+          X.CloseFont(fid);
+          readBack(data16 => {
+              countPixels(data16, white).should.equal(count8);
+              done();
+          });
+      });
+  });
+});

--- a/test/core-events-extra.js
+++ b/test/core-events-extra.js
@@ -1,0 +1,204 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('Core events (newly generated parsers)', () => {
+
+  let display;
+  let X;
+  let root;
+  let white;
+  let black;
+  let depth;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          white = display.screen[0].white_pixel;
+          black = display.screen[0].black_pixel;
+          depth = display.screen[0].root_depth;
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  function onEvent(name, cb) {
+      const listener = ev => {
+          if (ev.name === name) {
+              X.removeListener('event', listener);
+              cb(ev);
+          }
+      };
+      X.on('event', listener);
+  }
+
+  it('VisibilityNotify should fire when window becomes visible', done => {
+      const wid = X.AllocID();
+      X.CreateWindow(wid, root, 0, 0, 50, 50, 0, 0, 0, 0,
+          { eventMask: x11.eventMask.VisibilityChange });
+      onEvent('VisibilityNotify', ev => {
+          ev.wid.should.equal(wid);
+          ev.state.should.equal(0); // Unobscured
+          X.DestroyWindow(wid);
+          done();
+      });
+      X.MapWindow(wid);
+  });
+
+  it('ReparentNotify should fire on ReparentWindow', done => {
+      const parent = X.AllocID();
+      const child = X.AllocID();
+      X.CreateWindow(parent, root, 0, 0, 100, 100);
+      X.CreateWindow(child, root, 0, 0, 20, 20, 0, 0, 0, 0,
+          { eventMask: x11.eventMask.StructureNotify });
+      onEvent('ReparentNotify', ev => {
+          ev.event.should.equal(child);
+          ev.wid.should.equal(child);
+          ev.parent.should.equal(parent);
+          ev.x.should.equal(5);
+          ev.y.should.equal(6);
+          X.DestroyWindow(parent);
+          done();
+      });
+      X.ReparentWindow(child, parent, 5, 6);
+  });
+
+  it('GravityNotify should fire when parent resize moves child', done => {
+      const parent = X.AllocID();
+      const child = X.AllocID();
+      X.CreateWindow(parent, root, 0, 0, 100, 100);
+      // SouthEast gravity: child follows bottom-right corner
+      X.CreateWindow(child, parent, 50, 50, 20, 20, 0, 0, 0, 0,
+          { winGravity: 9, eventMask: x11.eventMask.StructureNotify });
+      X.MapWindow(parent);
+      onEvent('GravityNotify', ev => {
+          ev.event.should.equal(child);
+          ev.wid.should.equal(child);
+          ev.x.should.equal(30);
+          ev.y.should.equal(30);
+          X.DestroyWindow(parent);
+          done();
+      });
+      X.ResizeWindow(parent, 80, 80);
+  });
+
+  it('NoExposure should fire for fully valid CopyArea', done => {
+      const pixmap = X.AllocID();
+      const dst = X.AllocID();
+      const gc = X.AllocID();
+      X.CreatePixmap(pixmap, root, depth, 20, 20);
+      X.CreatePixmap(dst, root, depth, 20, 20);
+      X.CreateGC(gc, dst, { graphicsExposures: 1, foreground: black });
+      X.PolyFillRectangle(pixmap, gc, [0, 0, 20, 20]);
+      onEvent('NoExposure', ev => {
+          ev.drawable.should.equal(dst);
+          ev.majorOpcode.should.equal(62); // CopyArea
+          X.FreeGC(gc);
+          X.FreePixmap(pixmap);
+          X.FreePixmap(dst);
+          done();
+      });
+      X.CopyArea(pixmap, dst, gc, 0, 0, 0, 0, 20, 20);
+  });
+
+  it('GraphicsExposure should fire for out-of-bounds CopyArea source', done => {
+      const pixmap = X.AllocID();
+      const dst = X.AllocID();
+      const gc = X.AllocID();
+      X.CreatePixmap(pixmap, root, depth, 20, 20);
+      X.CreatePixmap(dst, root, depth, 20, 20);
+      X.CreateGC(gc, dst, { graphicsExposures: 1, foreground: black });
+      X.PolyFillRectangle(pixmap, gc, [0, 0, 20, 20]);
+      onEvent('GraphicsExposure', ev => {
+          ev.drawable.should.equal(dst);
+          ev.majorOpcode.should.equal(62); // CopyArea
+          X.FreeGC(gc);
+          X.FreePixmap(pixmap);
+          X.FreePixmap(dst);
+          done();
+      });
+      // source region sticks out of the 20x20 pixmap - missing part is exposed
+      X.CopyArea(pixmap, dst, gc, 10, 10, 0, 0, 20, 20);
+  });
+
+  it('CirculateNotify should fire on CirculateWindow', done => {
+      const parent = X.AllocID();
+      X.CreateWindow(parent, root, 0, 0, 100, 100, 0, 0, 0, 0,
+          { eventMask: x11.eventMask.SubstructureNotify });
+      const child1 = X.AllocID();
+      const child2 = X.AllocID();
+      X.CreateWindow(child1, parent, 0, 0, 50, 50);
+      X.CreateWindow(child2, parent, 0, 0, 50, 50);
+      X.MapWindow(parent);
+      X.MapSubwindows(parent);
+      onEvent('CirculateNotify', ev => {
+          ev.event.should.equal(parent);
+          ev.wid.should.equal(child1);
+          ev.place.should.equal(0); // Top
+          X.DestroyWindow(parent);
+          done();
+      });
+      X.CirculateWindow(parent, 0); // RaiseLowest
+  });
+
+  it('ColormapNotify should fire when window colormap attribute changes', done => {
+      const wid = X.AllocID();
+      X.CreateWindow(wid, root, 0, 0, 10, 10, 0, 0, 0, 0,
+          { eventMask: x11.eventMask.ColormapChange });
+      const cmap = X.AllocID();
+      X.CreateColormap(cmap, root, display.screen[0].root_visual, 0);
+      onEvent('ColormapNotify', ev => {
+          ev.wid.should.equal(wid);
+          ev.colormap.should.equal(cmap);
+          ev.new.should.equal(1);
+          X.DestroyWindow(wid);
+          X.FreeColormap(cmap);
+          done();
+      });
+      X.ChangeWindowAttributes(wid, { colormap: cmap });
+  });
+
+  it('KeymapNotify should follow FocusIn when KeymapState selected', done => {
+      const wid = X.AllocID();
+      X.CreateWindow(wid, root, 0, 0, 10, 10, 0, 0, 0, 0,
+          { eventMask: x11.eventMask.FocusChange | x11.eventMask.KeymapState });
+      X.MapWindow(wid);
+      onEvent('KeymapNotify', ev => {
+          ev.keys.length.should.equal(31);
+          X.DestroyWindow(wid);
+          done();
+      });
+      X.SetInputFocus(wid, 0);
+  });
+
+  it('ResizeRequest should redirect resize from another client', done => {
+      const wid = X.AllocID();
+      X.CreateWindow(wid, root, 0, 0, 50, 50, 0, 0, 0, 0,
+          { eventMask: x11.eventMask.ResizeRedirect });
+      X.MapWindow(wid);
+      onEvent('ResizeRequest', ev => {
+          ev.wid.should.equal(wid);
+          ev.width.should.equal(70);
+          ev.height.should.equal(80);
+          X.DestroyWindow(wid);
+          X2.terminate();
+          done();
+      });
+      let X2;
+      x11.createClient((err, dpy2) => {
+          should.not.exist(err);
+          X2 = dpy2.client;
+          X2.ResizeWindow(wid, 70, 80);
+      });
+  });
+});

--- a/test/core-fonts.js
+++ b/test/core-fonts.js
@@ -1,0 +1,102 @@
+const x11 = require('../lib');
+const should = require('should');
+const assert = require('assert');
+
+describe('Font requests', () => {
+
+  let display;
+  let X;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  it('OpenFont + QueryFont should return metrics for "fixed"', done => {
+      const fid = X.AllocID();
+      X.OpenFont(fid, 'fixed');
+      X.QueryFont(fid, (err, font) => {
+          should.not.exist(err);
+          font.fontAscent.should.be.above(0);
+          font.maxBounds.characterWidth.should.be.above(0);
+          font.charInfos.length.should.be.above(0);
+          font.properties.length.should.be.above(0);
+          X.CloseFont(fid);
+          done();
+      });
+  });
+
+  it('QueryTextExtents should measure a string', done => {
+      const fid = X.AllocID();
+      X.OpenFont(fid, 'fixed');
+      X.QueryTextExtents(fid, 'hello', (err, extents) => {
+          should.not.exist(err);
+          // "fixed" is monospaced: overall width = 5 * char width
+          extents.overallWidth.should.be.above(0);
+          X.QueryFont(fid, (err2, font) => {
+              should.not.exist(err2);
+              extents.overallWidth.should.equal(5 * font.maxBounds.characterWidth);
+              extents.fontAscent.should.equal(font.fontAscent);
+              X.CloseFont(fid);
+              done();
+          });
+      });
+  });
+
+  it('CloseFont should make font id invalid', done => {
+      const fid = X.AllocID();
+      X.OpenFont(fid, 'fixed');
+      X.CloseFont(fid);
+      X.QueryFont(fid, err => {
+          should.exist(err);
+          err.message.should.equal('Bad font');
+          done();
+          return true; // error handled - don't re-emit on client
+      });
+  });
+
+  it('ListFontsWithInfo should return same number of fonts as ListFonts', done => {
+      X.ListFonts('*', 10, (err, names) => {
+          should.not.exist(err);
+          names.length.should.be.above(0);
+          // note: names may differ from ListFonts (server resolves aliases), so
+          // only compare the count and check per-font info is sane
+          X.ListFontsWithInfo('*', 10, (err2, fonts) => {
+              should.not.exist(err2);
+              fonts.length.should.equal(names.length);
+              fonts.forEach(font => {
+                  font.name.length.should.be.above(0);
+                  font.maxBounds.characterWidth.should.be.above(0);
+                  font.fontAscent.should.be.above(0);
+              });
+              done();
+          });
+      });
+  });
+
+  it('GetFontPath/SetFontPath roundtrip', done => {
+      X.GetFontPath((err, paths) => {
+          should.not.exist(err);
+          paths.should.be.an.Array();
+          X.SetFontPath(paths);
+          X.GetFontPath((err2, paths2) => {
+              should.not.exist(err2);
+              assert.deepEqual(paths2, paths);
+              done();
+          });
+      });
+  });
+});

--- a/test/core-gc.js
+++ b/test/core-gc.js
@@ -1,0 +1,104 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('GC requests', () => {
+
+  let display;
+  let X;
+  let root;
+  let white;
+  let black;
+  let depth;
+  let pixmap;
+  let bytesPP;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          white = display.screen[0].white_pixel;
+          black = display.screen[0].black_pixel;
+          depth = display.screen[0].root_depth;
+          bytesPP = depth <= 8 ? 1 : (depth <= 16 ? 2 : 4);
+          pixmap = X.AllocID();
+          X.CreatePixmap(pixmap, root, depth, 20, 20);
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.FreePixmap(pixmap);
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  function getPixel(imageData, x, y) {
+      const off = (y * 20 + x) * bytesPP;
+      let value = 0;
+      for (let i = 0; i < bytesPP; ++i)
+          value += imageData[off + i] << (8 * i);
+      return value >>> 0;
+  }
+
+  it('CopyGC should copy selected components', done => {
+      const gcWhite = X.AllocID();
+      const gcDst = X.AllocID();
+      X.CreateGC(gcWhite, pixmap, { foreground: white });
+      X.CreateGC(gcDst, pixmap, { foreground: black });
+      X.CopyGC(gcWhite, gcDst, ['foreground']);
+      X.PolyFillRectangle(pixmap, gcDst, [0, 0, 20, 20]);
+      X.GetImage(2, pixmap, 0, 0, 20, 20, 0xffffffff, (err, img) => {
+          should.not.exist(err);
+          getPixel(img.data, 10, 10).should.equal(white >>> 0);
+          X.FreeGC(gcWhite);
+          X.FreeGC(gcDst);
+          done();
+      });
+  });
+
+  it('SetClipRectangles should restrict fills to clip area', done => {
+      const gc = X.AllocID();
+      X.CreateGC(gc, pixmap, { foreground: black });
+      X.PolyFillRectangle(pixmap, gc, [0, 0, 20, 20]); // all black
+      X.ChangeGC(gc, { foreground: white });
+      X.SetClipRectangles(gc, 0, 0, 0, [0, 0, 10, 20]); // left half only
+      X.PolyFillRectangle(pixmap, gc, [0, 0, 20, 20]); // fill all - clipped
+      X.GetImage(2, pixmap, 0, 0, 20, 20, 0xffffffff, (err, img) => {
+          should.not.exist(err);
+          getPixel(img.data, 5, 10).should.equal(white >>> 0);
+          getPixel(img.data, 15, 10).should.equal(black >>> 0);
+          X.FreeGC(gc);
+          done();
+      });
+  });
+
+  it('SetDashes should be accepted by server', done => {
+      const gc = X.AllocID();
+      X.CreateGC(gc, pixmap, { lineStyle: 1 }); // OnOffDash
+      X.SetDashes(gc, 0, [3, 2]);
+      // any encoding error would trigger BadLength/BadValue before the reply below
+      X.GetInputFocus(err => {
+          should.not.exist(err);
+          X.FreeGC(gc);
+          done();
+      });
+  });
+
+  it('FreeGC should make gc id invalid', done => {
+      const gc = X.AllocID();
+      X.CreateGC(gc, pixmap, {});
+      X.FreeGC(gc);
+      X.removeAllListeners('error'); // drop the beforeEach done-listener
+      X.on('error', err => {
+          err.message.should.equal('Bad GContext');
+          done();
+      });
+      X.ChangeGC(gc, { foreground: white });
+  });
+});

--- a/test/core-kbptr.js
+++ b/test/core-kbptr.js
@@ -1,0 +1,161 @@
+const x11 = require('../lib');
+const should = require('should');
+const assert = require('assert');
+
+describe('Keyboard and pointer control requests', () => {
+
+  let display;
+  let X;
+  let root;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  it('GetKeyboardControl should return current settings', done => {
+      X.GetKeyboardControl((err, control) => {
+          should.not.exist(err);
+          control.bellPercent.should.be.within(0, 100);
+          control.bellPitch.should.be.above(0);
+          control.autoRepeats.length.should.equal(32);
+          [0, 1].should.containEql(control.globalAutoRepeat);
+          done();
+      });
+  });
+
+  it('ChangeKeyboardControl should roundtrip bell settings', done => {
+      X.GetKeyboardControl((err, before) => {
+          should.not.exist(err);
+          X.ChangeKeyboardControl({ bellPercent: 55, bellPitch: 456 });
+          X.GetKeyboardControl((err2, control) => {
+              should.not.exist(err2);
+              control.bellPercent.should.equal(55);
+              control.bellPitch.should.equal(456);
+              X.ChangeKeyboardControl({
+                  bellPercent: before.bellPercent,
+                  bellPitch: before.bellPitch
+              });
+              done();
+          });
+      });
+  });
+
+  it('ChangePointerControl/GetPointerControl should roundtrip', done => {
+      X.GetPointerControl((err, before) => {
+          should.not.exist(err);
+          X.ChangePointerControl(3, 1, 42, true, true);
+          X.GetPointerControl((err2, control) => {
+              should.not.exist(err2);
+              control.accelNumerator.should.equal(3);
+              control.accelDenominator.should.equal(1);
+              control.threshold.should.equal(42);
+              X.ChangePointerControl(
+                  before.accelNumerator,
+                  before.accelDenominator,
+                  before.threshold,
+                  true,
+                  true
+              );
+              done();
+          });
+      });
+  });
+
+  it('GetScreenSaver should roundtrip with SetScreenSaver', done => {
+      X.GetScreenSaver((err, before) => {
+          should.not.exist(err);
+          X.SetScreenSaver(543, 21, 1, 1);
+          X.GetScreenSaver((err2, saver) => {
+              should.not.exist(err2);
+              saver.timeout.should.equal(543);
+              saver.interval.should.equal(21);
+              saver.preferBlanking.should.equal(1);
+              saver.allowExposures.should.equal(1);
+              X.SetScreenSaver(
+                  before.timeout,
+                  before.interval,
+                  before.preferBlanking,
+                  before.allowExposures
+              );
+              done();
+          });
+      });
+  });
+
+  it('ChangeKeyboardMapping/GetKeyboardMapping should roundtrip', done => {
+      const keycode = display.max_keycode; // remap the last valid keycode
+      X.GetKeyboardMapping(keycode, 1, (err, before) => {
+          should.not.exist(err);
+          X.ChangeKeyboardMapping(keycode, 2, [0x61, 0x41]); // a, A
+          X.GetKeyboardMapping(keycode, 1, (err2, rows) => {
+              should.not.exist(err2);
+              rows[0][0].should.equal(0x61);
+              rows[0][1].should.equal(0x41);
+              if (before[0] && before[0].length)
+                  X.ChangeKeyboardMapping(keycode, before[0].length, before[0]);
+              done();
+          });
+      });
+  });
+
+  it('GetPointerMapping/SetPointerMapping should roundtrip', done => {
+      X.GetPointerMapping((err, map) => {
+          should.not.exist(err);
+          map.length.should.be.above(0);
+          X.SetPointerMapping(map, (err2, status) => {
+              should.not.exist(err2);
+              status.should.equal(0); // Success
+              done();
+          });
+      });
+  });
+
+  it('GetModifierMapping/SetModifierMapping should roundtrip', done => {
+      X.GetModifierMapping((err, rows) => {
+          should.not.exist(err);
+          rows.length.should.equal(8);
+          X.SetModifierMapping(rows, (err2, status) => {
+              should.not.exist(err2);
+              status.should.equal(0); // Success
+              X.GetModifierMapping((err3, rows2) => {
+                  should.not.exist(err3);
+                  assert.deepEqual(rows2, rows);
+                  done();
+              });
+          });
+      });
+  });
+
+  it('Bell should be accepted by server', done => {
+      X.Bell(50);
+      X.Bell(-50);
+      // broken opcode/length would corrupt the stream and error before this reply
+      X.GetInputFocus(err => {
+          should.not.exist(err);
+          done();
+      });
+  });
+
+  it('GetMotionEvents should return an array', done => {
+      X.GetMotionEvents(root, 0, 0, (err, events) => {
+          should.not.exist(err);
+          events.should.be.an.Array();
+          done();
+      });
+  });
+});

--- a/test/core-misc.js
+++ b/test/core-misc.js
@@ -1,0 +1,111 @@
+const x11 = require('../lib');
+const should = require('should');
+const assert = require('assert');
+
+describe('Misc control requests', () => {
+
+  let display;
+  let X;
+  let root;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  it('NoOperation should be accepted by server', done => {
+      X.NoOperation();
+      X.GetInputFocus(err => {
+          should.not.exist(err);
+          done();
+      });
+  });
+
+  it('ListHosts should return host list and access control mode', done => {
+      X.ListHosts((err, res) => {
+          should.not.exist(err);
+          [0, 1].should.containEql(res.mode);
+          res.hosts.should.be.an.Array();
+          done();
+      });
+  });
+
+  it('ChangeHosts should insert and delete a host', done => {
+      const addr = [127, 0, 0, 2];
+      X.ChangeHosts(0, 0, addr); // insert Internet host
+      X.ListHosts((err, res) => {
+          should.not.exist(err);
+          const found = res.hosts.some(
+              h => h.family === 0 && h.address.equals(Buffer.from(addr)));
+          found.should.be.true();
+          X.ChangeHosts(1, 0, addr); // delete it
+          X.ListHosts((err2, res2) => {
+              should.not.exist(err2);
+              const found2 = res2.hosts.some(
+                  h => h.family === 0 && h.address.equals(Buffer.from(addr)));
+              found2.should.be.false();
+              done();
+          });
+      });
+  });
+
+  it('SetAccessControl should toggle mode reported by ListHosts', done => {
+      X.ListHosts((err, before) => {
+          should.not.exist(err);
+          X.SetAccessControl(1);
+          X.ListHosts((err2, res) => {
+              should.not.exist(err2);
+              res.mode.should.equal(1);
+              X.SetAccessControl(before.mode);
+              done();
+          });
+      });
+  });
+
+  it('SetCloseDownMode should be accepted by server', done => {
+      X.SetCloseDownMode(2); // RetainTemporary
+      X.SetCloseDownMode(0); // back to Destroy
+      X.GetInputFocus(err => {
+          should.not.exist(err);
+          done();
+      });
+  });
+
+  it('RotateProperties should rotate property values', done => {
+      const wid = X.AllocID();
+      X.CreateWindow(wid, root, 0, 0, 1, 1);
+      X.InternAtom(false, 'NODE_X11_ROT_A', (err, atomA) => {
+          should.not.exist(err);
+          X.InternAtom(false, 'NODE_X11_ROT_B', (err2, atomB) => {
+              should.not.exist(err2);
+              X.ChangeProperty(0, wid, atomA, X.atoms.STRING, 8, 'valueA');
+              X.ChangeProperty(0, wid, atomB, X.atoms.STRING, 8, 'valueB');
+              X.RotateProperties(wid, 1, [atomA, atomB]);
+              X.GetProperty(0, wid, atomA, X.atoms.STRING, 0, 100, (err3, prop) => {
+                  should.not.exist(err3);
+                  assert.equal(prop.data.toString(), 'valueB');
+                  X.GetProperty(0, wid, atomB, X.atoms.STRING, 0, 100, (err4, prop2) => {
+                      should.not.exist(err4);
+                      assert.equal(prop2.data.toString(), 'valueA');
+                      X.DestroyWindow(wid);
+                      done();
+                  });
+              });
+          });
+      });
+  });
+});

--- a/test/core-subwindows.js
+++ b/test/core-subwindows.js
@@ -1,0 +1,85 @@
+const x11 = require('../lib');
+const should = require('should');
+const assert = require('assert');
+
+describe('Window subtree requests', () => {
+
+  let display;
+  let X;
+  let parent;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err)
+              return done(err);
+          display = dpy;
+          X = display.client;
+          parent = X.AllocID();
+          X.CreateWindow(parent, display.screen[0].root, 0, 0, 100, 100);
+          X.MapWindow(parent);
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.DestroyWindow(parent);
+      X.terminate();
+      X.on('end', done);
+      X = null;
+      display = null;
+  });
+
+  function createChildren(n) {
+      const wids = [];
+      for (let i = 0; i < n; ++i) {
+          const wid = X.AllocID();
+          X.CreateWindow(wid, parent, 0, 0, 50, 50);
+          wids.push(wid);
+      }
+      return wids;
+  }
+
+  it('MapSubwindows should make children viewable', done => {
+      const children = createChildren(2);
+      X.MapSubwindows(parent);
+      X.GetWindowAttributes(children[1], (err, attrs) => {
+          should.not.exist(err);
+          attrs.mapState.should.equal(2); // Viewable
+          done();
+      });
+  });
+
+  it('UnmapSubwindows should unmap children', done => {
+      const children = createChildren(2);
+      X.MapSubwindows(parent);
+      X.UnmapSubwindows(parent);
+      X.GetWindowAttributes(children[0], (err, attrs) => {
+          should.not.exist(err);
+          attrs.mapState.should.equal(0); // Unmapped
+          done();
+      });
+  });
+
+  it('DestroySubwindows should remove all children', done => {
+      createChildren(3);
+      X.DestroySubwindows(parent);
+      X.QueryTree(parent, (err, tree) => {
+          should.not.exist(err);
+          tree.children.length.should.equal(0);
+          done();
+      });
+  });
+
+  it('CirculateWindow RaiseLowest should raise lowest occluded child', done => {
+      // overlapping children: QueryTree returns bottom-to-top stacking order
+      const children = createChildren(2);
+      X.MapSubwindows(parent);
+      X.CirculateWindow(parent, 0); // RaiseLowest
+      X.QueryTree(parent, (err, tree) => {
+          should.not.exist(err);
+          assert.deepEqual(tree.children, [children[1], children[0]]);
+          done();
+      });
+  });
+});


### PR DESCRIPTION
## Summary

Audited the implementation against the [X11R7.7 core protocol spec](https://xorg.freedesktop.org/releases/X11R7.7/doc/xproto/x11protocol.html) and filled in everything that was missing. The core protocol is now fully covered: **all 120 requests (opcodes 1–127) and all 34 event types**.

### New requests (~55, in `lib/corereqs.js`, existing style)

| Area | Requests |
|---|---|
| Window subtree | DestroySubwindows, MapSubwindows, UnmapSubwindows, CirculateWindow |
| Fonts | OpenFont, CloseFont, QueryFont, QueryTextExtents, ListFontsWithInfo, SetFontPath, GetFontPath |
| GC | CopyGC, SetDashes, SetClipRectangles, FreeGC |
| Drawing | CopyPlane, PolySegment, PolyRectangle, PolyArc, FillPoly, PolyText16, ImageText8, ImageText16 |
| Colormaps | FreeColormap, CopyColormapAndFree, Install/UninstallColormap, ListInstalledColormaps, AllocNamedColor, AllocColorCells, AllocColorPlanes, FreeColors, StoreColors, StoreNamedColor, QueryColors, LookupColor |
| Cursors | CreateGlyphCursor, FreeCursor, RecolorCursor, QueryBestSize |
| Keyboard/pointer | GetMotionEvents, ChangeKeyboardMapping, ChangeKeyboardControl (+ value-mask table), GetKeyboardControl, Change/GetPointerControl, GetScreenSaver, Set/GetPointerMapping, Set/GetModifierMapping |
| Misc | ChangeHosts, ListHosts, SetAccessControl, SetCloseDownMode, RotateProperties, NoOperation |

### New event parsers (10, generated)

KeymapNotify, GraphicsExposure, NoExposure, VisibilityNotify, ReparentNotify, GravityNotify, ResizeRequest, CirculateNotify, CirculateRequest, ColormapNotify — added to `autogen/generate-events.js` wanted list (+ aliases, KeymapNotify special case for its no-sequence-number layout) and regenerated `lib/generated/core-events.js`.

### Core changes

`lib/xcore.js` now supports multi-reply requests (resolves the old TODO): a reply template can mark itself multi-reply; the handler stays registered until the unpacker returns `undefined` for the terminating reply, and accumulated results are delivered as an array. Used by ListFontsWithInfo.

### Bug fixes found by live-server validation

- **`Bell` was broken**: sent opcode 108 (which is GetScreenSaver) in a 5-byte packet with declared length 4 — corrupting request framing — and ignored its `percent` argument. Now opcode 104, 4-byte packet, percent honored.
- **`GetKeyboardMapping` dropped the last keycode row** (off-by-one in the unpack loop); requesting 1 keycode returned `[]`. Existing callers iterate the returned rows, so they simply get the previously-missing last row now.

## Testing

Every new request/event is validated against a live Xvfb in 9 new `test/core-*.js` files (58 new tests, suite grows 44 → 102 passing, lint clean):

- Drawing requests assert exact pixel readback via GetImage (Text16 variants must render pixel-identically to their 8-bit siblings)
- Get/set pairs assert roundtrips and restore original server state
- Colormap store/query runs on a real writable (DirectColor) colormap
- Events are provoked for real (e.g. GraphicsExposure via out-of-bounds CopyArea source, ResizeRequest via a second client connection)