### PR TITLE
Complete extension coverage, GenericEvent support, docs, and protocol bug fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ No build step, no transpilation: `lib/` is what ships.
 - Node-API usage must work on maintained Node versions (see CI matrix in
   `.github/workflows/ci.yml`). Avoid long-deprecated APIs
   (`util.isError`, `new Buffer()`, …).
+- **Keep `docs/` in sync with code.** Any change to a request signature,
+  reply shape, event fields, enum, or extension coverage must update the
+  matching page (`docs/core-requests.md`, `docs/core-events.md`, or
+  `docs/ext/<module>.md`) in the same change. New extension modules get a
+  new `docs/ext/` page (copy the structure of `docs/ext/xinerama.md`) and a
+  row in the table in `docs/README.md`. The docs describe what the code
+  actually does — verify against the implementation and tests, not the X
+  spec.
 
 ## Running tests (do this on every change)
 
@@ -52,6 +60,7 @@ Details the script handles for you:
 | `lib/keysyms.js` | Generated keysym table (see `lib/keysyms.update.sh`) |
 | `lib/xserver.js` | Experimental X server implementation |
 | `autogen/` | Scripts that generate request stubs from XML protocol specs (xcb-proto) |
+| `docs/` | API reference: README + core protocol + one page per extension |
 | `examples/` | Runnable demos (need a real X server / XQuartz) |
 | `test/` | Mocha specs, driven by `test-runner.js` |
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,24 @@
+3.0.0 - unreleased
+  - BREAKING: AllocColor reply fixed — green/blue are no longer swapped and
+    pixel is the real 32-bit pixel value (was previously shifted right by 8)
+  - BREAKING: GetWindowAttributes reply field renamed doNotPropogateMask ->
+    doNotPropagateMask
+  - BREAKING: Randr.ConfigStatus.Sucess renamed to Success
+  - BREAKING: PolyText8/PolyText16 throw Error objects instead of strings
+    for unsupported items
+  - xc-misc GetXIDList returns plain ids (was one-element arrays);
+    GetVersion is the canonical name (QueryVersion kept as alias)
+  - GenericEvent (type 35) framing + dispatch via X.geEventParsers
+  - new extensions: xinerama, sync, record, shm, dbe, res, ge, present, xv,
+    xkb (partial), xinput (partial)
+  - completed extensions: fixes (XFIXES 5), randr (1.3), render, shape,
+    screen-saver, xtest, xc-misc, apple-wm (menu/update requests)
+  - bug fixes: damage Destroy BadLength, render Trapezoids overflow /
+    FillRectangles skipping rects / CreatePicture dropping zero-valued
+    attributes, xtest FakeInput coordinates, randr reply parsers,
+    screen-saver version/enum/event parsing, XFIXES ChangeSaveSet window,
+    apple-wm double callback when extension missing
+  - docs/ folder: core protocol + one page per extension
+
 1.0.3 - 19/02/2015
   - cleanup debug logs               #83

--- a/autogen/generate-replies.js
+++ b/autogen/generate-replies.js
@@ -46,7 +46,7 @@ const REPLY_ALIASES = {
     override_redirect: 'overrideRedirect',
     all_event_masks: 'allEventMasks',
     your_event_mask: 'myEventMasks',
-    do_not_propagate_mask: 'doNotPropogateMask'
+    do_not_propagate_mask: 'doNotPropagateMask'
   },
   QueryPointer: {
     root_x: 'rootX', root_y: 'rootY',

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,173 @@
+# node-x11 documentation
+
+`node-x11` is a pure-JavaScript X Window System protocol client for Node.js.
+There is no native code and no runtime dependency: the library speaks the X11
+wire protocol directly over a unix socket or TCP connection.
+
+- [Core protocol requests](core-requests.md) — all 120 requests of the core protocol
+- [Core protocol events](core-events.md) — all 34 core events
+- [Extensions](#extensions) — one page per protocol extension, listed below
+
+## Connecting
+
+```js
+const x11 = require('x11');
+
+x11.createClient((err, display) => {
+    if (err) throw err;
+    const X = display.client;   // the request interface
+    // ...
+});
+```
+
+`createClient(options, callback)` accepts an optional first argument:
+
+| option | meaning |
+|---|---|
+| `display` | display string, e.g. `':0'`, `'localhost:1.0'` or a literal socket path (default: `$DISPLAY`) |
+| `debug` | log outgoing requests and capture per-request stack traces for errors |
+| `disableBigRequests` | skip the automatic BIG-REQUESTS handshake done at connect time |
+
+The client connects over a unix socket when the display refers to the local
+host (on macOS the display must be a literal socket path, XQuartz launchd
+style, e.g. `/private/tmp/com.apple.launchd.../org.xquartz:0`), and over TCP
+(port 6000 + display number) otherwise. `~/.Xauthority` (or `$XAUTHORITY`) is
+used for authentication automatically.
+
+`createClient` returns the client object immediately; subscribe to `'error'`
+on it to catch connection-phase failures.
+
+### The display object
+
+The `display` passed to the callback describes the connection setup block:
+
+- `display.client` — the `X` client object all requests are called on
+- `display.screen[n]` — one entry per screen, with `root` (root window id),
+  `white_pixel`, `black_pixel`, `pixel_width`/`pixel_height`,
+  `mm_width`/`mm_height`, `default_colormap`, `root_depth`, `depths`, …
+- `display.min_keycode` / `display.max_keycode`
+
+## Making requests
+
+All requests live on `X = display.client` and follow the callback style —
+no promises. Requests with no reply take plain arguments; requests with a
+reply take a trailing `callback(err, result)`:
+
+```js
+const wid = X.AllocID();                       // allocate a resource id
+X.CreateWindow(wid, display.screen[0].root,    // no reply: fire and forget
+               10, 10, 400, 300);
+X.MapWindow(wid);
+
+X.InternAtom(false, 'WM_NAME', (err, atom) => { // with reply
+    // ...
+});
+```
+
+Resource ids (windows, pixmaps, GCs, …) are allocated client-side with
+`X.AllocID()` and can be recycled with `X.ReleaseID(id)` once the resource is
+destroyed. When you are done with the connection, call `X.terminate()`; the
+client emits `'end'` when the stream closes.
+
+See [core-requests.md](core-requests.md) for the complete reference.
+
+## Listening for events
+
+Select the events you want on a window — either at creation time or later —
+using masks from `x11.eventMask`, then listen on the client:
+
+```js
+X.ChangeWindowAttributes(wid, {
+    eventMask: x11.eventMask.Exposure | x11.eventMask.PointerMotion
+});
+X.on('event', ev => {
+    if (ev.name === 'MotionNotify')
+        console.log(ev.rootx, ev.rooty);
+});
+```
+
+Every event object carries `name`, `type`, `seq` and the event-specific
+fields; `ev.rawData` is the raw wire packet (useful with `SendEvent`).
+Extension events are delivered through the same `'event'` emitter once the
+extension has been initialised (its `requireExt` registers the parsers).
+GenericEvents (X Generic Event Extension, used by Present and XInput 2) are
+framed by their length field and dispatched to per-extension parsers
+registered in `X.geEventParsers`.
+
+See [core-events.md](core-events.md) for every core event and its fields.
+
+## Error handling
+
+X errors arrive asynchronously. Errors caused by a request with a reply are
+routed to that request's callback as `err` (an `Error` with `error` code,
+`seq`, `badParam`, `majorOpcode`/`minorOpcode`). Errors from reply-less
+requests — and errors nobody claims — are emitted as `'error'` on the client:
+
+```js
+X.on('error', err => console.error(err.message, err.badParam));
+```
+
+If a reply callback receives an error and returns `true`, the error is
+considered handled and is not re-emitted on the client. With
+`createClient({debug: true}, …)` each error also carries the stack trace of
+the request that caused it.
+
+## Extensions
+
+Extensions are loaded at runtime with `X.require(name, cb)`. The callback
+receives an extension object carrying the extension's requests, enums and
+version info; any events are registered on the client automatically:
+
+```js
+X.require('randr', (err, Randr) => {
+    if (err) throw err;              // extension missing on this server
+    Randr.GetScreenResources(display.screen[0].root, (err, res) => {
+        console.log(res.outputs);
+    });
+});
+```
+
+`name` is the module name below (the file in `lib/ext/`), not the on-the-wire
+extension name. Requiring an extension twice returns the cached instance.
+
+| module | X name | page |
+|---|---|---|
+| `apple-wm` | Apple-WM | [ext/apple-wm.md](ext/apple-wm.md) |
+| `big-requests` | BIG-REQUESTS | [ext/big-requests.md](ext/big-requests.md) |
+| `composite` | Composite | [ext/composite.md](ext/composite.md) |
+| `damage` | DAMAGE | [ext/damage.md](ext/damage.md) |
+| `dbe` | DOUBLE-BUFFER | [ext/dbe.md](ext/dbe.md) |
+| `dpms` | DPMS | [ext/dpms.md](ext/dpms.md) |
+| `fixes` | XFIXES | [ext/fixes.md](ext/fixes.md) |
+| `ge` | Generic Event Extension | [ext/ge.md](ext/ge.md) |
+| `glx` | GLX | [ext/glx.md](ext/glx.md) |
+| `present` | Present | [ext/present.md](ext/present.md) |
+| `randr` | RANDR | [ext/randr.md](ext/randr.md) |
+| `record` | RECORD | [ext/record.md](ext/record.md) |
+| `render` | RENDER | [ext/render.md](ext/render.md) |
+| `res` | X-Resource | [ext/res.md](ext/res.md) |
+| `screen-saver` | MIT-SCREEN-SAVER | [ext/screen-saver.md](ext/screen-saver.md) |
+| `shape` | SHAPE | [ext/shape.md](ext/shape.md) |
+| `shm` | MIT-SHM | [ext/shm.md](ext/shm.md) |
+| `sync` | SYNC | [ext/sync.md](ext/sync.md) |
+| `xc-misc` | XC-MISC | [ext/xc-misc.md](ext/xc-misc.md) |
+| `xinerama` | XINERAMA | [ext/xinerama.md](ext/xinerama.md) |
+| `xinput` | XInputExtension | [ext/xinput.md](ext/xinput.md) |
+| `xkb` | XKEYBOARD | [ext/xkb.md](ext/xkb.md) |
+| `xtest` | XTEST | [ext/xtest.md](ext/xtest.md) |
+| `xv` | XVideo | [ext/xv.md](ext/xv.md) |
+
+## Other exports
+
+- `x11.eventMask` — event mask bit names
+- `x11.keySyms` — keysym tables (lazy-loaded)
+- `x11.gcFunction` — GC raster operation constants (lazy-loaded)
+- `x11.createServer` — experimental X server implementation
+- Window class constants `x11.CopyFromParent` / `x11.InputOutput` /
+  `x11.InputOnly` and `SendEvent` destinations `x11.PointerWindow` /
+  `x11.InputFocus`
+
+## Running against a test server
+
+The test suite runs against a private Xvfb: `npm run test:local` (see
+`scripts/test-local.sh`). Runnable demos live in `examples/`.

--- a/docs/core-events.md
+++ b/docs/core-events.md
@@ -1,0 +1,208 @@
+# Core protocol events
+
+Reference for the 34 core protocol events as parsed by
+[`lib/generated/core-events.js`](../lib/generated/core-events.js) (the
+GenericEvent envelope is handled in [`lib/xcore.js`](../lib/xcore.js)). See
+[README.md](README.md#listening-for-events) for the delivery model and
+[core-requests.md](core-requests.md) for the requests mentioned here.
+Exercised by [`test/core-events-extra.js`](../test/core-events-extra.js) and
+others.
+
+## Selecting events
+
+Most events are only delivered when selected on a window via the `eventMask`
+window attribute — either in `CreateWindow` values or with
+`ChangeWindowAttributes`. Mask bits live on `x11.eventMask` (also
+`X.eventMask`):
+
+`KeyPress`, `KeyRelease`, `ButtonPress`, `ButtonRelease`, `EnterWindow`,
+`LeaveWindow`, `PointerMotion`, `PointerMotionHint`, `Button1Motion` …
+`Button5Motion`, `ButtonMotion`, `KeymapState`, `Exposure`,
+`VisibilityChange`, `StructureNotify`, `ResizeRedirect`,
+`SubstructureNotify`, `SubstructureRedirect`, `FocusChange`,
+`PropertyChange`, `ColormapChange`, `OwnerGrabButton`.
+
+```js
+X.ChangeWindowAttributes(wid, {
+    eventMask: x11.eventMask.Exposure | x11.eventMask.StructureNotify
+});
+X.on('event', ev => {
+    if (ev.name === 'Expose') redraw(ev.wid);
+});
+```
+
+GraphicsExposure/NoExposure are selected per GC (`graphicsExposures`),
+MappingNotify and ClientMessage are delivered unconditionally, and
+SelectionClear/SelectionRequest arrive at selection owners.
+
+Every parsed event carries `type` (numeric event code), `name`, `seq`
+(sequence number of the last request processed before the event; absent on
+KeymapNotify) and the fields listed below. The client additionally attaches
+`rawData`, the raw 32-byte wire packet, which can be passed to `SendEvent`
+unchanged. Field lists below name only the event-specific fields.
+
+## Keyboard and pointer
+
+### KeyPress (2)
+Key went down while selected. Fields: `keycode`, `time`, `root`, `wid`,
+`child`, `rootx`, `rooty`, `x`, `y`, `buttons` (modifier/button state mask),
+`sameScreen`.
+
+### KeyRelease (3)
+Key went up. Same fields as KeyPress.
+
+### ButtonPress (4)
+Pointer button went down. Same fields as KeyPress; `keycode` holds the
+button number.
+
+### ButtonRelease (5)
+Pointer button went up. Same fields as ButtonPress.
+
+### MotionNotify (6)
+Pointer moved. Same fields as KeyPress; `keycode` holds the detail
+(0 Normal, 1 Hint when `PointerMotionHint` is selected).
+
+### EnterNotify (7)
+Pointer entered the window. Fields: `detail` (0 Ancestor, 1 Virtual,
+2 Inferior, 3 Nonlinear, 4 NonlinearVirtual), `time`, `root`, `wid`,
+`child`, `rootx`, `rooty`, `x`, `y`, `buttons`, `mode` (0 Normal, 1 Grab,
+2 Ungrab), `sameScreenFocus` (bit 0 focus, bit 1 same-screen), plus a
+legacy `values` array repeating the numeric fields.
+
+### LeaveNotify (8)
+Pointer left the window. Same fields as EnterNotify.
+
+### FocusIn (9)
+Window gained keyboard focus (`FocusChange` mask). Fields: `detail`, `wid`,
+`mode` (0 Normal, 1 Grab, 2 Ungrab, 3 WhileGrabbed).
+
+### FocusOut (10)
+Window lost keyboard focus. Same fields as FocusIn.
+
+### KeymapNotify (11)
+Reports the full key state; sent right after every EnterNotify/FocusIn when
+`KeymapState` is selected. Special shape: no `seq` field, and `keys` is a
+31-byte Buffer covering keycodes 8–255 (the QueryKeymap bitmap minus its
+first byte) — bit `k & 7` of byte `(k >> 3) - 1` is set for each pressed
+keycode `k`.
+
+## Exposure
+
+### Expose (12)
+A window region needs redrawing (`Exposure` mask). Fields: `wid`, `x`, `y`,
+`width`, `height`, `count` (number of Expose events still to follow for
+this window; 0 on the last one).
+
+### GraphicsExposure (13)
+A `CopyArea`/`CopyPlane` destination region could not be computed from the
+source (GC has `graphicsExposures`). Fields: `drawable`, `x`, `y`, `width`,
+`height`, `minorOpcode`, `count`, `majorOpcode` (62 CopyArea,
+63 CopyPlane). Note the name is `GraphicsExposure` (the protocol spec calls
+it GraphicsExpose).
+
+### NoExposure (14)
+The graphics-exposure-generating request completed without exposures.
+Fields: `drawable`, `minorOpcode`, `majorOpcode`.
+
+### VisibilityNotify (15)
+Window visibility changed (`VisibilityChange` mask). Fields: `wid`, `state`
+(0 Unobscured, 1 PartiallyObscured, 2 FullyObscured).
+
+## Window structure
+
+`StructureNotify` selects these for the window itself (delivered with
+`event` = the window); `SubstructureNotify` selects them on a parent for
+all its children (`event`/`parent` = the parent).
+
+### CreateNotify (16)
+Fields: `parent`, `wid`, `x`, `y`, `width`, `height`, `borderWidth`,
+`overrideRedirect` (boolean).
+
+### DestroyNotify (17)
+Fields: `event`, `wid`.
+
+### UnmapNotify (18)
+Fields: `event`, `wid`, `fromConfigure` (boolean).
+
+### MapNotify (19)
+Fields: `event`, `wid`, `overrideRedirect` (boolean).
+
+### MapRequest (20)
+Another client called MapWindow on a child while `SubstructureRedirect` is
+selected on the parent (window-manager redirect). Fields: `parent`, `wid`.
+
+### ReparentNotify (21)
+Fields: `event`, `wid`, `parent` (new parent), `x`, `y`, `overrideRedirect`
+(boolean).
+
+### ConfigureNotify (22)
+Window geometry/stacking changed. Fields: `wid` (the event window), `wid1`
+(the window that was configured — note the nonstandard name),
+`aboveSibling`, `x`, `y`, `width`, `height`, `borderWidth`,
+`overrideRedirect` (0/1, not boolean here).
+
+### ConfigureRequest (23)
+Redirected ConfigureWindow from another client (`SubstructureRedirect`).
+Fields: `stackMode`, `parent`, `wid`, `sibling`, `x`, `y`, `width`,
+`height`, `borderWidth`, `mask` (which values the client actually asked to
+change).
+
+### GravityNotify (24)
+Child moved because its parent was resized and the child has a win-gravity.
+Fields: `event`, `wid`, `x`, `y`.
+
+### ResizeRequest (25)
+Another client tried to resize the window while `ResizeRedirect` is
+selected. Fields: `wid`, `width`, `height`.
+
+### CirculateNotify (26)
+Result of a CirculateWindow. Fields: `event`, `wid`, `place` (0 Top,
+1 Bottom).
+
+### CirculateRequest (27)
+Redirected CirculateWindow (`SubstructureRedirect`). Same fields as
+CirculateNotify.
+
+## Properties, selections, colormaps
+
+### PropertyNotify (28)
+A property was changed or deleted (`PropertyChange` mask). Fields: `wid`,
+`atom`, `time`, `state` (0 NewValue, 1 Deleted).
+
+### SelectionClear (29)
+This client lost selection ownership. Fields: `time`, `owner`, `selection`.
+
+### SelectionRequest (30)
+Another client called ConvertSelection on a selection this client owns —
+answer by writing the property and sending a SelectionNotify via
+`SendEvent`. Fields: `time`, `owner`, `requestor`, `selection`, `target`,
+`property`.
+
+### SelectionNotify (31)
+Conversion finished (sent by the selection owner; `property` is 0 None on
+failure). Fields: `time`, `requestor`, `selection`, `target`, `property`.
+
+### ColormapNotify (32)
+The window's colormap attribute changed or the colormap was
+(un)installed (`ColormapChange` mask). Fields: `wid`, `colormap`, `new`
+(1 when the attribute changed), `state` (0 Uninstalled, 1 Installed).
+
+## Client communication & mappings
+
+### ClientMessage (33)
+Synthetic event from another client via `SendEvent`; never generated by the
+server. Fields: `format` (8, 16 or 32), `wid`, `message_type` (atom),
+`data` — an array of 20 bytes, 10 shorts or 5 longs depending on `format`.
+
+### MappingNotify (34)
+Keyboard, modifier or pointer mapping changed; sent to all clients. Fields:
+`request` (0 Modifier, 1 Keyboard, 2 Pointer), `firstKeyCode`, `count`
+(the affected keycode range, meaningful for `request` = 1).
+
+### GenericEvent (35)
+Envelope for extension events (X Generic Event extension; used by Present
+and XInput 2). Variable length on the wire — the client frames it by its
+length field and dispatches on the extension's major opcode via parsers in
+`X.geEventParsers` (registered when the extension is required). Without a
+registered parser the event is delivered as `{type: 35, seq, extension,
+evtype, raw}` with `raw` the unparsed payload Buffer.

--- a/docs/core-requests.md
+++ b/docs/core-requests.md
@@ -1,0 +1,584 @@
+# Core protocol requests
+
+Reference for all 120 requests of the X11 core protocol as implemented on the
+client object (`X = display.client`, see [README.md](README.md) for connecting
+and the general calling convention). Requests with a reply take a trailing
+`cb(err, result)`; requests without one state "No reply." — they are fire and
+forget, and any X error they cause is emitted as `'error'` on the client with
+`err.seq` identifying the failing request. Source:
+[`lib/corereqs.js`](../lib/corereqs.js); reply unpackers partly in
+[`lib/generated/core-replies.js`](../lib/generated/core-replies.js). Tests:
+[`test/core-*.js`](../test).
+
+Unless noted otherwise, `wid`/`drawable`/`gc`/... arguments are X resource ids
+(allocate with `X.AllocID()`), `time` arguments default to `0` (CurrentTime),
+and coordinates are signed 16-bit pixels.
+
+At connect time the client automatically performs the BIG-REQUESTS handshake
+(unless `createClient({disableBigRequests: true}, …)`); the negotiated limit
+is available as `display.max_request_length` (in 4-byte units). `PutImage` is
+always encoded as a big request and therefore requires this handshake.
+
+## Windows
+
+### CreateWindow(wid, parent, x, y, width, height, borderWidth, depth, _class, visual, values)
+Opcode 1. No reply. Creates (but does not map) a window. Arguments after
+`height` are optional: `borderWidth`, `depth`, `_class` and `visual` default
+to `0` (CopyFromParent; `_class` may be `x11.CopyFromParent`/`x11.InputOutput`
+/`x11.InputOnly` = 0/1/2), `values` to `{}`. Accepted `values` keys:
+
+| key | type |
+|---|---|
+| `backgroundPixmap`, `backgroundPixel`, `borderPixmap`, `borderPixel` | CARD32 |
+| `bitGravity`, `winGravity` | CARD8 |
+| `backingStore` | CARD8 (0 NotUseful, 1 WhenMapped, 2 Always) |
+| `backingPlanes`, `backingPixel` | CARD32 |
+| `overrideRedirect`, `saveUnder` | BOOL |
+| `eventMask`, `doNotPropagateMask` | CARD32 mask (`x11.eventMask` bits) |
+| `colormap`, `cursor` | XID |
+
+```js
+const wid = X.AllocID();
+X.CreateWindow(wid, display.screen[0].root, 0, 0, 400, 300, 0, 0, 0, 0,
+    { eventMask: x11.eventMask.Exposure | x11.eventMask.KeyPress });
+X.MapWindow(wid);
+```
+
+### ChangeWindowAttributes(wid, values)
+Opcode 2. No reply. `values` accepts the same keys as `CreateWindow` (the
+implementation reuses the CreateWindow value-mask table).
+
+### GetWindowAttributes(wid, cb)
+Opcode 3. `cb(err, attrs)` — `{backingStore, visual, klass, bitGravity,
+winGravity, backingPlanes, backingPixel, saveUnder, mapIsInstalled, mapState,
+overrideRedirect, colormap, allEventMasks, myEventMasks, doNotPropagateMask}`.
+`klass`: 1 InputOutput, 2 InputOnly; `mapState`: 0 Unmapped, 1 Unviewable,
+2 Viewable.
+
+### DestroyWindow(wid)
+Opcode 4. No reply. Destroys the window and all its subwindows.
+
+### DestroySubwindows(wid)
+Opcode 5. No reply. Destroys all children of `wid`, bottom to top.
+
+### ChangeSaveSet(isInsert, wid)
+Opcode 6. No reply. Adds (`isInsert` truthy) or removes (falsy) another
+client's window to/from this client's save-set.
+
+### ReparentWindow(wid, newParentId, x, y)
+Opcode 7. No reply. Re-parents `wid` into `newParentId` at `x`, `y`.
+
+### MapWindow(wid)
+Opcode 8. No reply.
+
+### MapSubwindows(wid)
+Opcode 9. No reply. Maps all children of `wid` in stacking order.
+
+### UnmapWindow(wid)
+Opcode 10. No reply.
+
+### UnmapSubwindows(wid)
+Opcode 11. No reply.
+
+### ConfigureWindow(wid, options)
+Opcode 12. No reply. `options` keys: `x`, `y` (INT16), `width`, `height`,
+`borderWidth` (CARD16), `sibling` (window XID), `stackMode` (0 Above,
+1 Below, 2 TopIf, 3 BottomIf, 4 Opposite). Convenience wrappers (same
+opcode, not counted as separate requests):
+
+- `X.MoveWindow(wid, x, y)`
+- `X.ResizeWindow(wid, width, height)`
+- `X.MoveResizeWindow(wid, x, y, width, height)`
+- `X.RaiseWindow(wid)` / `X.LowerWindow(wid)`
+
+### CirculateWindow(wid, direction)
+Opcode 13. No reply. `direction`: 0 RaiseLowest, 1 LowerHighest. Circulates
+the children of `wid`; generates CirculateNotify.
+
+### GetGeometry(drawable, cb)
+Opcode 14. `cb(err, geom)` — `{depth, windowid, xPos, yPos, width, height,
+borderWidth}`. `windowid` is the root window of the drawable's screen.
+
+### QueryTree(wid, cb)
+Opcode 15. `cb(err, tree)` — `{root, parent, children}` where `children` is
+an array of window ids in bottom-to-top stacking order.
+
+## Properties & atoms
+
+### InternAtom(returnOnlyIfExist, name, cb)
+Opcode 16. `cb(err, atom)` — numeric atom id for the string `name`. Results
+are cached in `X.atoms` / `X.atom_names` (pre-seeded with the standard
+atoms, e.g. `X.atoms.WM_NAME`); a cache hit answers without a server round
+trip.
+
+### GetAtomName(atom, cb)
+Opcode 17. `cb(err, name)` — atom name as a string. Cached like `InternAtom`.
+
+### ChangeProperty(mode, wid, name, type, format, data)
+Opcode 18. No reply. `mode`: 0 Replace, 1 Prepend, 2 Append. `name` and
+`type` are atoms, `format` is 8, 16 or 32 (bits per element). `data` may be
+a Buffer, an array of bytes, or a string (encoded latin1).
+
+```js
+X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, 'hello');
+```
+
+### DeleteProperty(wid, prop)
+Opcode 19. No reply. `prop` is the property atom.
+
+### GetProperty(del, wid, name, type, longOffset, longLength, cb)
+Opcode 20. `cb(err, prop)` — `{type, bytesAfter, data}` with `data` a Buffer
+(sliced to the actual value length). `longOffset`/`longLength` are in 4-byte
+units. A nonexistent property yields `type` 0 and empty `data`. `del` truthy
+deletes the property after reading.
+
+### ListProperties(wid, cb)
+Opcode 21. `cb(err, atoms)` — array of property atoms defined on the window.
+
+### RotateProperties(wid, delta, atoms)
+Opcode 114. No reply. Rotates the values of the listed property atoms by
+`delta` positions.
+
+## Selections
+
+### SetSelectionOwner(owner, selection, time)
+Opcode 22. No reply. `owner` is a window id (0 to release), `selection` an
+atom; `time` optional (0 = CurrentTime).
+
+### GetSelectionOwner(selection, cb)
+Opcode 23. `cb(err, owner)` — owning window id, 0 if none.
+
+### ConvertSelection(requestor, selection, target, property, time)
+Opcode 24. No reply. Asks the selection owner to convert `selection` to
+`target` and store it in `property` on `requestor`; results arrive as a
+SelectionNotify event. `time` optional.
+
+### SendEvent(destination, propagate, eventMask, eventRawData)
+Opcode 25. No reply. Sends a synthetic event. `destination` is a window id
+or `x11.PointerWindow` (0) / `x11.InputFocus` (1); `eventRawData` must be a
+32-byte Buffer in wire format — the `rawData` property of a received event
+works directly.
+
+## Grabs & input control
+
+### GrabPointer(wid, ownerEvents, mask, pointerMode, keybMode, confineTo, cursor, time, cb)
+Opcode 26. `cb(err, status)` — 0 Success, 1 AlreadyGrabbed, 2 InvalidTime,
+3 NotViewable, 4 Frozen. `mask` is a pointer event mask, `pointerMode`/
+`keybMode`: 0 Synchronous, 1 Asynchronous; `confineTo` and `cursor` may be 0.
+
+### UngrabPointer(time)
+Opcode 27. No reply.
+
+### GrabButton(wid, ownerEvents, mask, pointerMode, keybMode, confineTo, cursor, button, modifiers)
+Opcode 28. No reply. Passive grab on `button` (0 = AnyButton) with
+`modifiers` (0x8000 = AnyModifier).
+
+### UngrabButton(wid, button, modifiers)
+Opcode 29. No reply.
+
+### ChangeActivePointerGrab(cursor, time, mask)
+Opcode 30. No reply.
+
+### GrabKeyboard(wid, ownerEvents, time, pointerMode, keybMode, cb)
+Opcode 31. `cb(err, status)` — same status values as `GrabPointer`.
+
+### UngrabKeyboard(time)
+Opcode 32. No reply.
+
+### GrabKey(wid, ownerEvents, modifiers, key, pointerMode, keybMode)
+Opcode 33. No reply. Passive grab on keycode `key` (0 = AnyKey).
+
+### UngrabKey(wid, key, modifiers)
+Opcode 34. No reply.
+
+### AllowEvents(mode, time)
+Opcode 35. No reply. Releases events frozen by a synchronous grab. `mode`:
+0 AsyncPointer, 1 SyncPointer, 2 ReplayPointer, 3 AsyncKeyboard,
+4 SyncKeyboard, 5 ReplayKeyboard, 6 AsyncBoth, 7 SyncBoth.
+
+### GrabServer()
+Opcode 36. No reply. Disables processing of requests from other clients.
+
+### UngrabServer()
+Opcode 37. No reply.
+
+### SetInputFocus(wid, revertTo)
+Opcode 42. No reply. `revertTo`: 0 None, 1 PointerRoot, 2 Parent. The
+protocol's time field is not exposed — the request is always sent with
+CurrentTime.
+
+### GetInputFocus(cb)
+Opcode 43. `cb(err, focus)` — `{revertTo, focus}` where `focus` is the focus
+window id (or 0 None / 1 PointerRoot). Commonly used as a cheap round-trip
+barrier after reply-less requests.
+
+## Pointer & keyboard queries
+
+### QueryPointer(wid, cb)
+Opcode 38. `cb(err, ptr)` — `{sameScreen, root, child, rootX, rootY, childX,
+childY, keyMask}`. `keyMask` holds the button/modifier state bits.
+
+### GetMotionEvents(wid, start, stop, cb)
+Opcode 39. `cb(err, events)` — array of `{time, x, y}` from the server's
+motion history between timestamps `start` and `stop` (0 = CurrentTime).
+
+### TranslateCoordinates(srcWid, dstWid, srcX, srcY, cb)
+Opcode 40. `cb(err, res)` — `{sameScreen, child, destX, destY}`.
+
+### WarpPointer(srcWin, dstWin, srcX, srcY, srcWidth, srcHeight, dstX, dstY)
+Opcode 41. No reply. Moves the pointer to `dstX`, `dstY` relative to
+`dstWin` (or relative movement when `dstWin` is 0), subject to the source
+rectangle check.
+
+### QueryKeymap(cb)
+Opcode 44. `cb(err, keys)` — 32-byte Buffer; bit `keycode & 7` of byte
+`keycode >> 3` is set for each currently pressed key.
+
+### ChangeKeyboardMapping(firstKeycode, keysymsPerKeycode, keysyms)
+Opcode 100. No reply. `keysyms` is a flat array of
+`keycodeCount * keysymsPerKeycode` keysyms; the keycode count is derived
+from its length.
+
+### GetKeyboardMapping(startCode, num, cb)
+Opcode 101. `cb(err, rows)` — one array of keysyms (CARD32) per keycode,
+`num` rows starting at keycode `startCode`.
+
+### ChangeKeyboardControl(values)
+Opcode 102. No reply. `values` keys: `keyClickPercent`, `bellPercent`
+(INT8), `bellPitch`, `bellDuration` (INT16), `led`, `ledMode`, `key`,
+`autoRepeatMode` (CARD8; autoRepeatMode 0 Off, 1 On, 2 Default).
+
+### GetKeyboardControl(cb)
+Opcode 103. `cb(err, control)` — `{globalAutoRepeat, ledMask,
+keyClickPercent, bellPercent, bellPitch, bellDuration, autoRepeats}`;
+`autoRepeats` is a 32-byte Buffer bitmap by keycode.
+
+### Bell(percent)
+Opcode 104. No reply. `percent` −100..100 relative to the base bell volume;
+optional (defaults to 0).
+
+### ChangePointerControl(accelNumerator, accelDenominator, threshold, doAcceleration, doThreshold)
+Opcode 105. No reply. The two booleans select which of
+acceleration/threshold to change.
+
+### GetPointerControl(cb)
+Opcode 106. `cb(err, control)` — `{accelNumerator, accelDenominator,
+threshold}`.
+
+### SetPointerMapping(map, cb)
+Opcode 116. `cb(err, status)` — 0 Success, 1 Busy (a mapped button is
+pressed). `map` is an array of button numbers, as returned by
+`GetPointerMapping`.
+
+### GetPointerMapping(cb)
+Opcode 117. `cb(err, map)` — array of button numbers, one per physical
+button.
+
+### SetModifierMapping(rows, cb)
+Opcode 118. `cb(err, status)` — 0 Success, 1 Busy, 2 Failed. `rows` is an
+array of 8 keycode arrays (Shift, Lock, Control, Mod1–Mod5); shorter rows
+are zero-padded to the longest.
+
+### GetModifierMapping(cb)
+Opcode 119. `cb(err, rows)` — 8 arrays of `keycodesPerModifier` keycodes
+(0 entries mean unused slots).
+
+## Drawing & GCs
+
+### CreateGC(cid, drawable, values)
+Opcode 55. No reply. Creates a graphics context. Accepted `values` keys
+(also used by `ChangeGC` and as `CopyGC` component names):
+
+| key | type |
+|---|---|
+| `function` | CARD8 raster op (constants in `x11.gcFunction`) |
+| `planeMask`, `foreground`, `background` | CARD32 |
+| `lineWidth` | CARD16 |
+| `lineStyle`, `capStyle`, `joinStyle`, `fillStyle`, `fillRule` | CARD8 |
+| `tile`, `stipple` | pixmap XID |
+| `tileStippleXOrigin`, `tileStippleYOrigin` | INT16 |
+| `font` | font XID |
+| `subwindowMode`, `graphicsExposures` | CARD8 |
+| `clipXOrigin`, `clipYOrigin` | INT16 |
+| `clipMask` | pixmap XID |
+| `dashOffset` | CARD16 |
+| `dashes`, `arcMode` | CARD8 |
+
+### ChangeGC(cid, values)
+Opcode 56. No reply. Same `values` keys as `CreateGC`.
+
+### CopyGC(srcGc, dstGc, components)
+Opcode 57. No reply. `components` is either a CARD32 bitmask or an array of
+`CreateGC` value names, e.g. `X.CopyGC(a, b, ['foreground', 'font'])`.
+
+### SetDashes(gc, dashOffset, dashes)
+Opcode 58. No reply. `dashes` is an array of dash lengths in pixels.
+
+### SetClipRectangles(gc, ordering, clipXOrigin, clipYOrigin, rects)
+Opcode 59. No reply. `ordering`: 0 UnSorted, 1 YSorted, 2 YXSorted,
+3 YXBanded. `rects` is a flat array `[x, y, width, height, ...]`.
+
+### FreeGC(gc)
+Opcode 60. No reply.
+
+### ClearArea(wid, x, y, width, height, exposures)
+Opcode 61. No reply. Clears to the window background; `exposures` truthy
+generates Expose events for the cleared area.
+
+### CopyArea(srcDrawable, dstDrawable, gc, srcX, srcY, dstX, dstY, width, height)
+Opcode 62. No reply. Obscured/out-of-bounds source regions produce
+GraphicsExposure (or NoExposure) events when `graphicsExposures` is set on
+the GC.
+
+### CopyPlane(srcDrawable, dstDrawable, gc, srcX, srcY, dstX, dstY, width, height, bitPlane)
+Opcode 63. No reply. `bitPlane` must have exactly one bit set; source pixels
+are mapped through it to the GC foreground/background.
+
+### PolyPoint(coordMode, drawable, gc, points)
+Opcode 64. No reply. `coordMode`: 0 Origin, 1 Previous. `points` is a flat
+array `[x, y, ...]`. Note that `coordMode` comes first, unlike the
+`PolySegment`-style requests below.
+
+### PolyLine(coordMode, drawable, gc, points)
+Opcode 65. No reply. Same argument convention as `PolyPoint`.
+
+### PolySegment(drawable, gc, segments)
+Opcode 66. No reply. `segments` is a flat array `[x1, y1, x2, y2, ...]`,
+four values per segment.
+
+### PolyRectangle(drawable, gc, rects)
+Opcode 67. No reply. Outlines only; `rects` flat `[x, y, width, height, ...]`.
+
+### PolyArc(drawable, gc, arcs)
+Opcode 68. No reply. `arcs` flat `[x, y, width, height, angle1, angle2, ...]`,
+six values per arc, angles in 1/64 degree.
+
+### FillPoly(drawable, gc, shape, coordMode, points)
+Opcode 69. No reply. `shape`: 0 Complex, 1 Nonconvex, 2 Convex; `coordMode`:
+0 Origin, 1 Previous; `points` flat `[x, y, ...]`.
+
+### PolyFillRectangle(drawable, gc, rects)
+Opcode 70. No reply. Filled rectangles, flat `[x, y, width, height, ...]`.
+
+### PolyFillArc(drawable, gc, arcs)
+Opcode 71. No reply. Filled arcs, same layout as `PolyArc`.
+
+## Pixmaps & images
+
+### CreatePixmap(pid, drawable, depth, width, height)
+Opcode 53. No reply. `drawable` only selects the screen.
+
+### FreePixmap(pixmap)
+Opcode 54. No reply.
+
+### PutImage(format, drawable, gc, width, height, dstX, dstY, leftPad, depth, data)
+Opcode 72. No reply. `format`: 0 Bitmap, 1 XYPixmap, 2 ZPixmap; `data` is a
+Buffer in wire scanline layout. Always encoded as a BIG-REQUESTS packet, so
+it only works after the automatic BigReq handshake (i.e. not with
+`disableBigRequests`).
+
+### GetImage(format, drawable, x, y, width, height, planeMask, cb)
+Opcode 73. `cb(err, image)` — `{depth, visualId, data}` with `data` the raw
+pixel Buffer. `visualId` is 0 for pixmaps.
+
+## Colormaps & colors
+
+Color values are 16-bit per channel (0–0xffff). RGB triples for cursors are
+objects `{R, G, B}`; colormap requests take separate `red`, `green`, `blue`
+arguments.
+
+### CreateColormap(cmid, wid, vid, alloc)
+Opcode 78. No reply. `wid` only selects the screen; `vid` is a visual id
+supported by it. `alloc`: 0 None, 1 All.
+
+### FreeColormap(cmap)
+Opcode 79. No reply.
+
+### CopyColormapAndFree(newCmid, srcCmap)
+Opcode 80. No reply. Moves this client's allocations from `srcCmap` into a
+new colormap `newCmid` and frees them in the source.
+
+### InstallColormap(cmap)
+Opcode 81. No reply.
+
+### UninstallColormap(cmap)
+Opcode 82. No reply.
+
+### ListInstalledColormaps(wid, cb)
+Opcode 83. `cb(err, cmaps)` — array of installed colormap ids for the screen
+of `wid`.
+
+### AllocColor(cmap, red, green, blue, cb)
+Opcode 84. Allocates the closest color the colormap supports.
+`cb(err, color)` — `{red, green, blue, pixel}` where `red`/`green`/`blue`
+are the values actually allocated and `pixel` can be used directly in GC
+values or `QueryColors`.
+
+### AllocNamedColor(cmap, name, cb)
+Opcode 85. `cb(err, color)` — `{pixel, exactRed, exactGreen, exactBlue,
+visualRed, visualGreen, visualBlue}`.
+
+### AllocColorCells(contiguous, cmap, colors, planes, cb)
+Opcode 86. `cb(err, cells)` — `{pixels, masks}`, arrays of CARD32. Requires
+a writable-class colormap (GrayScale/PseudoColor/DirectColor).
+
+### AllocColorPlanes(contiguous, cmap, colors, reds, greens, blues, cb)
+Opcode 87. `cb(err, res)` — `{redMask, greenMask, blueMask, pixels}`.
+
+### FreeColors(cmap, planeMask, pixels)
+Opcode 88. No reply. `pixels` is an array of pixel values.
+
+### StoreColors(cmap, items)
+Opcode 89. No reply. `items` is an array of `{pixel, red, green, blue,
+doMask}`; omitted channels default to 0 and `doMask` (1 red | 2 green |
+4 blue) defaults to 7 (all).
+
+### StoreNamedColor(cmap, pixel, name, doMask)
+Opcode 90. No reply. `doMask` optional, defaults to 7.
+
+### QueryColors(cmap, pixels, cb)
+Opcode 91. `cb(err, colors)` — array of `{red, green, blue}` in the order of
+`pixels`.
+
+### LookupColor(cmap, name, cb)
+Opcode 92. `cb(err, color)` — `{exactRed, exactGreen, exactBlue, visualRed,
+visualGreen, visualBlue}`.
+
+## Fonts & text
+
+Text-drawing requests are grouped here with the font requests; the 16-bit
+variants encode JS strings as big-endian CHAR2B via `charCodeAt`, so plain
+BMP unicode strings work when the font has the glyphs.
+
+### OpenFont(fid, name)
+Opcode 45. No reply. `name` is a core font name/alias, e.g. `'fixed'` or an
+XLFD pattern.
+
+### CloseFont(fid)
+Opcode 46. No reply.
+
+### QueryFont(fontable, cb)
+Opcode 47. `cb(err, font)` — `{minBounds, maxBounds, minCharOrByte2,
+maxCharOrByte2, defaultChar, drawDirection, minByte1, maxByte1,
+allCharsExist, fontAscent, fontDescent, properties, charInfos}`.
+`minBounds`/`maxBounds` and each `charInfos` entry are CHARINFO objects
+`{leftSideBearing, rightSideBearing, characterWidth, ascent, descent,
+attributes}`; `properties` is an array of `{name, value}` (name is an atom).
+
+### QueryTextExtents(fontable, str, cb)
+Opcode 48. `cb(err, extents)` — `{drawDirection, fontAscent, fontDescent,
+overallAscent, overallDescent, overallWidth, overallLeft, overallRight}`.
+`str` is sent as STRING16.
+
+### ListFonts(pattern, max, cb)
+Opcode 49. `cb(err, names)` — array of up to `max` font name strings
+matching `pattern` (`*`/`?` wildcards).
+
+### ListFontsWithInfo(pattern, max, cb)
+Opcode 50. `cb(err, fonts)` — array of font-info objects: the `QueryFont`
+header fields (no `charInfos`) plus `name` and `repliesHint`. On the wire
+this is the core protocol's only multi-reply request — the server sends one
+reply per font plus a terminator; the library collects the series and
+invokes `cb` exactly once with the complete array.
+
+### SetFontPath(paths)
+Opcode 51. No reply. `paths` is an array of directory strings; the order
+defines search priority.
+
+### GetFontPath(cb)
+Opcode 52. `cb(err, paths)` — array of directory strings.
+
+### PolyText8(drawable, gc, x, y, items)
+Opcode 74. No reply. `items` is an array of strings (each at most 254
+chars); each string becomes one text item with delta 0. Font-shift items
+and longer strings are not implemented (throws `Error('not supported yet')`).
+
+### PolyText16(drawable, gc, x, y, items)
+Opcode 75. No reply. STRING16 variant of `PolyText8`, same restrictions.
+
+### ImageText8(drawable, gc, x, y, text)
+Opcode 76. No reply. Draws `text` (latin1, max 255 chars) filling the
+bounding box with the GC background first.
+
+### ImageText16(drawable, gc, x, y, text)
+Opcode 77. No reply. STRING16 variant of `ImageText8`.
+
+## Cursors
+
+`foreRGB`/`backRGB` are `{R, G, B}` objects with 16-bit channels.
+
+### CreateCursor(cid, source, mask, foreRGB, backRGB, x, y)
+Opcode 93. No reply. `source`/`mask` are depth-1 pixmaps; `x`, `y` is the
+hotspot.
+
+### CreateGlyphCursor(cid, sourceFont, maskFont, sourceChar, maskChar, foreRGB, backRGB)
+Opcode 94. No reply. Builds a cursor from font glyphs — typically the
+standard `'cursor'` font, where glyph N is the shape and N+1 its mask.
+
+```js
+const fid = X.AllocID();
+X.OpenFont(fid, 'cursor');
+const cid = X.AllocID();
+X.CreateGlyphCursor(cid, fid, fid, 68, 69,   // XC_left_ptr + mask
+    { R: 0, G: 0, B: 0 }, { R: 0xffff, G: 0xffff, B: 0xffff });
+X.CloseFont(fid);
+```
+
+### FreeCursor(cursor)
+Opcode 95. No reply.
+
+### RecolorCursor(cursor, foreRGB, backRGB)
+Opcode 96. No reply.
+
+### QueryBestSize(_class, drawable, width, height, cb)
+Opcode 97. `cb(err, size)` — `{width, height}`, the best supported size for
+`_class`: 0 Cursor, 1 Tile, 2 Stipple.
+
+## Screen saver & host access
+
+### SetScreenSaver(timeout, interval, preferBlanking, allowExposures)
+Opcode 107. No reply. `timeout`/`interval` in seconds (−1 restores the
+default, 0 disables); `preferBlanking`/`allowExposures`: 0 No, 1 Yes,
+2 Default.
+
+### GetScreenSaver(cb)
+Opcode 108. `cb(err, saver)` — `{timeout, interval, preferBlanking,
+allowExposures}`.
+
+### ChangeHosts(mode, family, address)
+Opcode 109. No reply. `mode`: 0 Insert, 1 Delete; `family`: 0 Internet,
+1 DECnet, 2 Chaos, 5 ServerInterpreted, 6 InternetV6; `address` a Buffer or
+byte array (e.g. `[127, 0, 0, 2]`).
+
+### ListHosts(cb)
+Opcode 110. `cb(err, res)` — `{mode, hosts}` where `mode` is 1 when access
+control is enabled and `hosts` is an array of `{family, address}` with
+`address` a Buffer.
+
+### SetAccessControl(mode)
+Opcode 111. No reply. `mode`: 0 Disable, 1 Enable.
+
+### SetCloseDownMode(mode)
+Opcode 112. No reply. `mode`: 0 Destroy, 1 RetainPermanent,
+2 RetainTemporary.
+
+### KillClient(resource)
+Opcode 113. No reply. Terminates the client owning `resource` (or closes
+down retained resources for `resource` = 0 AllTemporary). Also available
+under the historical alias `X.KillKlient`.
+
+### ForceScreenSaver(activate)
+Opcode 115. No reply. Truthy activates the screen saver, falsy resets it.
+
+## Extensions & misc
+
+### QueryExtension(name, cb)
+Opcode 98. `cb(err, ext)` — `{present, majorOpcode, firstEvent,
+firstError}`. Normally not called directly: `X.require(module, cb)` performs
+it (and the extension setup) for you, see [README.md](README.md#extensions).
+
+### ListExtensions(cb)
+Opcode 99. `cb(err, names)` — array of extension name strings.
+
+### NoOperation()
+Opcode 127. No reply. Does nothing; useful as padding or a keep-alive.

--- a/docs/ext/apple-wm.md
+++ b/docs/ext/apple-wm.md
@@ -1,0 +1,146 @@
+# Apple-WM extension
+
+XQuartz-specific extension letting an X11 window manager cooperate with the
+macOS native environment: draw Aqua-style window frames, control window
+levels relative to native apps, and receive notifications from the
+X11.app controller (menu commands, app activation, pasteboard). Only
+available on the XQuartz server on macOS.
+
+- Module: `X.require('apple-wm', cb)` (X name `Apple-WM`)
+- Source: [`lib/ext/apple-wm.js`](../../lib/ext/apple-wm.js)
+- Spec: [AppleWM.3 man page](http://www.xfree86.org/current/AppleWM.3.html),
+  [applewm.c (XQuartz server)](https://opensource.apple.com/source/X11server/X11server-106.3/Xquartz/xorg-server-1.10.2/hw/xquartz/applewm.c)
+
+```js
+X.require('apple-wm', (err, AppleWM) => {
+    AppleWM.QueryVersion((err, [major, minor, patch]) => {});
+    AppleWM.SelectInput(AppleWM.NotifyMask.All);
+    AppleWM.SetWindowLevel(win, AppleWM.WindowLevel.Floating);
+    X.on('event', ev => {
+        if (ev.name === 'AppleWMControllerNotify' &&
+            ev.type === AppleWM.EventKind.Controller.CloseWindow) {
+            // user picked Close from the native menu
+        }
+    });
+});
+```
+
+No version negotiation happens during `require`; call `QueryVersion`
+yourself if needed.
+
+Frame requests take two rectangles describing the window: the inner
+(client) rect `ix, iy, iw, ih` and the outer (frame) rect
+`ox, oy, ow, oh`, all as unsigned 16-bit values.
+
+## Requests
+
+Listed in minor opcode order.
+
+### QueryVersion(cb)
+Minor opcode 0. `cb(err, [major, minor, patch])` — extension version.
+
+### FrameGetRect(frameClass, frameRect, ix, iy, iw, ih, ox, oy, ow, oh, cb)
+Minor opcode 1. Computes the geometry of a frame part for a window with the
+given inner/outer rects. `frameClass` is a `FrameClass` value, `frameRect`
+a `FrameRect` value (Titlebar/Tracking/Growbox).
+`cb(err, {x, y, w, h})` — the requested part's rectangle.
+
+### FrameHitTest(frameClass, px, py, ix, iy, iw, ih, ox, oy, ow, oh, cb)
+Minor opcode 2. Hit-tests point `px, py` against the frame of a window with
+the given rects. `cb(err, hit)` — numeric hit-test result (0 when no frame
+part is hit).
+
+### FrameDraw(screen, window, frameClass, attr, ix, iy, iw, ih, ox, oy, ow, oh, title)
+Minor opcode 3. Draws a native-styled frame for `window` on `screen`.
+`frameClass` is a `FrameClass` value, `attr` a bitmask of `FrameAttr`
+flags, `title` the titlebar string. No reply.
+
+### DisableUpdate(screen)
+Minor opcode 4. Temporarily suppresses compositing updates for `screen`
+(default 0) while a batch of drawing happens. Pair with `ReenableUpdate`.
+No reply.
+
+### ReenableUpdate(screen)
+Minor opcode 5. Re-enables updates suppressed by `DisableUpdate`. No reply.
+
+### SelectInput(mask)
+Minor opcode 6. Selects which Apple-WM notification events this client
+receives; `mask` is a bitmask of `NotifyMask` values. No reply.
+
+### SetWindowMenuCheck(index)
+Minor opcode 7. Places the checkmark on item `index` (0-based) of the
+X11.app Window menu previously set with `SetWindowMenu`. No reply.
+
+### SetFrontProcess()
+Minor opcode 8. Asks macOS to bring the X server (XQuartz) to the front,
+above native applications. No arguments, no reply.
+
+### SetWindowLevel(window, level)
+Minor opcode 9. Places `window` in one of the native window layers;
+`level` is a `WindowLevel` value. No reply.
+
+### CanQuit(state)
+Minor opcode 10. Tells the server whether it may quit (non-zero `state` =
+the window manager consents; the server asks via the controller events
+before quitting). No reply.
+
+### SetWindowMenu(items)
+Minor opcode 11. Replaces the window-manager section of the X11.app Window
+menu. `items` is an array where each element is either a plain string label
+or a `[shortcut, label]` pair (`shortcut` a single ASCII character used as
+the Cmd-key equivalent). No reply.
+
+### SendPSN(hi, lo)
+Minor opcode 12. Sends the window manager's macOS Process Serial Number
+(64 bits as two 32-bit halves) to the server. No reply.
+
+### AttachTransient(child, parent)
+Minor opcode 13. Marks window `child` as a transient attached to `parent`
+(sheet-like native behavior). Pass `parent = 0` to detach. No reply.
+
+## Events
+
+Enable delivery with `SelectInput`. All three events share one parsed
+shape: `{name, type, time, arg}` where `name` is the event name below,
+`type` is the kind code (see `EventKind`), `time` is the server timestamp
+and `arg` is a kind-specific 32-bit argument (e.g. the window id for
+per-window controller actions).
+
+### AppleWMControllerNotify
+First event + 0, selected by `NotifyMask.Controller`. Sent when the user
+drives X11 windows from the native side. `type` is one of
+`EventKind.Controller`: `MinimizeWindow` 0, `ZoomWindow` 1, `CloseWindow`
+2, `BringAllToFront` 3, `WideWindow` 4, `HideAll` 5, `ShowAll` 6,
+`WindowMenuItem` 9, `WindowMenuNotify` 10, `NextWindow` 11,
+`PreviousWindow` 12.
+
+### AppleWMActivationNotify
+First event + 1, selected by `NotifyMask.Activation`. X11.app gained or
+lost the native foreground. `type` is one of `EventKind.Activation`:
+`IsActive` 0, `IsInactive` 1, `ReloadPreferences` 2.
+
+### AppleWMPasteboardNotify
+First event + 2, selected by `NotifyMask.Pasteboard`. `type` is
+`EventKind.Pasteboard.CopyToPasteboard` (0) — the server wants the current
+selection copied to the macOS pasteboard.
+
+## Notes
+
+Enums attached to the extension object:
+
+- `AppleWM.FrameRect = {Titlebar: 1, Tracking: 2, Growbox: 3}`
+- `AppleWM.FrameClass = {DecorLarge: 1, DecorSmall: 16, Managed: 1<<15,
+  Transient: 1<<16, Stationary: 1<<17}` (plus Reserved* placeholder bits)
+- `AppleWM.FrameAttr = {Active: 1, Urgent: 2, Title: 4, Prelight: 8,
+  Shaded: 16, CloseBox: 0x100, Collapse: 0x200, Zoom: 0x400,
+  CloseBoxClicked: 0x800, CollapseBoxClicked: 0x1000,
+  ZoomBoxClicked: 0x2000, GrowBox: 0x4000}`
+- `AppleWM.NotifyMask = {Controller: 1, Activation: 2, Pasteboard: 4,
+  All: 7}`
+- `AppleWM.WindowLevel = {Normal: 0, Floating: 1, TornOff: 2, Dock: 3,
+  Desktop: 4}`
+- `AppleWM.EventKind = {Controller: {...}, Activation: {...},
+  Pasteboard: {...}}` (values listed under Events above)
+
+Requires XQuartz; on any other server `X.require('apple-wm', cb)` calls
+back with an "extension not available" error.

--- a/docs/ext/big-requests.md
+++ b/docs/ext/big-requests.md
@@ -1,0 +1,50 @@
+# BIG-REQUESTS extension
+
+Raises the maximum request length from the core limit of 262140 bytes
+(65535 4-byte units) to a server-advertised value in the megabytes, using an
+extended length encoding. Needed for large image transfers and glyph
+uploads.
+
+- Module: `X.require('big-requests', cb)` (X name `BIG-REQUESTS`, version 2.0)
+- Source: [`lib/ext/big-requests.js`](../../lib/ext/big-requests.js) ·
+  Tests: no dedicated file — enabled implicitly at connect by every test
+- Spec: [bigreq.html](http://www.x.org/releases/X11R7.6/doc/bigreqsproto/bigreq.html)
+
+You normally never require this module yourself: `x11.createClient` enables
+it automatically as part of connecting, unless you opt out:
+
+```js
+x11.createClient({ disableBigRequests: true }, (err, display) => {
+    // display.max_request_length stays at the handshake value (65535)
+});
+
+x11.createClient((err, display) => {
+    // BigReq enabled; typically 4194303 units (16 MiB) on Xorg/Xvfb
+    console.log(display.max_request_length);
+});
+```
+
+## Requests
+
+### Enable(cb)
+Switches this connection to the extended length encoding.
+`cb(err, maxRequestLength)` — the new maximum request length in 4-byte
+units. Called automatically at connect; `createClient` stores the result as
+`display.max_request_length` (replacing the core handshake value) before
+invoking your callback.
+
+## Events / errors
+
+None.
+
+## Notes
+
+- After `Enable`, requests may use the extended encoding: a core length
+  field of 0 followed by a 32-bit length. Requests up to the core limit keep
+  the classic encoding; only oversized ones need the extended form.
+- Render's `AddGlyphs`/`AddGlyphsFromPicture`
+  ([ext/render.md](render.md)) always emit the extended encoding, so they
+  only work while BigReq is enabled (the default).
+- With `disableBigRequests` the extension is not required at all — no
+  `Enable` request is sent and the connection keeps the core 262140-byte
+  limit.

--- a/docs/ext/composite.md
+++ b/docs/ext/composite.md
@@ -1,0 +1,89 @@
+# Composite extension
+
+Lets a client (typically a compositing window manager) redirect the rendering
+of windows into off-screen storage, name that storage as a pixmap, and access
+a special overlay window stacked above everything else. Usually used together
+with DAMAGE ([ext/damage.md](damage.md)) to learn when the off-screen
+contents change, and XFIXES ([ext/fixes.md](fixes.md)) for region arithmetic.
+
+- Module: `X.require('composite', cb)` (X name `Composite`, version 0.4)
+- Source: [`lib/ext/composite.js`](../../lib/ext/composite.js) ·
+  Example: [`examples/smoketest/compositetest.js`](../../examples/smoketest/compositetest.js)
+- Spec: [compositeproto.txt](http://cgit.freedesktop.org/xorg/proto/compositeproto/plain/compositeproto.txt)
+
+```js
+X.require('composite', (err, Composite) => {
+    X.require('damage', (err, Damage) => {
+        Composite.RedirectWindow(wid, Composite.Redirect.Automatic);
+        const pixmap = X.AllocID();
+        Composite.NameWindowPixmap(wid, pixmap);
+        // pixmap now refers to the off-screen storage of wid;
+        // use Damage.Create(damage, wid, ...) to hear about updates
+    });
+});
+```
+
+The version is negotiated automatically while requiring (the module asks for
+0.4); it is available as `Composite.major` / `Composite.minor`.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])` — the version the
+server will speak. Called automatically by `X.require` with 0.4.
+
+### RedirectWindow(window, updateType)
+Redirects the hierarchy rooted at `window` to off-screen storage.
+`updateType` is one of `Composite.Redirect` (`Automatic: 0` — the server
+keeps the screen updated itself, `Manual: 1` — the client paints).
+No reply.
+
+### RedirectSubwindows(window, updateType)
+Like `RedirectWindow`, but redirects all current and future children of
+`window` instead of the window itself. Compositing managers typically call
+this on the root window. No reply.
+
+### UnredirectWindow(window)
+Terminates redirection of `window` started by this client with
+`RedirectWindow`. No reply.
+
+### UnredirectSubwindows(window)
+Terminates redirection of the children of `window` started by this client
+with `RedirectSubwindows`. No reply.
+
+### CreateRegionFromBorderClip(region, window)
+Initializes `region` (a client-allocated XFIXES region XID) with the border
+clip of `window`, i.e. the part of the window not obscured by siblings or
+ancestors. Operate on it with the XFIXES region requests
+([ext/fixes.md](fixes.md)). No reply.
+
+### NameWindowPixmap(window, pixmap)
+Binds `pixmap` (a client-allocated XID) to the off-screen storage of the
+redirected `window`. The pixmap keeps referring to that snapshot of storage
+even after the window is resized (the server allocates new storage and the
+name must be re-fetched). Use it like a regular pixmap, e.g. as a `CopyArea`
+source. No reply.
+
+### GetOverlayWindow(window, cb)
+`cb(err, overlayWid)` — the XID of the composite overlay window of the screen
+`window` is on. The overlay window is mapped above all other windows and is
+untouched by the server; compositing output is drawn there. The server
+reference-counts overlay users per client.
+
+### ReleaseOverlayWindow(window)
+Drops this client's reference to the overlay window of the screen `window` is
+on; the overlay is unmapped when no clients use it. No reply.
+
+## Events / errors
+
+None.
+
+## Notes
+
+- `Composite.Redirect = {Automatic: 0, Manual: 1}`.
+- The module negotiates version 0.4; the coordinate-origin translation
+  requests of later protocol revisions are not implemented (a source comment
+  marks the version for bumping once they are).
+- Redirection is reference-counted by the server per window and per client;
+  a second `Manual` redirect of the same window by another client fails with
+  `BadAccess`.

--- a/docs/ext/damage.md
+++ b/docs/ext/damage.md
@@ -1,0 +1,95 @@
+# DAMAGE extension
+
+Reports changes ("damage") to drawables. A client creates a damage object
+monitoring a drawable and receives `DamageNotify` events whenever the
+drawable's contents change — the building block of compositing managers and
+screen-sharing tools, usually together with Composite
+([ext/composite.md](composite.md)) and XFIXES regions
+([ext/fixes.md](fixes.md)).
+
+- Module: `X.require('damage', cb)` (X name `DAMAGE`, version 1.1)
+- Source: [`lib/ext/damage.js`](../../lib/ext/damage.js) ·
+  Example: [`examples/smoketest/damagetest.js`](../../examples/smoketest/damagetest.js)
+- Spec: [damageproto.txt](http://www.x.org/releases/X11R7.6/doc/damageproto/damageproto.txt)
+
+```js
+X.require('damage', (err, Damage) => {
+    const damage = X.AllocID();
+    Damage.Create(damage, wid, Damage.ReportLevel.NonEmpty);
+    X.on('event', ev => {
+        if (ev.name === 'DamageNotify') {
+            Damage.Subtract(damage, 0, 0); // acknowledge, rearm reporting
+            // repaint from ev.drawable here
+        }
+    });
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`Damage.major` / `Damage.minor`.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])` — the version the
+server will speak. Called automatically by `X.require` with 1.1.
+
+### Create(damage, drawable, reportLevel)
+Creates damage object `damage` (a client-allocated XID) monitoring
+`drawable`. `reportLevel` is one of `Damage.ReportLevel` and controls how
+`DamageNotify` events are batched:
+
+| Level | Value | Meaning |
+| --- | --- | --- |
+| `RawRectangles` | 0 | an event per changed rectangle |
+| `DeltaRectangles` | 1 | events only for areas not already damaged |
+| `BoundingBox` | 2 | events when the damage bounding box grows |
+| `NonEmpty` | 3 | a single event when the region becomes non-empty |
+
+No reply.
+
+### Destroy(damage)
+Destroys damage object `damage`. No reply.
+
+### Subtract(damage, repair, parts)
+Synchronously subtracts `repair` (an XFIXES region XID, or `0` for "the whole
+damage region") from the damage region of `damage`. If `parts` is a region
+XID it receives the intersection of the damage region and `repair` before the
+subtraction; pass `0` to discard it. Subtracting rearms event delivery: with
+`NonEmpty` reporting, call `Subtract(damage, 0, 0)` after each event to be
+told about the next change. No reply.
+
+### Add(drawable, region)
+Reports damage in `region` (an XFIXES region XID) against `drawable`, as if
+the client had drawn there. Damage objects of other clients monitoring the
+drawable are notified. No reply. Note: the source names the first parameter
+`damage`, but the protocol field is a drawable.
+
+## Events
+
+### DamageNotify
+Delivered when a monitored drawable changes, subject to the report level.
+Not selected via an event mask — creating a damage object selects delivery.
+Parsed fields:
+
+- `level` — report level of the damage object (`Damage.ReportLevel`); the
+  server may set bit `0x80` when more events for the same drawable follow
+- `seq` — sequence number
+- `drawable` — the monitored drawable
+- `damage` — the damage object
+- `time` — server timestamp
+- `area` — `{x, y, w, h}` changed rectangle, drawable-relative
+- `geometry` — `{x, y, w, h}` current geometry of the drawable
+- `name` — `'DamageNotify'`
+
+Note the `w`/`h` field names (not `width`/`height`), and that the event has
+no `type` field, unlike most other extension events in this library.
+
+## Notes
+
+- `Damage.ReportLevel = {RawRectangles: 0, DeltaRectangles: 1, BoundingBox: 2,
+  NonEmpty: 3}`.
+- `Damage.events = {DamageNotify: 0}` (offset from the extension's
+  `firstEvent`).
+- Regions passed to `Subtract` and `Add` are XFIXES regions; create them with
+  `Fixes.CreateRegion` ([ext/fixes.md](fixes.md)).

--- a/docs/ext/dbe.md
+++ b/docs/ext/dbe.md
@@ -1,0 +1,78 @@
+# DOUBLE-BUFFER (DBE) extension
+
+Flicker-free drawing: associates a back buffer with a window, lets you render
+into it with ordinary core drawing requests, then swaps it to the front in one
+atomic operation.
+
+- Module: `X.require('dbe', cb)` (X name `DOUBLE-BUFFER`, version 1.0)
+- Source: [`lib/ext/dbe.js`](../../lib/ext/dbe.js) ·
+  Tests: [`test/dbe.js`](../../test/dbe.js)
+- Spec: [dbe.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/xextproto/dbe.txt)
+
+```js
+X.require('dbe', (err, Dbe) => {
+    const backBuf = X.AllocID();
+    Dbe.AllocateBackBufferName(wid, backBuf, Dbe.SwapAction.Untouched);
+    // the back buffer is a drawable: draw with core requests
+    X.PolyFillRectangle(backBuf, gc, [0, 0, 100, 100]);
+    Dbe.SwapBuffers([{ window: wid, swapAction: Dbe.SwapAction.Untouched }]);
+});
+```
+
+The version is negotiated automatically while requiring (the spec requires
+`GetVersion` before any other DBE request); it is available as `Dbe.major` /
+`Dbe.minor`.
+
+## Requests
+
+### GetVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])`. Called
+automatically by `X.require` with 1.0.
+
+### AllocateBackBufferName(window, backBuffer, swapActionHint)
+Associates `backBuffer` (a fresh XID from `X.AllocID()`) with the back buffer
+of `window`. `swapActionHint` is a `Dbe.SwapAction` value hinting the swap
+behavior the client intends to use. The back buffer is a drawable usable
+with any core drawing request. No reply.
+
+### DeallocateBackBufferName(backBuffer)
+Frees the buffer name. The window stays double-buffered while other names
+reference its back buffer. No reply.
+
+### SwapBuffers(swapInfos)
+`swapInfos` is an array of `{window, swapAction}` — swaps front and back
+buffers of each listed window in one atomic request. `swapAction` (a
+`Dbe.SwapAction` value) determines what the new back buffer contains
+afterwards. No reply.
+
+### BeginIdiom()
+Marks the start of a request sequence the server may optimize as a unit.
+Purely a hint. No reply.
+
+### EndIdiom()
+Ends the sequence started by `BeginIdiom`. No reply.
+
+### GetVisualInfo(drawables, cb)
+`drawables` is an array of screen specifiers (any drawable on each screen of
+interest, e.g. root windows). `cb(err, screens)` — one entry per drawable,
+each an array of `{visual, depth, perfLevel}` describing the double-buffer
+capable visuals of that screen (higher `perfLevel` means better expected
+performance).
+
+### GetBackBufferAttributes(backBuffer, cb)
+`cb(err, {window})` — the window the buffer name is attached to, or 0 (None)
+if it has been deallocated or the window was destroyed.
+
+## Events / errors
+
+None.
+
+## Notes
+
+- `Dbe.SwapAction = {Undefined: 0, Background: 1, Untouched: 2, Copied: 3}`
+  — the new back-buffer contents after a swap: undefined, cleared to the
+  window background, left as-is (the old front buffer), or a copy of the old
+  back buffer.
+- Only the untouched front-buffer contents change on `SwapBuffers`; a
+  `GetImage` on the window before and after a swap is the easiest way to
+  verify it worked (see [`test/dbe.js`](../../test/dbe.js)).

--- a/docs/ext/dpms.md
+++ b/docs/ext/dpms.md
@@ -1,0 +1,73 @@
+# DPMS extension
+
+Display Power Management Signaling: query and control the monitor power
+level (On / Standby / Suspend / Off) and the idle timeouts that trigger each
+level.
+
+- Module: `X.require('dpms', cb)` (X name `DPMS`, version 1.1)
+- Source: [`lib/ext/dpms.js`](../../lib/ext/dpms.js) ·
+  Tests: [`test/dpms.js`](../../test/dpms.js)
+- Spec: [dpms.txt](http://www.x.org/releases/X11R7.6/doc/xextproto/dpms.txt)
+
+```js
+X.require('dpms', (err, dpms) => {
+    dpms.GetTimeouts((err, timeouts) => {
+        // [standbySeconds, suspendSeconds, offSeconds]
+    });
+    dpms.Enable();
+    dpms.ForceLevel(3); // blank the display (Off)
+});
+```
+
+All replies are arrays (positional), not objects.
+
+## Requests
+
+### GetVersion(clientMajor, clientMinor, cb)
+`cb(err, [major, minor])` — the DPMS version the server implements. Not
+called automatically.
+
+### Capable(cb)
+`cb(err, [capable])` — `capable` is 1 when the display system supports DPMS,
+else 0. Note the single-element array.
+
+### GetTimeouts(cb)
+`cb(err, [standby, suspend, off])` — idle timeouts in seconds; 0 disables
+the corresponding level.
+
+### SetTimeouts(standby, suspend, off)
+Sets the three idle timeouts (seconds, CARD16; 0 disables a level). No
+reply. The server requires `standby <= suspend <= off` (ignoring zeros) and
+answers BadValue otherwise.
+
+### Enable()
+Enables DPMS control of the display, using the current timeout values. No
+reply.
+
+### Disable()
+Disables DPMS (display stays on regardless of timeouts). No reply.
+
+### ForceLevel(level)
+Immediately puts the display into `level`: 0 On, 1 Standby, 2 Suspend,
+3 Off. No reply. DPMS must be enabled first, otherwise the server answers
+with an error (the test calls `Enable()` before forcing a level).
+
+### Info(cb)
+`cb(err, [powerLevel, state])` — current power level (same codes as
+`ForceLevel`) and `state` 1 when DPMS is enabled, 0 when disabled.
+
+## Events / errors
+
+None.
+
+## Notes
+
+- Reply unpacking uses the generated decoders in
+  [`lib/generated/dpms-replies.js`](../../lib/generated/dpms-replies.js);
+  results are re-shaped into the positional arrays above for API
+  compatibility.
+- No level constants are attached to the extension object; use the numeric
+  codes (0 On, 1 Standby, 2 Suspend, 3 Off).
+- Some servers are built or started without DPMS (the require callback then
+  gets `Error('extension not available')`); the test suite skips itself in
+  that case.

--- a/docs/ext/fixes.md
+++ b/docs/ext/fixes.md
@@ -1,0 +1,211 @@
+# XFIXES extension
+
+A grab bag of protocol fixes: server-side region objects and region
+arithmetic, cursor image/name access and cursor change notification,
+selection owner tracking, save-set extensions, show/hide cursor, and pointer
+barriers. Regions created here are used by DAMAGE
+([ext/damage.md](damage.md)), Composite ([ext/composite.md](composite.md)),
+and RENDER ([ext/render.md](render.md)).
+
+- Module: `X.require('fixes', cb)` (X name `XFIXES`, version 5.0)
+- Source: [`lib/ext/fixes.js`](../../lib/ext/fixes.js) ·
+  Tests: [`test/fixes.js`](../../test/fixes.js)
+- Spec: [fixesproto.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/fixesproto/fixesproto.txt)
+
+```js
+X.require('fixes', (err, Fixes) => {
+    const region = X.AllocID();
+    Fixes.CreateRegion(region, [{ x: 10, y: 10, width: 40, height: 20 }]);
+    Fixes.FetchRegion(region, (err, reg) => {
+        // reg.extents   -> { x: 10, y: 10, width: 40, height: 20 }
+        // reg.rectangles -> [{ x: 10, y: 10, width: 40, height: 20 }]
+        Fixes.DestroyRegion(region);
+    });
+});
+```
+
+The version is negotiated automatically while requiring (the module asks for
+5.0); it is available as `Fixes.major` / `Fixes.minor`.
+
+Rectangles are passed and returned as `{x, y, width, height}` objects
+(`x`/`y` signed, `width`/`height` unsigned). Region arguments are XIDs from
+`X.AllocID()`; `0` means `None` where noted.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Opcode 0. Negotiates the protocol version. `cb(err, [major, minor])` — the
+version the server will speak. Called automatically by `X.require` with 5.0.
+
+### ChangeSaveSet(window, mode, target, map)
+Opcode 1. Extended save-set control for `window` (a window of another
+client). `mode` from `Fixes.SaveSetMode` (`Insert: 0`, `Delete: 1`), `target`
+from `Fixes.SaveSetTarget` (`Nearest: 0`, `Root: 1`) — where the window is
+reparented when this client dies, `map` from `Fixes.SaveSetMap` (`Map: 0`,
+`Unmap: 1`). No reply.
+
+### SelectSelectionInput(window, selection, eventMask)
+Opcode 2. Selects `SelectionNotify` event delivery to `window` for the
+`selection` atom. `eventMask` is a bitwise OR of `Fixes.SelectionEventMask`
+(`SetSelectionOwner: 1`, `SelectionWindowDestroy: 2`,
+`SelectionClientClose: 4`); `0` deselects. No reply.
+
+### SelectCursorInput(window, eventMask)
+Opcode 3. Selects `CursorNotify` event delivery to `window`. `eventMask` is
+`Fixes.CursorNotifyMask.DisplayCursor` (1) or `0` to deselect. No reply.
+
+### GetCursorImage(cb)
+Opcode 4. `cb(err, image)` — the image of the cursor currently displayed:
+`{x, y, width, height, xhot, yhot, cursorSerial, cursorImage}` where `x`/`y`
+is the pointer position, `xhot`/`yhot` the hotspot, and `cursorImage` a
+Buffer of `width * height` packed ARGB32 pixels with premultiplied alpha.
+
+### CreateRegion(region, rects)
+Opcode 5. Creates `region` (a client-allocated XID) as the union of `rects`,
+an array of `{x, y, width, height}` (may be empty). No reply.
+
+### CreateRegionFromBitmap(region, bitmap)
+Opcode 6. Creates `region` containing the set bits of `bitmap`, a depth-1
+pixmap. No reply.
+
+### CreateRegionFromWindow(region, wid, kind)
+Opcode 7. Creates `region` from the shape of window `wid`; `kind` from
+`Fixes.WindowRegionKind` (`Bounding: 0`, `Clip: 1`). The region is a copy —
+later shape changes do not affect it. No reply.
+
+### CreateRegionFromGC(region, gc)
+Opcode 8. Creates `region` from the clip list of `gc` (a copy). No reply.
+
+### CreateRegionFromPicture(region, picture)
+Opcode 9. Creates `region` from the clip list of a RENDER `picture`
+(a copy; see [ext/render.md](render.md)). No reply.
+
+### DestroyRegion(region)
+Opcode 10. Destroys `region`. No reply.
+
+### SetRegion(region, rects)
+Opcode 11. Replaces the contents of `region` with the union of `rects`
+(array of `{x, y, width, height}`). No reply.
+
+### CopyRegion(src, dst)
+Opcode 12. Replaces the contents of region `dst` with region `src`.
+No reply.
+
+### UnionRegion(src1, src2, dst)
+Opcode 13. `dst = src1 ∪ src2`. All three are existing regions; `dst` may be
+one of the sources. No reply.
+
+### IntersectRegion(src1, src2, dst)
+Opcode 14. `dst = src1 ∩ src2`. No reply.
+
+### SubtractRegion(src1, src2, dst)
+Opcode 15. `dst = src1 - src2`. No reply.
+
+### InvertRegion(src, bounds, dst)
+Opcode 16. `dst = bounds - src`, where `bounds` is a single
+`{x, y, width, height}` rectangle. No reply.
+
+### TranslateRegion(region, dx, dy)
+Opcode 17. Moves `region` in place by the signed offsets `dx`, `dy`.
+No reply.
+
+### RegionExtents(src, dst)
+Opcode 18. Replaces `dst` with the bounding box of `src`. No reply.
+
+### FetchRegion(region, cb)
+Opcode 19. `cb(err, reg)` — the contents of `region` as
+`{extents, rectangles}`: `extents` is the bounding `{x, y, width, height}`
+rectangle and `rectangles` an array of `{x, y, width, height}` covering the
+region (YX-banded).
+
+### SetGCClipRegion(gc, region, xOrigin, yOrigin)
+Opcode 20. Sets the clip list of `gc` to `region` (a copy) with the given
+clip origin. `region` `0` = `None` removes clipping. No reply.
+
+### SetWindowShapeRegion(dest, destKind, xOffset, yOffset, region)
+Opcode 21. Sets the shape of window `dest` to `region` (a copy) offset by
+`xOffset`/`yOffset`. `destKind` from `Fixes.WindowRegionKind`; the SHAPE
+extension's `Input` kind (2, [ext/shape.md](shape.md)) is also accepted by
+servers with SHAPE 1.1. `region` `0` = `None` removes the shape. No reply.
+
+### SetPictureClipRegion(picture, region, xOrigin, yOrigin)
+Opcode 22. Sets the clip list of RENDER `picture` to `region` (a copy) with
+the given clip origin. `region` `0` = `None`. No reply.
+
+### SetCursorName(cursor, name)
+Opcode 23. Labels `cursor` with `name` (a latin1 string; the server interns
+it as an atom). No reply.
+
+### GetCursorName(cursor, cb)
+Opcode 24. `cb(err, {atom, name})` — the atom and string name of `cursor`
+(`atom` 0 and empty `name` when unnamed).
+
+### GetCursorImageAndName(cb)
+Opcode 25. `cb(err, image)` — like `GetCursorImage` plus `cursorAtom` and
+`cursorName` (string) of the displayed cursor.
+
+### ChangeCursor(src, dst)
+Opcode 26. Makes every use of cursor `dst` show the contents of cursor
+`src`, then makes `dst` an alias for `src`. No reply.
+
+### ChangeCursorByName(src, name)
+Opcode 27. Like `ChangeCursor` for every cursor whose name matches the
+latin1 string `name`. No reply.
+
+### ExpandRegion(src, dst, left, right, top, bottom)
+Opcode 28. Replaces `dst` with `src` where every rectangle is grown by the
+given amounts in each direction. No reply.
+
+### HideCursor(window)
+Opcode 29. Hides the cursor while the pointer is inside `window` (or a
+subwindow). Reference-counted per client; pair with `ShowCursor`. No reply.
+
+### ShowCursor(window)
+Opcode 30. Undoes one `HideCursor` on `window`. No reply.
+
+### CreatePointerBarrier(barrier, window, x1, y1, x2, y2, directions, devices)
+Opcode 31 (XFIXES 5.0). Creates pointer barrier `barrier` (a
+client-allocated XID) on the screen of `window` along the line
+(`x1`,`y1`)-(`x2`,`y2`) — the line must be axis-aligned. `directions` is a
+bitwise OR of `Fixes.BarrierDirections` (`PositiveX: 1`, `PositiveY: 2`,
+`NegativeX: 4`, `NegativeY: 8`) naming movement directions allowed *through*
+the barrier; `0` blocks both. `devices` is an optional array of XInput2
+device ids the barrier applies to (empty or omitted = all master pointers).
+No reply.
+
+### DeletePointerBarrier(barrier)
+Opcode 32 (XFIXES 5.0). Destroys `barrier`. No reply.
+
+## Events
+
+### SelectionNotify
+Delivered after `SelectSelectionInput` when selection ownership changes.
+Fields: `type`, `seq`, `subtype` (`Fixes.SelectionEvent`:
+`SetSelectionOwner: 0`, `SelectionWindowDestroy: 1`,
+`SelectionClientClose: 2`), `window` (the selecting window), `owner` (new
+owner window, 0 = None), `selection` (atom), `timestamp`,
+`selectionTimestamp` (last-change time of the selection), `name`
+(`'SelectionNotify'`).
+
+### CursorNotify
+Delivered after `SelectCursorInput` when the displayed cursor changes.
+Fields: `type`, `seq`, `subtype` (`Fixes.CursorNotify.DisplayCursor` = 0),
+`window`, `cursorSerial` (matches `cursorSerial` of `GetCursorImage`),
+`timestamp`, `cursorName` (the name *atom*, not a string; 0 if unnamed),
+`name` (`'CursorNotify'`).
+
+## Notes
+
+- Enums on the extension object: `SaveSetMode`, `SaveSetTarget`,
+  `SaveSetMap`, `SelectionEvent`, `SelectionEventMask`, `CursorNotify`,
+  `CursorNotifyMask`, `WindowRegionKind`, `BarrierDirections`, and
+  `events = {SelectionNotify: 0, CursorNotify: 1}`.
+- XFIXES 5 is implemented completely (opcodes 0–32), including the pointer
+  barrier requests. XFIXES 6 (`SetClientDisconnectMode`,
+  `GetClientDisconnectMode`) is not implemented.
+- Region-returning requests never allocate ids server-side: the client picks
+  every region XID with `X.AllocID()`, including destination regions of the
+  arithmetic requests (create them first, e.g. `CreateRegion(dst, [])`).
+- Rectangle format differs from the SHAPE extension: XFIXES uses
+  `{x, y, width, height}` objects, SHAPE uses `[x, y, width, height]`
+  arrays.

--- a/docs/ext/ge.md
+++ b/docs/ext/ge.md
@@ -1,0 +1,62 @@
+# Generic Event Extension (GE)
+
+Carries only a version handshake; its purpose is the GenericEvent (type 35)
+wire event that other extensions (Present, XInput2, ...) use to deliver
+events longer than the classic 32 bytes. Requiring `ge` is how a client
+announces it understands type-35 events.
+
+- Module: `X.require('ge', cb)` (X name `Generic Event Extension`,
+  version 1.0)
+- Source: [`lib/ext/ge.js`](../../lib/ext/ge.js) ·
+  Tests: [`test/ge.js`](../../test/ge.js)
+- Spec: [geproto](https://www.x.org/releases/X11R7.7/doc/xextproto/geproto.html)
+
+```js
+X.require('ge', (err, GE) => {
+    // GE.major / GE.minor — negotiated version (1.0)
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`GE.major` / `GE.minor`.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])` — the version the
+server will speak. Called automatically by `X.require`.
+
+## Events
+
+None of its own. GenericEvents are always defined (and parsed) by the
+extension that sends them; see below.
+
+## GenericEvent dispatch (`X.geEventParsers`)
+
+`lib/xcore.js` handles the type-35 wire format itself:
+
+- A GenericEvent header carries the sending extension's major opcode in
+  byte 1 and an extra length (in 4-byte units) in bytes 4-7. The event body
+  is `32 + extra * 4` bytes; xcore frames it by that length so
+  variable-length events do not corrupt the reply stream.
+- The parsed event is produced by `X.geEventParsers[majorOpcode]`, a map
+  keyed by the sending extension's major opcode. An extension module
+  registers its parser as
+  `X.geEventParsers[ext.majorOpcode] = (type, seq, extra, code, raw) => ...`
+  where `type` is 35, `code` is the major opcode, `extra` is the extra
+  length, and `raw` is the event from byte 8 on (the 16-bit `evtype`
+  selecting the extension's event is at `raw` offset 0).
+- With no parser registered the client still frames the event correctly and
+  emits `{type: 35, seq, extension, evtype, raw}`.
+- As with all events, the full wire packet (here variable-length, not 32
+  bytes) is attached as `event.rawData`.
+
+[ext/present.md](present.md) is the in-tree example of a registered parser;
+XInput2 events are not wired up yet (see [ext/xinput.md](xinput.md)).
+
+## Notes
+
+- The spec requires clients to negotiate the version before relying on
+  GenericEvents; `X.require('ge', ...)` does that. Extensions in this repo
+  that send GenericEvents perform their own version handshakes, so requiring
+  `ge` explicitly is only needed when talking to the wire format directly.

--- a/docs/ext/glx.md
+++ b/docs/ext/glx.md
@@ -1,0 +1,202 @@
+# GLX extension
+
+OpenGL rendering over the X protocol (indirect rendering). The module wraps a
+subset of the GLX protocol: context/drawable management, a handful of
+single-op GL requests (display lists, textures), and the `Render` /
+`RenderLarge` requests that carry batched GL commands. A small GL command
+serializer is provided by [`lib/ext/glxrender.js`](../../lib/ext/glxrender.js)
+via `GLX.renderPipeline(ctx)`.
+
+- Module: `X.require('glx', cb)` (X name `GLX`)
+- Source: [`lib/ext/glx.js`](../../lib/ext/glx.js) ·
+  Render pipeline: [`lib/ext/glxrender.js`](../../lib/ext/glxrender.js) ·
+  Constants: [`lib/ext/glxconstants.js`](../../lib/ext/glxconstants.js) ·
+  Examples: [`examples/opengl/`](../../examples/opengl/)
+- Spec: [glx.xml (xcb proto)](https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/master/src/glx.xml),
+  [GLX protocol PDF](https://registry.khronos.org/OpenGL/specs/gl/glxproto.pdf)
+
+```js
+X.require('glx', (err, GLX) => {
+    const ctx = X.AllocID();
+    GLX.CreateContext(ctx, visual, 0 /* screen */, 0, 0);
+    GLX.MakeCurrent(win, ctx, 0, (err, contextTag) => {});
+    const gl = GLX.renderPipeline(ctx);
+
+    gl.ClearColor(0, 0, 0, 1);
+    gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    gl.Begin(gl.TRIANGLES);
+    gl.Color3f(1, 0, 0); gl.Vertex3f(0, 1, 0);
+    gl.Color3f(0, 1, 0); gl.Vertex3f(-1, -1, 0);
+    gl.Color3f(0, 0, 1); gl.Vertex3f(1, -1, 0);
+    gl.End();
+    gl.SwapBuffers(win);   // flushes the batch, then issues glXSwapBuffers
+});
+```
+
+Unlike most extensions, no version negotiation happens during `require`;
+call `QueryVersion` yourself if you need it. All GL enums from
+`glxconstants.js` are copied onto both the `GLX` object and every render
+pipeline (`GLX.TRIANGLES`, `gl.COMPILE`, `gl.LIGHT0`, ...).
+
+## Requests
+
+Listed in minor opcode order. `ctx` arguments are GLX context XIDs
+(from `X.AllocID()` + `CreateContext`), except where a request takes the
+context *tag* returned by `MakeCurrent` — on the wire `Render`,
+`RenderLarge`, `NewList` etc. expect the tag, but with indirect contexts the
+examples pass the context XID and current servers accept it.
+
+### Render(ctx, data)
+Minor opcode 1. Sends a batch of serialized GL commands. `data` is a Buffer
+or an array of Buffers, each holding one or more GL render commands
+(2-byte length, 2-byte opcode, payload). Buffer lengths must be multiples
+of 4. No reply. Normally used through `renderPipeline` rather than directly.
+
+### RenderLarge(ctx, requestNum, requestTotal, data)
+Minor opcode 2. Carries one GL command too big for `Render`, split into
+`requestTotal` parts; `requestNum` is 1-based. `data` is a Buffer (padded
+to 4 bytes automatically). No reply. Used internally by the pipeline's
+`TexImage2D`.
+
+### CreateContext(ctx, visual, screen, shareListCtx, isDirect)
+Minor opcode 3. Creates GLX context `ctx` (client-allocated XID) for
+`visual` on `screen`. `shareListCtx` is a context to share display lists
+with (0 for none); `isDirect` should be 0 — this client renders indirectly.
+No reply.
+
+### MakeCurrent(drawable, ctx, oldContextTag, cb)
+Minor opcode 5. Binds `ctx` to `drawable` (window or GLX pixmap).
+`oldContextTag` is the tag from a previous `MakeCurrent` (0 the first
+time). `cb(err, contextTag)` — tag identifying the new current context.
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Minor opcode 7. `cb(err, [major, minor])` — GLX version supported by the
+server. Not called automatically.
+
+### SwapBuffers(ctx, drawable)
+Minor opcode 11. Exchanges front and back buffers of `drawable`. `ctx` is
+the context tag. No reply.
+
+### CreateGLXPixmap(screen, visual, pixmap, glxpixmap)
+Minor opcode 13. Creates an off-screen GLX rendering surface `glxpixmap`
+(client-allocated XID) backed by the ordinary `pixmap`, which must match
+`visual`'s depth. No reply. Currently prints debug output
+(`console.log`/`console.trace`) on every call.
+
+### GetVisualConfigs(screen, cb)
+Minor opcode 14. `cb(err, configs)` — array with one object per GL-capable
+visual: `{visualID, visualType, rgbMode, redBits, greenBits, blueBits,
+alphaBits, accumRedBits, accumGreen, accumBlueBits, accumAlphaBits,
+doubleBufferMode, stereoMode, rgbBits, depthBits, stencilBits,
+numAuxBuffers, level}`. Only the first 18 properties are decoded; extra
+tag/value properties the server may append are ignored.
+
+### VendorPrivate(ctx, code, data)
+Minor opcode 16. Sends vendor-specific command `code` with payload `data`
+(Buffer, length multiple of 4). No reply. Used by `BindTexImage` /
+`ReleaseTexImage` below.
+
+### QueryExtensionsString(screen, cb)
+Minor opcode 18. `cb(err, str)` — space-separated GLX extension list for
+`screen` (string may include trailing padding NULs).
+
+### QueryServerString(screen, name, cb)
+Minor opcode 19. `cb(err, str)` — a server GLX string. `name` is 1
+(vendor), 2 (version) or 3 (extensions) per the GLX protocol; note the
+`VENDOR`/`EXTENSIONS` values in `glxconstants.js` are the *GL* glGetString
+enums (0x1F00...), not these.
+
+### GetFBConfigs(screen, cb)
+Minor opcode 21. `cb(err, configs)` — array of framebuffer configs, each an
+array of `[attribute, value]` pairs (raw GLX attribute codes, not decoded).
+
+### NewList(ctx, list, mode)
+Minor opcode 101. glNewList — starts recording display list `list`.
+`mode` is `GLX.COMPILE` or `GLX.COMPILE_AND_EXECUTE`. No reply.
+
+### EndList(ctx)
+Minor opcode 102. glEndList — ends display list recording. No reply.
+
+### GenLists(ctx, count, cb)
+Minor opcode 104. glGenLists — `cb(err, base)` where `base` is the first
+of `count` consecutive display list ids.
+
+### Finish(ctx, cb)
+Minor opcode 108. glFinish — blocks until all previous GL commands have
+completed. `cb(err)` — the reply carries no data.
+
+### GenTextures(ctx, count, cb)
+Minor opcode 145. glGenTextures — `cb(err, ids)`, array of `count` texture
+ids.
+
+### IsTexture(ctx, texture, cb)
+Minor opcode 146. glIsTexture. The unpacker currently returns the first 26
+raw reply bytes as an array of numbers rather than a boolean; the GL result
+is at index 0.
+
+### Helpers built on VendorPrivate
+
+- `BindTexImage(ctx, drawable, buffer, attribs)` — GLX_EXT_texture_from_pixmap
+  bind (vendor opcode 1330). `attribs` is an optional flat
+  `[attribute, value, ...]` array; note the current serializer writes
+  `attribs.length` in place of each attribute value, so pass no attribs
+  (omit or `[]`). No reply.
+- `ReleaseTexImage(ctx, drawable, buffer)` — matching release (vendor
+  opcode 1331). No reply.
+
+## Render pipeline (glxrender.js)
+
+`GLX.renderPipeline(ctx)` returns an object with immediate-mode-style GL
+methods. Each call serializes one GL render command into an internal buffer
+list; nothing is sent until the batch is flushed. Flushing happens when:
+
+- `gl.Render()` is called explicitly (optional `ctxLocal` argument overrides
+  the pipeline's context);
+- the batch would exceed 65520 bytes (`MAX_SMALL_RENDER`);
+- any of the bound GLX requests is invoked — `NewList`, `EndList`,
+  `GenLists`, `GenTextures`, `IsTexture`, `SwapBuffers` and `Finish` exist
+  on the pipeline with the `ctx` argument pre-bound (e.g.
+  `gl.SwapBuffers(drawable)`, `gl.GenLists(count, cb)`) and flush pending
+  commands first;
+- `TexImage2D` is called (it flushes, then ships the pixel data via
+  `RenderLarge`, splitting at 262124-byte chunks).
+
+Serialized commands: `Begin(mode)`, `End()`, `Vertex3f/Vertex3fv`,
+`Color3f`, `Color4f`, `Normal3f/Normal3fv`, `TexCoord2f`, `ClearColor`,
+`Clear(mask)`, `Enable(cap)`, `ShadeModel`, `BlendFunc`, `PointSize`,
+`Hint`, `MatrixMode`, `LoadIdentity`, `PushMatrix`, `PopMatrix`,
+`Rotatef`, `Scalef`, `Translatef`, `Ortho`, `Frustum`, `Viewport`,
+`CallList(list)`, `Lightfv(light, pname, v)` and
+`Materialfv(face, pname, v)` (both accept a 4-element array or 4 scalars),
+`BindTexture`, `TexEnvf`, `TexParameterf/fv/i`,
+`TexImage2D(target, level, internalFormat, width, height, border, format,
+type, data)` (`type` must be `FLOAT`, `BYTE` or `UNSIGNED_BYTE`; `data` is
+a plain array).
+
+See [`examples/opengl/glxgears.js`](../../examples/opengl/glxgears.js) for a
+complete program (context setup, display lists, per-frame drawing).
+
+## Events / errors
+
+No events. The 13 GLX protocol errors are registered with the client's
+error parsers; a failed request yields an error whose `message` is
+`GLX: Bad <thing>` (context, drawable, pixmap, context tag, current window,
+Render request, RenderLarge request, FB config, pbuffer, ...).
+
+## Notes
+
+- Enums: `glxconstants.js` exports the classic GL 1.x constant set
+  (primitive modes, caps, texture/pixel formats, matrix modes, light and
+  material names, hints, ...) under their names minus the `GL_` prefix
+  (`TRIANGLES`, `DEPTH_TEST`, `RGBA`, `MODELVIEW`, ...). All of them are
+  merged onto the `GLX` object and onto every render pipeline.
+- Only indirect rendering is possible — commands travel over the X
+  connection, so this is GL 1.x-era functionality and not fast. `isDirect`
+  in `CreateContext` should be 0.
+- `Ortho` and `Frustum` serialize the same GL opcode (182, glFrustum);
+  a true glOrtho (opcode 181) is not currently emitted.
+- `ProgramString` / `BindProgram` on the pipeline are unfinished and throw
+  ReferenceErrors if called.
+- Large coverage gaps vs. the full GLX protocol (DestroyContext,
+  glXGetString, pbuffers, MakeContextCurrent, ...) — only the requests
+  listed above are implemented.

--- a/docs/ext/present.md
+++ b/docs/ext/present.md
@@ -1,0 +1,110 @@
+# Present extension
+
+Presents pixmap contents to a window synchronized with the display refresh
+(msc — media stream counter), the modern way to do tear-free updates and
+vblank-timed animation. Completion and idle notifications arrive as
+GenericEvents (see [ext/ge.md](ge.md)).
+
+- Module: `X.require('present', cb)` (X name `Present`, version 1.2
+  announced by the client)
+- Source: [`lib/ext/present.js`](../../lib/ext/present.js) ·
+  Tests: [`test/present.js`](../../test/present.js)
+- Spec: [presentproto.txt](https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/presentproto.txt)
+
+```js
+X.require('present', (err, Present) => {
+    const eid = X.AllocID();
+    Present.SelectInput(eid, wid, Present.EventMask.CompleteNotify);
+    Present.Pixmap(wid, pixmap, {
+        serial: 1,
+        options: Present.Option.Async | Present.Option.Copy
+    });
+    X.on('event', ev => {
+        if (ev.name === 'PresentCompleteNotify')
+            console.log('presented at msc', ev.msc);
+    });
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`Present.major` / `Present.minor`.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])` — the version the
+server will speak. Called automatically by `X.require` (announcing 1.2).
+
+### Pixmap(window, pixmap, opts)
+PresentPixmap: copies `pixmap` to `window` at the target msc. No reply.
+`opts` keys (all optional, default 0/empty):
+
+- `serial` — client cookie echoed in the CompleteNotify/IdleNotify events
+- `valid`, `update` — XFIXES region XIDs ([ext/fixes.md](fixes.md));
+  0 = None
+- `xOff`, `yOff` — presentation offset (signed)
+- `targetCrtc` — RandR crtc to time against; 0 = server picks
+- `waitFence`, `idleFence` — SYNC fence XIDs ([ext/sync.md](sync.md));
+  0 = None
+- `options` — mask of `Present.Option` values
+- `targetMsc`, `divisor`, `remainder` — when to present: at `targetMsc`, or
+  when `msc % divisor == remainder` (all default 0 = next vblank)
+- `notifies` — array of `{window, serial}`: additional windows whose
+  CompleteNotify subscribers are notified
+
+### NotifyMSC(window, serial, targetMsc, divisor, remainder)
+No reply. Requests a `PresentCompleteNotify` event with
+`kind = CompleteKind.NotifyMSC` when the msc of `window`'s crtc reaches
+`targetMsc` (same divisor/remainder semantics as `Pixmap`). Delivered only to
+clients that selected `CompleteNotify` on `window`.
+
+### SelectInput(eid, window, eventMask)
+No reply. Selects Present events on `window`. `eid` is a fresh XID
+(`X.AllocID()`) naming the event context; `eventMask` is a mask of
+`Present.EventMask` values (`NoEvent` = 0 deselects). Events arrive on the
+client as GenericEvents parsed into the shapes below.
+
+### QueryCapabilities(target, cb)
+`target` is a window (or RandR crtc). `cb(err, caps)` — a mask of
+`Present.Capability` values.
+
+## Events
+
+All Present events are GenericEvents (type 35) dispatched through
+`X.geEventParsers` ([ext/ge.md](ge.md)); the module registers its parser at
+require time. Common fields on every event: `type` (35), `seq`, `extension`
+(Present's major opcode), `evtype` (`Present.events` value), `eid`
+(SelectInput context), `wid`/`window` (same value).
+
+### PresentConfigureNotify (evtype 0)
+Window size/position changed. Extra fields: `x`, `y`, `width`, `height`,
+`offX`, `offY`, `pixmapWidth`, `pixmapHeight`, `pixmapFlags`.
+
+### PresentCompleteNotify (evtype 1)
+A `Pixmap` or `NotifyMSC` request completed. Extra fields: `kind`
+(`Present.CompleteKind`), `mode` (`Present.CompleteMode`), `serial` (from
+the request), `ust` (unadjusted system time, microseconds), `msc`.
+
+### PresentIdleNotify (evtype 2)
+A presented pixmap is reusable by the client. Extra fields: `serial`,
+`pixmap`, `idleFence`.
+
+Unknown evtypes (e.g. RedirectNotify, which has no parser) are delivered as
+`PresentGenericEvent` with the unparsed body in `raw`.
+
+## Notes
+
+- Enums attached to the ext object:
+  `Present.EventMask = {NoEvent: 0, ConfigureNotify: 1, CompleteNotify: 2,
+  IdleNotify: 4, RedirectNotify: 8}`,
+  `Present.Option = {None: 0, Async: 1, Copy: 2, UST: 4, Suboptimal: 8}`,
+  `Present.Capability = {None: 0, Async: 1, Fence: 2, UST: 4}`,
+  `Present.CompleteKind = {Pixmap: 0, NotifyMSC: 1}`,
+  `Present.CompleteMode = {Copy: 0, Flip: 1, Skip: 2, SuboptimalCopy: 3}`.
+- 64-bit protocol fields (`targetMsc`, `divisor`, `remainder`, `ust`, `msc`)
+  are plain JS numbers composed from two 32-bit halves; values above
+  2^53 - 1 lose precision (irrelevant in practice for msc counters).
+- Servers may report capability bits newer than the `Capability` enum
+  (AsyncMayTear = 8, Syncobj = 16 on current Xorg).
+- On Xvfb the copy happens at a fake vblank; test/present.js polls with
+  `GetImage` rather than assuming immediate completion.

--- a/docs/ext/randr.md
+++ b/docs/ext/randr.md
@@ -1,0 +1,263 @@
+# RANDR extension
+
+Resize, rotate and reflect the screen, and inspect/configure the CRTCs,
+outputs and modes behind it. This is the modern interface to multi-monitor
+setups (see [ext/xinerama.md](xinerama.md) for the legacy view). All RANDR 1.3
+requests are implemented (minor opcodes 0-31, except the deprecated 1.0
+`OldGetScreenInfo`/`OldScreenChangeSelectInput` at 1 and 3).
+
+- Module: `X.require('randr', cb)` (X name `RANDR`, protocol version 1.3)
+- Source: [`lib/ext/randr.js`](../../lib/ext/randr.js) ·
+  Tests: [`test/randr.js`](../../test/randr.js)
+- Spec: [randrproto.txt](http://www.x.org/releases/X11R7.6/doc/randrproto/randrproto.txt)
+
+```js
+X.require('randr', (err, Randr) => {
+    // you MUST negotiate the version you intend to use before other
+    // requests, otherwise the server may not behave as expected
+    Randr.QueryVersion(1, 3, (err, version) => {
+        Randr.GetScreenResources(root, (err, res) => {
+            Randr.GetOutputInfo(res.outputs[0], 0, (err, info) => {
+                // info.name, info.connection, info.modes, ...
+            });
+        });
+    });
+});
+```
+
+`X.require` calls `QueryVersion(255, 255)` automatically and stores the
+result as `Randr.major_version` / `Randr.minor_version`. Despite that, call
+`QueryVersion` yourself with the version you actually target before issuing
+other requests (see Notes).
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])` — the version the
+server will speak to this client.
+
+### SetScreenConfig(win, timestamp, configTimestamp, sizeId, rotation, rate, cb)
+RANDR 1.0-style screen configuration: pick size `sizeId` from
+`GetScreenInfo().screens`, a `rotation` (`Randr.Rotation` bit) and refresh
+`rate`. `cb(err, {status, newTs, configTs, root, subpixelOrder})`. When the
+server answers with a non-zero `status`, `err` is an `Error` with
+`err.code` set to the status (`Randr.ConfigStatus`) and the reply object is
+still passed as the second argument.
+
+### SelectInput(win, mask)
+Selects RANDR event delivery for `win`; `mask` is a bitwise OR of
+`Randr.NotifyMask` values. No reply. Note that only `RRScreenChangeNotify`
+has an event parser (see Events).
+
+### GetScreenInfo(win, cb)
+1.0-style screen state. `cb(err, info)` with
+
+```js
+{
+  rotations,          // bitmask of supported Rotation values
+  root, timestamp, config_timestamp,
+  sizeID,             // index into screens of the current size
+  rotation, rate,     // current rotation and refresh rate
+  screens,            // [{px_width, px_height, mm_width, mm_height}, ...]
+  rates               // flat CARD16 rate-info entries, as on the wire:
+                      // for each size a count followed by that many rates
+}
+```
+
+### GetScreenSizeRange(win, cb)
+`cb(err, {minWidth, minHeight, maxWidth, maxHeight})` — the sizes accepted by
+`SetScreenSize`.
+
+### SetScreenSize(win, width, height, mmWidth, mmHeight)
+Sets the screen size; `width`/`height` in pixels, `mmWidth`/`mmHeight` in
+millimeters. No reply.
+
+### GetScreenResources(win, cb)
+`cb(err, resources)` with
+
+```js
+{
+  timestamp, config_timestamp,
+  crtcs,      // [crtc, ...] XIDs
+  outputs,    // [output, ...] XIDs
+  modeinfos   // [{id, width, height, dot_clock, h_sync_start, h_sync_end,
+              //   h_total, h_skew, v_sync_start, v_sync_end, v_total,
+              //   name_len, modeflags, name}, ...]
+}
+```
+
+May force a hardware re-probe; prefer `GetScreenResourcesCurrent` when stale
+data is acceptable.
+
+### GetOutputInfo(output, configTimestamp, cb)
+`cb(err, info)` with
+
+```js
+{
+  timestamp, crtc,
+  mm_width, mm_height,
+  connection,        // Randr.Connection value
+  subpixelOrder,
+  preferredModes,    // count: the first N entries of modes are preferred
+  crtcs,             // [crtc, ...] usable with this output
+  modes,             // [mode, ...] mode XIDs (match modeinfos ids)
+  clones,            // [output, ...] outputs sharing this one's wiring
+  name               // e.g. 'HDMI-1'
+}
+```
+
+### ListOutputProperties(output, cb)
+`cb(err, atoms)` — array of property name atoms defined on `output`.
+
+### QueryOutputProperty(output, property, cb)
+`cb(err, {pending, range, immutable, validValues})` — booleans plus an array
+of INT32: a `[min, max]` pair when `range` is true, otherwise the list of
+valid values.
+
+### ConfigureOutputProperty(output, property, pending, range, values)
+Sets the property's valid values (`[min, max]` when `range` is truthy, else a
+list) and whether changes are `pending` until the next `SetCrtcConfig`.
+`values` is an array of INT32. No reply.
+
+### ChangeOutputProperty(output, property, type, format, mode, data)
+Sets property contents. `type` is an atom, `format` 8/16/32, `mode` 0
+replace / 1 prepend / 2 append. `data` may be a Buffer (raw bytes), an array
+of numbers (one per format unit) or a string (latin1). No reply.
+
+### DeleteOutputProperty(output, property)
+Deletes the property. No reply. A subsequent `QueryOutputProperty` yields a
+BadName error.
+
+### GetOutputProperty(output, property, type, longOffset, longLength, del, pending, cb)
+Like core `GetProperty` but for outputs; `longOffset`/`longLength` are in
+4-byte units, `del` deletes after reading, `pending` reads the pending value.
+`cb(err, {format, type, bytesAfter, numItems, data})` — `data` is a Buffer of
+`numItems` format-sized items.
+
+### CreateMode(win, modeInfo, cb)
+Registers a user mode line. `modeInfo` is `{width, height, dot_clock,
+h_sync_start, h_sync_end, h_total, h_skew, v_sync_start, v_sync_end,
+v_total, modeflags, name}` — all except `width`/`height`/`name` default to 0
+and the mode XID is chosen by the server. `cb(err, mode)`. Some servers
+refuse user modes with a RANDR error.
+
+### DestroyMode(mode)
+Destroys a user mode not in use by any output. No reply.
+
+### AddOutputMode(output, mode)
+Adds a user mode to the output's mode list. No reply.
+
+### DeleteOutputMode(output, mode)
+Removes a user mode from the output's mode list. No reply.
+
+### GetCrtcInfo(crtc, configTimestamp, cb)
+`cb(err, info)` with
+
+```js
+{
+  status,             // Randr.ConfigStatus
+  timestamp, x, y, width, height,
+  mode,               // current mode XID, 0 when disabled
+  rotation,           // current rotation
+  rotations,          // bitmask of supported rotations
+  output,             // [output, ...] currently driven (note: singular name)
+  possible            // [output, ...] connectable to this crtc
+}
+```
+
+### SetCrtcConfig(crtc, timestamp, configTimestamp, x, y, mode, rotation, outputs, cb)
+Applies a crtc configuration; `outputs` is an array of output XIDs, `mode` 0
+with `outputs` `[]` disables the crtc. `cb(err, {status, timestamp})`; a
+non-Success status is reported in `status` (not converted to an error).
+
+### GetCrtcGammaSize(crtc, cb)
+`cb(err, size)` — length of the gamma ramps (0 when unsupported).
+
+### GetCrtcGamma(crtc, cb)
+`cb(err, {size, red, green, blue})` — three arrays of `size` CARD16 values.
+
+### SetCrtcGamma(crtc, red, green, blue)
+Sets the gamma ramps; three equal-length arrays of CARD16, length must equal
+`GetCrtcGammaSize`. No reply.
+
+### GetScreenResourcesCurrent(win, cb)
+Same reply shape as `GetScreenResources` but returns the server's current
+idea of the configuration without forcing a re-probe.
+
+### SetCrtcTransform(crtc, transform, filterName, filterParams)
+Sets the pending crtc transform. `transform` is an array of 9 JS numbers (a
+3x3 row-major matrix) converted to 16.16 FIXED on the wire — values are
+rounded to the nearest 1/65536. `filterName` is a string (e.g. `'bilinear'`,
+may be `''`), `filterParams` an array of numbers (also FIXED on the wire).
+No reply. On crtcs without transform support the server answers BadValue.
+
+### GetCrtcTransform(crtc, cb)
+`cb(err, info)` with
+
+```js
+{
+  pendingTransform,   // [9 numbers], FIXED converted back to floats
+  hasTransforms,      // boolean: crtc supports transforms
+  currentTransform,   // [9 numbers]
+  pendingFilter,      // string
+  pendingParams,      // [numbers]
+  currentFilter,
+  currentParams
+}
+```
+
+### GetPanning(crtc, cb)
+`cb(err, {status, timestamp, left, top, width, height, trackLeft, trackTop,
+trackWidth, trackHeight, borderLeft, borderTop, borderRight,
+borderBottom})`.
+
+### SetPanning(crtc, timestamp, panning, cb)
+`panning` is an object with the same fields `GetPanning` returns (the
+`status`/`timestamp` fields are ignored on input). `cb(err, {status,
+timestamp})`. Servers without a panning hook (e.g. Xvfb) answer with a RANDR
+error.
+
+### SetOutputPrimary(win, output)
+Marks `output` as primary; `output` 0 (None) clears it. No reply.
+
+### GetOutputPrimary(win, cb)
+`cb(err, output)` — the primary output XID, 0 when none is set.
+
+## Events
+
+### RRScreenChangeNotify
+Delivered after `SelectInput` with `NotifyMask.ScreenChange` whenever the
+screen configuration changes. Parsed fields: `name`
+(`'RRScreenChangeNotify'`), `type`, `seq`, `rotation` (new rotation, from the
+event detail byte), `time`, `configtime`, `root`, `requestWindow`, `sizeId`,
+`subpixelOrder`, `width`, `height`, `physWidth`, `physHeight`, `raw`
+(Buffer).
+
+The 1.2 `RRNotify` event (crtc/output/property sub-events selected via
+`CrtcChange`/`OutputChange`/`OutputProperty` masks) has no parser; only
+`ScreenChange` events arrive in usable form.
+
+## Notes
+
+- Version negotiation matters: the server tailors behavior (and some
+  requests only work) after the client announces the version it speaks.
+  `X.require` announces 255.255; the test suite explicitly re-negotiates
+  with `QueryVersion(1, 2, ...)` before touching resources — do the same
+  with the version you target.
+- 16.16 FIXED: crtc transforms and filter parameters travel as 32-bit fixed
+  point (value × 65536). The module converts to/from JS numbers for you;
+  expect quantization to multiples of 1/65536 on read-back.
+- Enums attached to the extension object:
+  - `Randr.NotifyMask = {ScreenChange: 1, CrtcChange: 2, OutputChange: 4,
+    OutputProperty: 8, All: 15}`
+  - `Randr.Rotation = {Rotate_0: 1, Rotate_90: 2, Rotate_180: 4,
+    Rotate_270: 8, Reflect_X: 16, Reflect_Y: 32}` (bitmask)
+  - `Randr.ConfigStatus = {Success: 0, InvalidConfigTime: 1, InvalidTime: 2,
+    Failed: 3}`
+  - `Randr.Connection = {Connected: 0, Disconnected: 1, Unknown: 2}`
+  - `Randr.ModeFlag = {HSyncPositive: 1, HSyncNegative: 2, ...,
+    ClockDivideBy2: 8192}` (mode timing flags bitmask)
+- `GetCrtcInfo` names its list of driven outputs `output` (singular);
+  `SetCrtcConfig` accepts it directly (`info.output`).
+- Mode name strings are concatenated without separators on the wire; the
+  unpacker splits them using each mode's `name_len`.

--- a/docs/ext/record.md
+++ b/docs/ext/record.md
@@ -1,0 +1,142 @@
+# RECORD extension
+
+Intercepts the X protocol itself: a record context selects which clients and
+which request/reply/event/error ranges to capture, and `EnableContext` streams
+the raw intercepted protocol bytes back. This is the mechanism behind
+`xdotool`-style event sniffers and macro recorders.
+
+- Module: `X.require('record', cb)` (X name `RECORD`, version 1.13)
+- Source: [`lib/ext/record.js`](../../lib/ext/record.js) ·
+  Tests: [`test/record.js`](../../test/record.js)
+- Spec: [record.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/recordproto/record.txt)
+
+```js
+// control connection: owns the context
+X.require('record', (err, Record) => {
+    const context = X.AllocID();
+    Record.CreateContext(context, 0, [Record.CS.AllClients], [
+        { deviceEvents: { first: 2, last: 6 } } // core input events
+    ]);
+
+    // dedicated connection: receives the recorded data
+    x11.createClient((err, dpy2) => {
+        dpy2.client.require('record', (err, Record2) => {
+            Record2.EnableContext(context, reply => {
+                if (reply.category === Record.Category.FromServer)
+                    console.log(reply.data); // raw protocol bytes
+            }, err => {
+                // EndOfData: recording stopped
+            });
+        });
+    });
+});
+```
+
+The version is negotiated automatically while requiring (client version 1.13)
+and is available as `Record.major` / `Record.minor`.
+
+## Range and client-spec arguments
+
+`ranges` arguments are arrays of range objects; every key is optional:
+
+```js
+{
+    coreRequests:    {first, last},   // core request opcodes
+    coreReplies:     {first, last},
+    extRequests:     { major: {first, last}, minor: {first, last} },
+    extReplies:      { major: {first, last}, minor: {first, last} },
+    deliveredEvents: {first, last},   // events sent to the client
+    deviceEvents:    {first, last},   // device events (grabs bypassed)
+    errors:          {first, last},
+    clientStarted:   false,           // record new-connection setup
+    clientDied:      false            // record disconnects
+}
+```
+
+Omitted sub-ranges default to `{first: 0, last: 0}` (record nothing of that
+kind). `clientSpecs` arguments are arrays of client XIDs (any XID owned by
+the client, e.g. its `resource_base`) or one of the `Record.CS`
+pseudo-clients.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])`. Called
+automatically by `X.require`.
+
+### CreateContext(context, elementHeader, clientSpecs, ranges)
+Creates record context `context` (a fresh XID from `X.AllocID()`).
+`elementHeader` is a bitmask of `Record.HType` flags controlling optional
+per-element header data in the recorded stream; pass 0 for none. No reply.
+
+### RegisterClients(context, elementHeader, clientSpecs, ranges)
+Adds clients/ranges to an existing context; same arguments as
+`CreateContext`. No reply.
+
+### UnregisterClients(context, clientSpecs)
+Removes the listed clients from the context. No reply.
+
+### GetContext(context, cb)
+`cb(err, {enabled, elementHeader, interceptedClients})` — `enabled` is a
+boolean, `interceptedClients` is an array of
+`{clientResource, ranges}` where `ranges` is a list of fully populated range
+objects (shape as above, with booleans for `clientStarted`/`clientDied`).
+
+### EnableContext(context, onData, cb)
+Starts recording. This is a multi-reply request: the server keeps sending
+replies on this connection until the context is disabled or freed.
+`onData(reply)` is invoked for each reply as it arrives; `cb(err, replies)`
+fires once, when the `EndOfData` reply terminates the series (`replies` is
+the accumulated array of every reply passed to `onData`).
+
+Each reply has the shape:
+
+```js
+{
+    category,       // Record.Category.* (StartOfData first, then data)
+    elementHeader,  // as configured on the context
+    clientSwapped,  // boolean: recorded client uses swapped byte order
+    xidBase,        // XID base of the recorded client
+    serverTime,     // server timestamp of the first element in data
+    recSequenceNum, // recorded client's sequence number
+    data            // Buffer of raw protocol bytes (may be empty)
+}
+```
+
+Wait for the `StartOfData` reply before triggering anything you expect to be
+recorded — only from that point on is the context live.
+
+### DisableContext(context)
+Stops recording; the server finishes the `EnableContext` series with an
+`EndOfData` reply. Must be issued from a different connection than the one
+blocked in `EnableContext`. No reply.
+
+### FreeContext(context)
+Destroys the context (implicitly disabling it). No reply.
+
+## Events / errors
+
+No events. One error, `BadContext` (error code `Record.firstError + 0`),
+raised when a request names an invalid record context. The error object gets
+`badContext` (the offending XID) and message `'RECORD BadContext'`.
+
+## Notes
+
+- Dedicated connection required: while `EnableContext` is active, its
+  connection carries only recording replies — issue every other request
+  (including `DisableContext`/`FreeContext`) from a separate connection. The
+  usual pattern is a control connection that creates and owns the context and
+  a second connection used solely for `EnableContext` (see
+  [`test/record.js`](../../test/record.js)).
+- `reply.data` is raw wire-format protocol, not parsed objects: for a
+  `FromClient` element the first byte is the request opcode; for `FromServer`
+  it is an event code or reply/error marker. Parsing it is up to the caller.
+- Enums attached to the extension object:
+  - `Record.HType = {FromServerTime: 1, FromClientTime: 2,
+    FromClientSequence: 4}` — `elementHeader` bits.
+  - `Record.CS = {CurrentClients: 1, FutureClients: 2, AllClients: 3}` —
+    pseudo-client specs.
+  - `Record.Category = {FromServer: 0, FromClient: 1, ClientStarted: 2,
+    ClientDied: 3, StartOfData: 4, EndOfData: 5}` — reply categories
+    (`EndOfData` is consumed internally to terminate the series and never
+    reaches `onData`).

--- a/docs/ext/render.md
+++ b/docs/ext/render.md
@@ -1,0 +1,223 @@
+# RENDER extension
+
+Client-side compositing: alpha-blended composition of "pictures" (drawables
+plus a pixel format), solid fills, gradients, geometric rasterization
+(triangles, trapezoids) and anti-aliased glyph rendering. This is the
+foundation modern toolkits draw with instead of the core protocol.
+
+- Module: `X.require('render', cb)` (X name `RENDER`)
+- Source: [`lib/ext/render.js`](../../lib/ext/render.js) ·
+  Tests: [`test/render.js`](../../test/render.js)
+- Spec: [renderproto.txt](http://www.x.org/releases/X11R7.6/doc/renderproto/renderproto.txt)
+
+```js
+X.require('render', (err, Render) => {
+    const pixmap = X.AllocID();
+    X.CreatePixmap(pixmap, root, 24, 100, 100);
+    const pic = X.AllocID();
+    Render.CreatePicture(pic, pixmap, Render.rgb24);
+    const grad = X.AllocID();
+    Render.LinearGradient(grad, [0, 0], [100, 0],
+        [[0, [1, 0, 0, 1]], [1, [0, 0, 1, 1]]]);       // red -> blue
+    Render.Composite(Render.PictOp.Src, grad, 0, pic,
+        0, 0, 0, 0, 0, 0, 100, 100);
+});
+```
+
+While requiring, the module calls `QueryPictFormat` and scans the reply for
+the standard formats, exposing their PICTFORMAT ids as properties:
+
+- `Render.mono1` — 1-bit alpha (a1)
+- `Render.rgb24` — 24-bit TrueColor without alpha (x8r8g8b8)
+- `Render.rgba32` — 32-bit TrueColor with alpha (a8r8g8b8)
+- `Render.a8` — 8-bit alpha-only
+
+Colors are given as `[r, g, b, a]` arrays of floats in 0..1 (clamped, scaled
+to 16 bits per channel). Coordinates and matrix/filter values are JS numbers
+converted to 16.16 FIXED (truncated to 1/65536 units) on the wire.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+`cb(err, [major, minor])`. Not called automatically — the extension object
+carries no version fields unless you call this yourself.
+
+### QueryPictFormat(cb) / QueryPictFormats(cb)
+`cb(err, {formats})` — `formats` is an array of 12-element arrays:
+
+```
+[id, type, depth,
+ redShift, redMask, greenShift, greenMask,
+ blueShift, blueMask, alphaShift, alphaMask, colormap]
+```
+
+`QueryPictFormats` is a protocol-name alias. The screen/depth/visual and
+subpixel sections of the reply are not parsed. Called automatically by
+`X.require` to discover the standard formats above.
+
+### QueryPictIndexValues(pictformat, cb)
+`cb(err, values)` — array of `{pixel, red, green, blue, alpha}`. Only valid
+for indexed pictformats; on TrueColor-only servers (e.g. Xvfb) the server
+answers with a Match error.
+
+### CreatePicture(pid, drawable, pictformat, values)
+Creates picture `pid` over `drawable` with the given pictformat. Optional
+`values` object accepts: `repeat` (`Render.Repeat`), `alphaMap` (picture),
+`alphaXOrigin`, `alphaYOrigin`, `clipXOrigin`, `clipYOrigin`, `clipMask`
+(pixmap or 0), `graphicsExposures`, `subwindowMode`, `polyEdge`
+(`Render.PolyEdge`), `polyMode` (`Render.PolyMode`), `dither` (atom),
+`componentAlpha`. No reply.
+
+### ChangePicture(pid, values)
+Changes picture attributes; same `values` keys as `CreatePicture`, and any
+key that is not `undefined` is sent (so 0 works, e.g. `{clipMask: 0}` resets
+the clip). No reply.
+
+### SetPictureClipRectangles(pid, clipXOrigin, clipYOrigin, rects)
+Sets the clip list; `rects` is a flat array `[x1, y1, w1, h1, x2, y2, ...]`.
+No reply.
+
+### FreePicture(pid)
+No reply.
+
+### Composite(op, src, mask, dst, srcX, srcY, maskX, maskY, dstX, dstY, width, height)
+The central operation: composites `src` (optionally through `mask`, 0 =
+none) into `dst` with operator `op` (`Render.PictOp`). No reply.
+
+### Trapezoids(op, src, srcX, srcY, dst, maskFormat, trapz)
+Rasterizes trapezoids; `trapz` is a flat list of 10 values per trapezoid:
+`top, bottom, leftX1, leftY1, leftX2, leftY2, rightX1, rightY1, rightX2,
+rightY2` (floats, converted to FIXED). Deprecated by the Render spec in
+favor of `Triangles`/`AddTraps`, but functional. No reply.
+
+### Triangles(op, src, srcX, srcY, dst, maskFormat, tris)
+Rasterizes triangles; `tris` is a flat array of vertex coordinates
+`[x1, y1, x2, y2, x3, y3, ...]` (6 numbers per triangle, floats).
+`maskFormat` is a pictformat or 0. No reply.
+
+### TriStrip(op, src, srcX, srcY, dst, maskFormat, points)
+Triangle strip; `points` is a flat array `[x1, y1, x2, y2, ...]`, each point
+after the second adds a triangle. No reply.
+
+### TriFan(op, src, srcX, srcY, dst, maskFormat, points)
+Triangle fan; same `points` layout as `TriStrip`, first point shared by all
+triangles. No reply.
+
+### CreateGlyphSet(gsid, format)
+Creates glyph set `gsid` whose glyphs use pictformat `format` (typically
+`Render.a8` for anti-aliased or `Render.mono1` for bitmap glyphs). No reply.
+
+### ReferenceGlyphSet(gsid, existing)
+Makes `gsid` a new reference to the `existing` glyph set. No reply.
+
+### FreeGlyphSet(gsid)
+No reply.
+
+### AddGlyphs(gsid, glyphs)
+Uploads glyph images. Each glyph is
+`{id, width, height, x, y, offX, offY, image}` where `image` is a Buffer of
+`width * height` bytes (for a8), `x`/`y` place the origin relative to the
+bitmap, and `offX`/`offY` (pen advance) are given in 1/64 pixel units —
+divided by 64 before sending. Rows are re-padded to a 4-byte stride
+automatically. No reply. Caveats: the passed glyph objects are mutated
+(image/width/offX/offY rewritten), and the request always uses BIG-REQUESTS
+length encoding, so it requires the default auto-enabled
+[ext/big-requests.md](big-requests.md).
+
+### AddGlyphsFromPicture(gsid, src, glyphs)
+Copies glyphs from picture `src`; glyph entries additionally carry
+`srcX`/`srcY`. No reply. As far as we know no X server implements this
+request (expect a Bad Implementation error).
+
+### FreeGlyphs(gsid, glyphIds)
+Removes the glyphs with the given ids from the set. No reply. Freed glyphs
+are silently skipped by later `CompositeGlyphs`.
+
+### CompositeGlyphs8/16/32(op, src, dst, maskFormat, gsid, srcX, srcY, glyphs)
+Draws glyph runs from glyph set `gsid` into `dst` (also callable as
+`CompositeGlyphs(glyphBits, op, ...)` with `glyphBits` 8/16/32 selecting the
+glyph index width). `glyphs` is an array whose entries are:
+
+- `'string'` — glyph indices are the char codes, drawn at the current pen
+  position (0,0 delta);
+- `[dx, dy, 'string']` — pen moves by `dx`,`dy` before drawing;
+- a number — switches to that glyph set for subsequent entries.
+
+Strings are limited to 254 glyphs per entry (longer strings are not split
+automatically). No reply.
+
+### FillRectangles(op, pid, color, rects)
+Fills rectangles with a solid `color` (`[r, g, b, a]` floats); `rects` is a
+flat array `[x1, y1, w1, h1, ...]`. No reply.
+
+### CreateCursor(cid, source, x, y)
+Creates cursor `cid` from picture `source` — which must be an ARGB32
+(`Render.rgba32`) picture — with hotspot `x`,`y`. No reply.
+
+### SetPictureTransform(pid, matrix)
+Sets the projective transform applied when `pid` is used as a source;
+`matrix` is an array of exactly 9 numbers (3x3 row-major). Throws on wrong
+length or non-number elements. No reply.
+
+### QueryFilters(cb)
+`cb(err, [aliases, filters])` — `filters` is an array of filter name
+strings, `aliases` an array of CARD16 indices mapping each filter to the one
+it aliases (0xffff = no alias). Always queries the first screen's root
+drawable.
+
+### SetPictureFilter(pid, name, filterParams)
+Sets the source filter. Known names are validated client-side:
+`'nearest'`/`'bilinear'`/`'fast'`/`'good'`/`'best'` (no parameters),
+`'convolution'` (flat array `[w, h, elem1, ..., elemWxH]`), `'binomial'` and
+`'gaussian'` (exactly 1 number). Any other name throws, so server-specific
+filters reported by `QueryFilters` beyond this list cannot be set. No reply.
+
+### CreateAnimCursor(cid, cursors)
+Creates an animated cursor; `cursors` is an array of `[cursor, delayMs]`
+pairs (or `{cursor, delay}` objects). No reply.
+
+### AddTraps(pic, offX, offY, trapList)
+Adds trapezoids to an alpha picture; `trapList` is a flat array of FIXED
+values (6 per trap: top `l, r, y` then bottom `l, r, y`), offset by
+`offX`,`offY`. No reply.
+
+### CreateSolidFill(pid, r, g, b, a)
+Creates a solid-fill source picture; channels are floats 0..1. No reply.
+
+### LinearGradient(pid, p1, p2, stops) / CreateLinearGradient(...)
+Creates a linear gradient source from point `p1` to `p2` (`[x, y]` arrays).
+`stops` is an array of `[offset, [r, g, b, a]]` pairs, offsets 0..1
+ascending. No reply. `CreateLinearGradient` is a protocol-name alias.
+
+### RadialGradient(pid, p1, p2, r1, r2, stops) / CreateRadialGradient(...)
+Radial gradient between the circle at `p1` with radius `r1` and the circle
+at `p2` with radius `r2`; same `stops` format. No reply.
+
+### ConicalGradient(pid, center, angle, stops) / CreateConicalGradient(...)
+Conical gradient around `center` (`[x, y]`) starting at `angle` degrees;
+same `stops` format. No reply.
+
+## Events / errors
+
+No events. Five extension errors get descriptive messages via registered
+error parsers: PictFormat, Picture, PictOp, GlyphSet and Glyph ("...argument
+does not name a defined ...").
+
+## Notes
+
+- Standard-format discovery happens once at require time; if a server lacks
+  one of the standard formats the corresponding property (`mono1`, `rgb24`,
+  `rgba32`, `a8`) is simply `undefined`.
+- Enums attached to the extension object:
+  - `Render.PictOp` — compositing operators: the PictOpClear..Saturate range
+    (0..13), Disjoint\* (0x10..0x1b), Conjoint\* (0x20..0x2b) and the 0.11
+    blend modes Multiply..HSLLuminosity (0x30..0x3e).
+  - `Render.PolyEdge = {Sharp: 0, Smooth: 1}`,
+    `Render.PolyMode = {Precise: 0, Imprecise: 1}`
+  - `Render.Repeat = {None: 0, Normal: 1, Pad: 2, Reflect: 3}`
+  - `Render.Subpixel = {Unknown: 0, HorizontalRGB: 1, HorizontalBGR: 2,
+    VerticalRGB: 3, VerticalBGR: 4, None: 5}`
+  - `Render.Filters = {Nearest: 'nearest', Bilinear: 'bilinear',
+    Convolution: 'convolution', Fast: 'fast', Good: 'good', Best: 'best'}`
+- FIXED conversion truncates toward zero (`parseInt(f * 65536)`), so tiny
+  negative values round up.

--- a/docs/ext/res.md
+++ b/docs/ext/res.md
@@ -1,0 +1,80 @@
+# X-Resource extension
+
+Server introspection: enumerates connected clients, the resources (windows,
+pixmaps, GCs, ...) each one owns and how much pixmap memory they consume.
+Version 1.2 adds client PID lookup and exact per-resource byte accounting.
+
+- Module: `X.require('res', cb)` (X name `X-Resource`, version 1.2)
+- Source: [`lib/ext/res.js`](../../lib/ext/res.js) ·
+  Tests: [`test/res.js`](../../test/res.js)
+- Spec: [resproto.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/resourceproto/resproto.txt)
+
+```js
+X.require('res', (err, Res) => {
+    Res.QueryClients((err, clients) => {
+        // [{resourceBase, resourceMask}, ...] — one entry per connection
+        Res.QueryClientResources(clients[0].resourceBase, (err, types) => {
+            // [{resourceType, count}, ...] — resourceType is an atom
+        });
+    });
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`Res.major` / `Res.minor`.
+
+Clients are identified by any XID inside their resource range — typically the
+`resourceBase` from `QueryClients` (for your own connection,
+`display.resource_base`).
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])`. Called
+automatically by `X.require` with 1.2.
+
+### QueryClients(cb)
+`cb(err, clients)` — array of `{resourceBase, resourceMask}` XID ranges, one
+per connected client.
+
+### QueryClientResources(xid, cb)
+`xid`: any XID in the target client's range. `cb(err, types)` — array of
+`{resourceType, count}` for each resource type the client owns;
+`resourceType` is an atom (e.g. 20 = `PIXMAP`).
+
+### QueryClientPixmapBytes(xid, cb)
+`cb(err, bytes)` — estimated pixmap memory usage of the client owning `xid`,
+in bytes. The 64-bit bytes/bytesOverflow pair is composed into a plain JS
+number, exact only up to 2^53 - 1.
+
+### QueryClientIds(specs, cb)
+Since 1.2. `specs` is an array of `{client, mask}`: `client` is an XID in the
+target client's range or 0 for all clients; `mask` is a set of
+`Res.ClientIdMask` bits or 0 for all id methods. `cb(err, ids)` — array of
+`{client, mask, value}` where `value` is a list of CARD32s: a single PID for
+`LocalClientPID`, empty for `ClientXID` (the id is the `client` field
+itself).
+
+### QueryResourceBytes(client, specs, cb)
+Since 1.2. `client`: XID restricting the query to one client, or 0 for all.
+`specs` is an array of `{resource, type}`: `resource` is an XID or 0 (all
+resources), `type` an atom or 0 (any type). `cb(err, sizes)` — array of size
+records `{resource, type, bytes, refCount, useCount, crossReferences}`;
+`crossReferences` is a list of `{resource, type, bytes, refCount, useCount}`
+for resources referenced by the main one.
+
+## Events / errors
+
+None.
+
+## Notes
+
+- `Res.ClientIdMask = {ClientXID: 1, LocalClientPID: 2}`.
+- `QueryClientIds` and `QueryResourceBytes` need a server speaking
+  X-Resource 1.2; guard with a version check
+  (`Res.major > 1 || Res.minor >= 2`) as the tests do.
+- `LocalClientPID` only yields a PID for clients local to the server host;
+  remote clients report no value.
+- Byte counts from `QueryClientPixmapBytes`/`QueryResourceBytes` include
+  scanline padding, so a pixmap may account for more than
+  `width * height * bytesPerPixel`.

--- a/docs/ext/screen-saver.md
+++ b/docs/ext/screen-saver.md
@@ -1,0 +1,103 @@
+# MIT-SCREEN-SAVER extension
+
+Lets a client find out about the state of the built-in screen saver, be
+notified when it activates or cycles, provide its own saver window ("external
+saver"), and temporarily suspend saver activation. Complements the core
+`SetScreenSaver` / `GetScreenSaver` / `ForceScreenSaver` requests
+([core-requests.md](../core-requests.md)).
+
+- Module: `X.require('screen-saver', cb)` (X name `MIT-SCREEN-SAVER`,
+  version 1.1)
+- Source: [`lib/ext/screen-saver.js`](../../lib/ext/screen-saver.js) ·
+  Tests: [`test/screen-saver.js`](../../test/screen-saver.js)
+- Spec: [saver.pdf](http://www.x.org/releases/X11R7.6/doc/scrnsaverproto/saver.pdf)
+
+```js
+X.require('screen-saver', (err, Saver) => {
+    Saver.QueryInfo(root, (err, info) => {
+        // { state, window, until, idle, eventMask, kind }
+    });
+    Saver.SelectInput(root, Saver.eventMask.Notify);
+    X.on('event', ev => {
+        if (ev.name === 'ScreenSaverNotify')
+            console.log('saver state', ev.state, 'forced', ev.forced);
+    });
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`Saver.major` / `Saver.minor`.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Opcode 0. Negotiates the protocol version. `cb(err, [major, minor])` — the
+version the server will speak. Called automatically by `X.require` with 1.1.
+The client version is sent as two single bytes (CARD8) per the wire
+protocol.
+
+### QueryInfo(drawable, cb)
+Opcode 1. `cb(err, info)` — saver state for the screen of `drawable`:
+
+- `state` — current `Saver.State` (`Off`, `On`, or `Disabled`)
+- `window` — XID of the saver window (valid only while the saver is on)
+- `until` — with state `Off`: milliseconds until the saver activates
+  (0 = never); with state `On`: milliseconds until it cycles
+- `idle` — milliseconds since the last user input
+- `eventMask` — events this client has selected with `SelectInput`
+- `kind` — `Saver.Kind` of the current/last saver (`Blanked`, `Internal`,
+  `External`)
+
+### SelectInput(drawable, eventMask)
+Opcode 2. Selects `ScreenSaverNotify` delivery for the screen of `drawable`.
+`eventMask` is a bitwise OR of `Saver.eventMask` (`Notify: 1` — on/off
+transitions, `Cycle: 2` — cycle intervals); `0` deselects. No reply.
+
+### SetAttributes(drawable, x, y, width, height, borderWidth, windowClass, depth, visual, [values])
+Opcode 3. Registers this client as the external screen saver for the screen
+of `drawable` and describes the saver window the server will create when the
+saver next activates. Geometry and `windowClass`/`depth`/`visual` follow
+core `CreateWindow` (`0` = CopyFromParent). `values` is an optional object
+of CreateWindow-style attributes; accepted keys: `backgroundPixmap`,
+`backgroundPixel`, `borderPixmap`, `borderPixel`, `bitGravity`,
+`winGravity`, `backingStore`, `backingPlanes`, `backingPixel`,
+`overrideRedirect`, `saveUnder`, `eventMask`, `doNotPropagateMask`,
+`colormap`, `cursor` (each a 32-bit value). No reply.
+
+### UnsetAttributes(drawable)
+Opcode 4. Withdraws this client's external saver registration for the screen
+of `drawable`. No reply.
+
+### Suspend(suspend)
+Opcode 5. `suspend` truthy disables saver activation, falsy re-enables it.
+Suspensions are counted per client by the server, so always pair
+`Suspend(true)` with a later `Suspend(false)`; all of a client's suspensions
+are dropped when it disconnects. No reply.
+
+## Events
+
+### ScreenSaverNotify
+Delivered after `SelectInput`. Parsed fields:
+
+- `state` — new saver state (`Saver.State`; `Cycle: 2` for cycle events)
+- `seq` — sequence number
+- `time` — server timestamp
+- `root` — root window of the screen
+- `saverWindow` — the saver window (with state `On`)
+- `kind` — `Saver.Kind` of the saver
+- `forced` — `1` when the transition was caused by `ForceScreenSaver`,
+  else `0`
+- `name` — `'ScreenSaverNotify'`
+
+## Notes
+
+- Enums: `Saver.State = {Off: 0, On: 1, Cycle: 2, Disabled: 3}`,
+  `Saver.Kind = {Blanked: 0, Internal: 1, External: 2}`,
+  `Saver.eventMask = {Notify: 1, Cycle: 2}`,
+  `Saver.events = {ScreenSaverNotify: 0}`.
+- `QueryInfo`'s `state` reports `Disabled` when the core saver timeout is 0;
+  the `Cycle` value only appears in the `state` field of events.
+- On an idle Xvfb the saver may already be `On`; tests treat any state in
+  0–3 as valid.
+- `SetAttributes` describes a window the *server* creates later; it does not
+  itself create or map a window and returns no XID.

--- a/docs/ext/shape.md
+++ b/docs/ext/shape.md
@@ -1,0 +1,104 @@
+# SHAPE extension
+
+Gives windows non-rectangular shapes. A window has three shapes: `Bounding`
+(the visible outline), `Clip` (where the window may draw) and `Input` (where
+it receives pointer events); each can be set from rectangles, a bitmap, or
+another window's shape.
+
+- Module: `X.require('shape', cb)` (X name `SHAPE`, version 1.1)
+- Source: [`lib/ext/shape.js`](../../lib/ext/shape.js) ·
+  Tests: [`test/shape.js`](../../test/shape.js)
+- Spec: [shape.pdf](http://www.x.org/releases/X11R7.6/doc/xextproto/shape.pdf)
+
+```js
+X.require('shape', (err, Shape) => {
+    // two 10x10 squares as the visible outline of wid
+    Shape.Rectangles(Shape.Op.Set, Shape.Kind.Bounding, wid, 0, 0,
+        [[0, 0, 10, 10], [20, 20, 10, 10]]);
+    Shape.GetRectangles(wid, Shape.Kind.Bounding, (err, res) => {
+        // res.ordering, res.rectangles -> [[x, y, width, height], ...]
+    });
+});
+```
+
+Unlike most extensions in this library, the version is *not* negotiated while
+requiring: `Shape.major` / `Shape.minor` are undefined; call `QueryVersion`
+yourself if you need the server's version.
+
+Rectangles are `[x, y, width, height]` arrays (not objects — compare
+[ext/fixes.md](fixes.md)).
+
+## Requests
+
+### QueryVersion(cb)
+Opcode 0. `cb(err, [major, minor])` — the SHAPE version the server supports.
+Takes no client version arguments.
+
+### Rectangles(op, kind, window, x, y, rectangles, [ordering])
+Opcode 1. Combines the union of `rectangles` (array of
+`[x, y, width, height]`), offset by `x`/`y` from the window origin, with the
+`kind` shape of `window` using operation `op` (see the enums under Notes).
+`ordering` is a hint from `Shape.Ordering` describing how the rectangles are
+sorted; defaults to `Shape.Ordering.Unsorted`. No reply.
+
+### Mask(op, kind, window, x, y, bitmap)
+Opcode 2. Like `Rectangles`, but takes the set bits of `bitmap` (a depth-1
+pixmap XID, or `0` for `None` = remove the shape) as the source region.
+No reply.
+
+### Combine(op, destKind, srcKind, destWindow, x, y, srcWindow)
+Opcode 3. Combines the `srcKind` shape of `srcWindow`, offset by `x`/`y`,
+into the `destKind` shape of `destWindow` using `op`. No reply.
+
+### Offset(kind, window, x, y)
+Opcode 4. Moves the `kind` shape of `window` by the signed offsets `x`, `y`.
+No reply.
+
+### QueryExtents(window, cb)
+Opcode 5. `cb(err, extents)` — `{boundingShaped, clipShaped, bounding,
+clip}`: the two booleans tell whether a bounding/clip shape is set, and
+`bounding`/`clip` are `{x, y, width, height}` extents rectangles (when no
+shape is set, the full window geometry including/excluding the border).
+
+### SelectInput(window, enable)
+Opcode 6. Enables (`enable` = 1) or disables (0) `ShapeNotify` delivery for
+`window` to this client. No reply.
+
+### InputSelected(window, cb)
+Opcode 7. `cb(err, enabled)` — `1` when this client has `ShapeNotify`
+delivery selected on `window`, else `0`.
+
+### GetRectangles(window, kind, cb)
+Opcode 8. `cb(err, res)` — `{ordering, rectangles}`: the `kind` shape of
+`window` as an array of `[x, y, width, height]` rectangles, and the
+`Shape.Ordering` value the server reports for the list. When no such shape
+is set, one rectangle covering the whole window is returned.
+
+## Events
+
+### ShapeNotify
+Delivered after `SelectInput(window, 1)` whenever a shape of the window
+changes. Parsed fields:
+
+- `type` — event code
+- `kind` — which shape changed (`Shape.Kind`)
+- `seq` — sequence number
+- `window` — the shaped window
+- `x`, `y`, `width`, `height` — extents of the new shape
+- `time` — server timestamp
+- `shaped` — `1` when a shape is now set, `0` when it was removed
+- `name` — `'ShapeNotify'`
+
+## Notes
+
+- Enums:
+  `Shape.Kind = {Bounding: 0, Clip: 1, Input: 2}`,
+  `Shape.Op = {Set: 0, Union: 1, Intersect: 2, Subtract: 3, Invert: 4}`,
+  `Shape.Ordering = {Unsorted: 0, YSorted: 1, YXSorted: 2, YXBanded: 3}`,
+  `Shape.events = {ShapeNotify: 0}`.
+- The server may re-band rectangles: `GetRectangles` can return the same
+  region as different (typically YXBanded) rectangles in a different order
+  than they were set.
+- `Input` shapes require SHAPE 1.1 (any current server). XFIXES regions can
+  also be applied as window shapes via `Fixes.SetWindowShapeRegion`
+  ([ext/fixes.md](fixes.md)).

--- a/docs/ext/shm.md
+++ b/docs/ext/shm.md
@@ -1,0 +1,106 @@
+# MIT-SHM extension
+
+Transfers images between client and server through SysV shared memory instead
+of the X socket — the fast path for large `PutImage`/`GetImage` traffic when
+client and server share a machine. This module implements the wire protocol
+(SHM 1.1); obtaining an actual shared memory segment is left to the caller,
+see [Notes](#notes).
+
+- Module: `X.require('shm', cb)` (X name `MIT-SHM`, version 1.1)
+- Source: [`lib/ext/shm.js`](../../lib/ext/shm.js) ·
+  Tests: [`test/shm.js`](../../test/shm.js)
+- Spec: [shm.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/xextproto/shm.txt)
+
+```js
+X.require('shm', (err, Shm) => {
+    // shmid must come from an external shmget() — see Notes
+    const seg = X.AllocID();
+    Shm.Attach(seg, shmid, false);
+    Shm.PutImage(wid, gc, {
+        totalWidth: 640, totalHeight: 480,
+        srcX: 0, srcY: 0, srcWidth: 640, srcHeight: 480,
+        dstX: 0, dstY: 0,
+        depth: 24, format: Shm.ImageFormat.ZPixmap,
+        sendEvent: true, shmseg: seg, offset: 0
+    });
+    X.on('event', ev => {
+        // ShmCompletion: the server is done reading the segment
+    });
+});
+```
+
+`QueryVersion` is issued automatically while requiring; its results are
+cached on the extension object as `Shm.major`, `Shm.minor`,
+`Shm.sharedPixmaps`, `Shm.pixmapFormat`, `Shm.uid` and `Shm.gid`.
+
+## Requests
+
+### QueryVersion(cb)
+Takes no version arguments. `cb(err, {sharedPixmaps, majorVersion,
+minorVersion, uid, gid, pixmapFormat})` — `sharedPixmaps` is a boolean,
+`uid`/`gid` identify the server process, `pixmapFormat` is the image format
+shared pixmaps must use (only meaningful when `sharedPixmaps` is true).
+Called automatically by `X.require`.
+
+### Attach(shmseg, shmid, readOnly)
+Attaches the SysV segment `shmid` to the server as SEG XID `shmseg` (a fresh
+XID from `X.AllocID()`). With `readOnly` truthy the server maps it
+read-only, which makes `GetImage` into it fail. No reply.
+
+### Detach(shmseg)
+Detaches the segment from the server; the SEG XID becomes invalid. No reply.
+
+### PutImage(drawable, gc, img)
+Copies a subrectangle of the image stored in a shared segment to `drawable`.
+`img` is `{totalWidth, totalHeight, srcX, srcY, srcWidth, srcHeight, dstX,
+dstY, depth, format, sendEvent, shmseg, offset}` — `totalWidth`/`totalHeight`
+describe the full image in the segment, `src*` select the subrectangle,
+`format` is a `Shm.ImageFormat` value and `offset` is the byte offset of the
+image inside the segment. When `sendEvent` is truthy the server sends a
+`ShmCompletion` event after it has finished reading the segment (until then
+the client must not modify the data). No reply.
+
+### GetImage(drawable, x, y, width, height, planeMask, format, shmseg, offset, cb)
+Like core `GetImage`, but the pixel data is written into the shared segment
+at `offset` instead of being returned in the reply.
+`cb(err, {depth, visual, size})` — `size` is the number of bytes written.
+
+### CreatePixmap(pid, drawable, width, height, depth, shmseg, offset)
+Creates pixmap `pid` (a fresh XID) whose storage is the shared segment at
+`offset`; drawing into the pixmap changes the segment and vice versa. Only
+valid when `Shm.sharedPixmaps` is true, and the data layout must match
+`Shm.pixmapFormat`. No reply.
+
+## Events / errors
+
+### ShmCompletion
+Sent after a `PutImage` with `sendEvent` once the server has finished reading
+the segment. Fields: `{name: 'ShmCompletion', type, seq, drawable,
+minorEvent, majorEvent, shmseg, offset}` — `majorEvent`/`minorEvent` identify
+the completed request (the SHM major opcode and minor opcode 3).
+
+### BadSeg
+Error code `Shm.firstError + Shm.errors.BadSeg` (`Shm.errors = {BadSeg: 0}`),
+raised when a request names a SEG XID that is not an attached segment; the
+error's `badParam` carries the offending XID. Note that `Attach` with a bogus
+`shmid` fails with core `BadAccess` instead — the XID is fine, the server's
+`shmat()` is what fails.
+
+## Notes
+
+- Pure-Node limitation: Node.js has no built-in binding to SysV shared memory
+  (`shmget`/`shmat`), and this package's zero-runtime-dependency rule rules
+  out native addons. The module therefore only speaks the wire protocol — to
+  actually use it you must obtain a `shmid` (and a mapping of the segment in
+  your process) from an optional native module or an external helper. Without
+  one, every request except `QueryVersion` will error with `BadSeg` or
+  `BadAccess`; [`test/shm.js`](../../test/shm.js) validates the encoding via
+  exactly those controlled errors.
+- AttachFd (minor opcode 6, SHM 1.2) is not implemented: it passes a file
+  descriptor over the unix socket using `SCM_RIGHTS` ancillary data, which a
+  plain Node `net.Socket` cannot send. The same applies to
+  CreateSegment (opcode 7).
+- Shared memory only works when client and server run on the same machine
+  (and, for `Attach`, when the server's uid/gid may access the segment).
+- `Shm.ImageFormat = {XYBitmap: 0, XYPixmap: 1, ZPixmap: 2}` — the core
+  image format codes, reused for `format` arguments and `pixmapFormat`.

--- a/docs/ext/sync.md
+++ b/docs/ext/sync.md
@@ -1,0 +1,161 @@
+# SYNC extension
+
+Server-side synchronization primitives: 64-bit counters that clients can
+create, change and wait on, alarms that fire events when a counter crosses a
+threshold, client scheduling priorities, and (since 3.1) fences bound to a
+drawable's rendering.
+
+- Module: `X.require('sync', cb)` (X name `SYNC`, version 3.1)
+- Source: [`lib/ext/sync.js`](../../lib/ext/sync.js) ·
+  Tests: [`test/sync.js`](../../test/sync.js)
+- Spec: [sync.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/xextproto/sync.txt)
+
+```js
+X.require('sync', (err, Sync) => {
+    const counter = X.AllocID();
+    Sync.CreateCounter(counter, 100);
+    Sync.QueryCounter(counter, (err, value) => {
+        // value === 100
+    });
+    const alarm = X.AllocID();
+    Sync.CreateAlarm(alarm, {
+        counter,
+        valueType: Sync.ValueType.Absolute,
+        value: 1000,
+        testType: Sync.TestType.PositiveComparison,
+        delta: 1,
+        events: 1
+    });
+    X.on('event', ev => {
+        // AlarmNotify fires when the counter reaches 1000
+    });
+});
+```
+
+`Initialize` is issued automatically while requiring (the protocol demands it
+before any other SYNC request); the negotiated version is available as
+`Sync.major` / `Sync.minor`.
+
+All counter, alarm-value and delta arguments are plain JS numbers. On the wire
+they are INT64; see [Notes](#notes) for the precision caveat.
+
+## Requests
+
+### Initialize(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])`. Called
+automatically by `X.require` with 3.1.
+
+### ListSystemCounters(cb)
+`cb(err, counters)` — array of `{counter, resolution, name}`: the counter
+XID, its resolution (a number) and its ASCII name. Every server provides at
+least `SERVERTIME`.
+
+### CreateCounter(id, initialValue)
+Creates a counter with a fresh XID `id` (from `X.AllocID()`) holding
+`initialValue`. No reply.
+
+### SetCounter(counter, value)
+Sets the counter to `value` (may be negative). No reply.
+
+### ChangeCounter(counter, amount)
+Adds `amount` (may be negative) to the counter. No reply.
+
+### QueryCounter(counter, cb)
+`cb(err, value)` — the counter's current value as a number.
+
+### DestroyCounter(counter)
+Destroys the counter; pending Awaits on it are released and triggered alarms
+on it become Inactive. No reply.
+
+### Await(waitList)
+`waitList` is an array of wait conditions:
+`{counter, valueType, value, testType, eventThreshold}` (omitted fields
+default to 0). The server stops processing further requests from this
+connection until at least one condition is satisfied — replies to requests
+sent after `Await` only arrive once it unblocks. If the counter jumps past
+`value` by more than `eventThreshold`, a `CounterNotify` event is sent.
+No reply.
+
+### CreateAlarm(id, values)
+Creates alarm `id` (a fresh XID). `values` is a value-mask style object with
+any of `{counter, valueType, value, testType, delta, events}`; omitted
+attributes keep server defaults. When the trigger condition on `counter`
+becomes true the alarm sends `AlarmNotify` (if `events` is set) and re-arms
+itself by adding `delta` to the trigger value. No reply.
+
+### ChangeAlarm(id, values)
+Changes alarm attributes; same `values` object as `CreateAlarm`. No reply.
+
+### QueryAlarm(alarm, cb)
+`cb(err, {trigger, delta, events, state})` where `trigger` is
+`{counter, waitType, waitValue, testType}`, `events` is a boolean and
+`state` is one of `Sync.AlarmState`.
+
+### DestroyAlarm(alarm)
+Destroys the alarm. No reply.
+
+### SetPriority(id, priority)
+Sets the scheduling priority (INT32, higher runs first) of the client owning
+XID `id`; `id = 0` means the requesting client. No reply.
+
+### GetPriority(id, cb)
+`cb(err, priority)` — the client's current priority. `id = 0` for the
+requesting client.
+
+### CreateFence(drawable, fence, initiallyTriggered)
+SYNC 3.1. Creates fence `fence` (a fresh XID) on the screen of `drawable`,
+initially triggered when `initiallyTriggered` is truthy. No reply.
+
+### TriggerFence(fence)
+Asks the server to set the fence to triggered once all rendering affecting it
+has completed. No reply.
+
+### ResetFence(fence)
+Puts a triggered fence back into the untriggered state. No reply.
+
+### DestroyFence(fence)
+Destroys the fence. No reply.
+
+### QueryFence(fence, cb)
+`cb(err, triggered)` — boolean, current fence state.
+
+### AwaitFence(fenceList)
+`fenceList` is an array of fence XIDs. Like `Await`, blocks further request
+processing for this connection until every listed fence is triggered.
+No reply.
+
+## Events / errors
+
+### CounterNotify
+Sent when an `Await` condition is satisfied with the counter overshooting the
+awaited value by more than the condition's `eventThreshold`, or when an
+awaited counter is destroyed. Fields:
+`{type, seq, name: 'CounterNotify', kind, counter, waitValue, counterValue,
+time, count, destroyed}` — `count` is the number of further CounterNotify
+events following this one, `destroyed` is a boolean.
+
+### AlarmNotify
+Sent when an alarm with `events` enabled triggers or changes state. Fields:
+`{type, seq, name: 'AlarmNotify', kind, alarm, counterValue, alarmValue,
+time, state}` — `state` is one of `Sync.AlarmState`.
+
+## Notes
+
+- INT64 precision: counter/alarm values travel as 64-bit integers on the wire
+  but are composed into plain JS numbers (no BigInt in the public API).
+  Values with magnitude above 2^53 lose precision; everything up to
+  ±2^53 - 1 round-trips exactly (verified up to 2^40 in the tests).
+- Enums attached to the extension object:
+  - `Sync.ValueType = {Absolute: 0, Relative: 1}`
+  - `Sync.TestType = {PositiveTransition: 0, NegativeTransition: 1,
+    PositiveComparison: 2, NegativeComparison: 3}`
+  - `Sync.AlarmState = {Active: 0, Inactive: 1, Destroyed: 2}`
+  - `Sync.CA = {Counter: 1, ValueType: 2, Value: 4, TestType: 8, Delta: 16,
+    Events: 32}` — the value mask bits; `CreateAlarm`/`ChangeAlarm` build the
+    mask automatically from the keys present in `values`, so `CA` is only
+    needed for reference.
+- Fence requests require SYNC 3.1; check `Sync.minor >= 1` before using them
+  (the tests skip fences on older servers).
+- `Await`/`AwaitFence` block on the server side only — the Node process keeps
+  running; it is the replies on this connection that stall. Use a second
+  connection to satisfy the condition (see the Await tests).

--- a/docs/ext/xc-misc.md
+++ b/docs/ext/xc-misc.md
@@ -1,0 +1,47 @@
+# XC-MISC extension
+
+Lets a long-running client ask the server which resource IDs (XIDs) are free
+again, so it can keep allocating IDs after exhausting its initial range.
+
+- Module: `X.require('xc-misc', cb)` (X name `XC-MISC`, version 1.1)
+- Source: [`lib/ext/xc-misc.js`](../../lib/ext/xc-misc.js) ·
+  Tests: [`test/xc-misc.js`](../../test/xc-misc.js)
+- Spec: [xc-misc.pdf](http://www.x.org/releases/X11R7.6/doc/xcmiscproto/xc-misc.pdf)
+
+```js
+X.require('xc-misc', (err, XCMisc) => {
+    XCMisc.GetXIDRange((err, range) => {
+        // {startId, count} — a contiguous block of unused XIDs
+    });
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`XCMisc.major` / `XCMisc.minor`.
+
+## Requests
+
+### GetVersion(clientMajor, clientMinor, cb)
+`cb(err, [major, minor])` — the XC-MISC version the server will speak.
+Called automatically by `X.require`. `QueryVersion` is kept as an alias for
+backwards compatibility (the spec name is GetVersion).
+
+### GetXIDRange(cb)
+`cb(err, {startId, count})` — the largest contiguous range of XIDs the
+server currently considers unused for this client. `count` 1 with `startId`
+0 means no IDs are available.
+
+### GetXIDList(count, cb)
+`cb(err, ids)` — an array of up to `count` individual unused XIDs (possibly
+fewer when the server cannot find that many).
+
+## Events / errors
+
+None.
+
+## Notes
+
+- The client's built-in `X.AllocID` allocator does not use this extension
+  yet; XIDs released with `X.ReleaseID` are recycled locally. XC-MISC is the
+  server-side mechanism for reclaiming IDs once the handshake-assigned range
+  is exhausted.

--- a/docs/ext/xinerama.md
+++ b/docs/ext/xinerama.md
@@ -1,0 +1,55 @@
+# XINERAMA extension
+
+Reports how multiple physical monitors are combined into one logical screen.
+On servers where Xinerama is inactive (single head), the query requests still
+work and report zero screens.
+
+- Module: `X.require('xinerama', cb)` (X name `XINERAMA`, version 1.1)
+- Source: [`lib/ext/xinerama.js`](../../lib/ext/xinerama.js) ·
+  Tests: [`test/xinerama.js`](../../test/xinerama.js)
+- Spec: [xinerama.txt](https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/specs/xinerama/xinerama.txt)
+
+```js
+X.require('xinerama', (err, Xinerama) => {
+    Xinerama.QueryScreens((err, screens) => {
+        // [{x, y, width, height}, ...] — one entry per monitor
+    });
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`Xinerama.major` / `Xinerama.minor`.
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version. `cb(err, [major, minor])` — the version the
+server will speak. Called automatically by `X.require`.
+
+### GetState(window, cb)
+`cb(err, state)` — `1` when Xinerama is active for the screen `window` is on,
+else `0`.
+
+### GetScreenCount(window, cb)
+`cb(err, count)` — number of physical monitors composing the screen.
+
+### GetScreenSize(window, screen, cb)
+`cb(err, {width, height})` — size of monitor number `screen` (0-based).
+
+### IsActive(cb)
+`cb(err, state)` — non-zero when Xinerama is active. Prefer this over
+`GetState` on modern servers.
+
+### QueryScreens(cb)
+`cb(err, screens)` — array of `{x, y, width, height}` monitor geometries in
+screen coordinates. Empty when Xinerama is inactive.
+
+## Events / errors
+
+None.
+
+## Notes
+
+- On an inactive server (`IsActive` → 0) `QueryScreens` returns `[]`;
+  RANDR ([ext/randr.md](randr.md)) is the modern interface to per-output
+  geometry and is what most compositors use today.

--- a/docs/ext/xinput.md
+++ b/docs/ext/xinput.md
@@ -1,0 +1,97 @@
+# XInputExtension (XInput) extension (partial)
+
+Enumerates input devices beyond the core pointer/keyboard. Implements two
+XI1 query requests plus the XI2 version handshake and device query; XI2
+event selection/delivery is not implemented yet (see Notes).
+
+- Module: `X.require('xinput', cb)` (X name `XInputExtension`; XI2 2.2
+  announced, XI1 version reported by the server)
+- Source: [`lib/ext/xinput.js`](../../lib/ext/xinput.js) ·
+  Tests: [`test/xinput.js`](../../test/xinput.js)
+- Spec: [XIproto.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/inputproto/XIproto.txt)
+  (XI2: [XI2proto.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/inputproto/XI2proto.txt))
+
+```js
+X.require('xinput', (err, XI) => {
+    XI.XIQueryDevice(XI.AllDevices, (err, devices) => {
+        devices.forEach(dev => {
+            // {deviceId, use, attachment, enabled, name, classes}
+            console.log(dev.deviceId, dev.name);
+        });
+    });
+});
+```
+
+`X.require` first announces XI2 support with `XIQueryVersion(2, 2)` —
+result in `XI.xi2` (`{majorVersion, minorVersion}`, or `null` on a pre-XI2
+server, which remains usable for the XI1 requests) — then fetches the XI1
+version into `XI.serverMajor` / `XI.serverMinor`.
+
+## Requests
+
+### GetExtensionVersion(cb)
+XI1 (opcode 1). `cb(err, {serverMajor, serverMinor, present})` — the XI1
+version; `present` is 1 when the extension is available. Called
+automatically by `X.require`.
+
+### ListInputDevices(cb)
+XI1 (opcode 2). `cb(err, devices)` — array of
+`{type, id, numClasses, use, attached, classes, name}`. `type` is an atom
+(device type, often 0), `use` a `XI.DeviceUse` value, `attached` the id of
+the attached master (XI2 servers). `classes` is an array of
+`{classId, ...}` where `classId` is a `XI.InputClass` value:
+
+- `Key` → `{minKeycode, maxKeycode, numKeys}`
+- `Button` → `{numButtons}`
+- `Valuator` → `{mode, motionBufferSize, axes: [{resolution, min, max}]}`
+- other classes → `{classId}` only
+
+### XIQueryVersion(clientMajor, clientMinor, cb)
+XI2 (opcode 47). Announces the client's supported XI2 version; must precede
+any other XI2 request. `cb(err, {majorVersion, minorVersion})` — what the
+server will speak. Called automatically by `X.require` with (2, 2).
+
+### XIQueryDevice(deviceId, cb)
+XI2 (opcode 48). `deviceId` is a device id, or `XI.AllDevices` (0) /
+`XI.AllMasterDevices` (1). `cb(err, devices)` — array of
+`{deviceId, use, attachment, enabled, name, classes}`. `use` is a
+`XI.DeviceType` value; `attachment` is the paired master (for master
+devices) or the master a slave is attached to. `classes` is an array of
+`{type, sourceId, ...}` where `type` is a `XI.ClassType` value:
+
+- `Key` → `{keycodes}` (array of keycodes)
+- `Button` → `{numButtons, state, labels}` (`state` — array of 32-bit mask
+  words, `labels` — array of atoms, one per button)
+- `Valuator` → `{number, label, min, max, value, resolution, mode}`
+  (min/max/value are FP3232 fixed point converted to Number)
+- `Scroll` → `{number, scrollType, flags, increment}`
+- `Touch`/`Gesture` → `{type, sourceId}` only (no per-class fields parsed)
+
+## Events
+
+None. XI2 events are GenericEvents ([ext/ge.md](ge.md)) but no parser is
+registered in `X.geEventParsers` yet, and `XISelectEvents` is not
+implemented, so device events cannot be selected or parsed through this
+module (an unsolicited XI2 GenericEvent would surface as the generic
+`{type: 35, extension, evtype, raw}` shape).
+
+## Notes
+
+- Not implemented: everything outside the four requests above — the XI1
+  device open/grab/event family (OpenDevice, GrabDevice,
+  SelectExtensionEvent, ...) and the rest of XI2 (XISelectEvents,
+  XIGrabDevice, XIGetClientPointer, XIChangeHierarchy, passive grabs,
+  properties, barriers, ...).
+- Enums attached to the ext object:
+  `XI.DeviceUse = {IsXPointer: 0, IsXKeyboard: 1, IsXExtensionDevice: 2,
+  IsXExtensionKeyboard: 3, IsXExtensionPointer: 4}` (XI1),
+  `XI.InputClass = {Key: 0, Button: 1, Valuator: 2, Feedback: 3,
+  Proximity: 4, Focus: 5, Other: 6}` (XI1),
+  `XI.DeviceType = {MasterPointer: 1, MasterKeyboard: 2, SlavePointer: 3,
+  SlaveKeyboard: 4, FloatingSlave: 5}` (XI2),
+  `XI.ClassType = {Key: 0, Button: 1, Valuator: 2, Scroll: 3, Touch: 8,
+  Gesture: 9}` (XI2), plus `XI.AllDevices` = 0, `XI.AllMasterDevices` = 1.
+- FP3232 fixed-point fields become plain JS numbers (53-bit mantissa:
+  fine for input axes).
+- Wire layouts are cross-checked against `X11/extensions/XIproto.h` and
+  `XI2proto.h`.

--- a/docs/ext/xkb.md
+++ b/docs/ext/xkb.md
@@ -1,0 +1,145 @@
+# XKEYBOARD (XKB) extension (partial)
+
+Advanced keyboard control: modifier/group state, controls (repeat timings,
+AccessX), named bells, and keyboard component names. Only a subset of the
+44-request protocol is implemented; notably the keymap requests (GetMap and
+the Set* siblings) are not (see Notes).
+
+- Module: `X.require('xkb', cb)` (X name `XKEYBOARD`, version 1.0 requested)
+- Source: [`lib/ext/xkb.js`](../../lib/ext/xkb.js) ·
+  Tests: [`test/xkb.js`](../../test/xkb.js)
+- Spec: [xkbproto.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/kbproto/xkbproto.txt)
+
+```js
+X.require('xkb', (err, Xkb) => {
+    Xkb.GetState(Xkb.UseCoreKbd, (err, state) => {
+        // state.group — current keyboard layout group (0-3)
+    });
+    // ring the bell as an event only (silent), watch for it
+    Xkb.SelectEvents(Xkb.UseCoreKbd, Xkb.EventType.BellNotify, 0,
+        Xkb.EventType.BellNotify, 0, 0);
+    Xkb.Bell(Xkb.UseCoreKbd, Xkb.DfltXIClass, Xkb.DfltXIId,
+        50, 0, 1, 440, 10, 0, 0);
+});
+```
+
+`X.require` performs the mandatory `UseExtension` handshake and exposes the
+result as `Xkb.supported` (1/0), `Xkb.serverMajor`, `Xkb.serverMinor`.
+
+## Requests
+
+Implemented: UseExtension (0), SelectEvents (1), Bell (3), GetState (4),
+LatchLockState (5), GetControls (6), GetNames (17). Everything else is not
+(see Notes). All device-taking requests accept a DeviceSpec: a device id or
+one of the shorthands `Xkb.UseCoreKbd` (0x100), `Xkb.UseCorePtr` (0x200).
+
+### UseExtension(wantedMajor, wantedMinor, cb)
+Must be the first XKB request a client issues; `X.require` calls it with
+(1, 0). `cb(err, {supported, serverMajor, serverMinor})` — `supported` is
+1 when the server accepts the client's version.
+
+### SelectEvents(deviceSpec, affectWhich, clear, selectAll, affectMap, map, details)
+No reply. Selects XKB events (masks of `Xkb.EventType`). For every bit in
+`affectWhich & ~clear & ~selectAll` an `[affect, details]` pair must be
+supplied in the `details` object, keyed by lowerCamel event name (e.g.
+`{stateNotify: [0x3fff, 0x3fff]}`); a missing pair throws. Bits in `clear`
+or `selectAll` need no pair, so the common "select everything about these
+events" call is simply `SelectEvents(deviceSpec, mask, 0, mask, 0, 0)`, and
+deselecting is `SelectEvents(deviceSpec, mask, mask, 0, 0, 0)`. MapNotify
+(bit 1) is controlled by `affectMap`/`map` (masks of map component parts),
+not by the details switch.
+
+### Bell(deviceSpec, bellClass, bellID, percent, forceSound, eventOnly, pitch, duration, name, window)
+No reply. Rings a named bell. `bellClass`/`bellID` select the bell feedback
+(`Xkb.DfltXIClass`/`Xkb.DfltXIId` for the default); `percent` is signed
+volume -100..100; `forceSound` (bool) rings even if audible bell is
+disabled, `eventOnly` (bool) sends only the BellNotify event; `pitch`/
+`duration` are signed (-1/-1 picks the bell control defaults, as in
+test/xkb.js); `name` is an atom or 0, `window` a window or 0.
+
+### GetState(deviceSpec, cb)
+`cb(err, state)` — `{deviceID, mods, baseMods, latchedMods, lockedMods,
+group, lockedGroup, baseGroup, latchedGroup, compatState, grabMods,
+compatGrabMods, lookupMods, compatLookupMods, ptrBtnState}`. Mod fields are
+`Xkb.ModMask` masks; group fields are 0-3.
+
+### LatchLockState(deviceSpec, affectModLocks, modLocks, lockGroup, groupLock, affectModLatches, modLatches, latchGroup, groupLatch)
+No reply. Locks/latches modifiers and groups. `affectModLocks`/`modLocks`
+and `affectModLatches`/`modLatches` are mask/value pairs of `Xkb.ModMask`;
+`lockGroup`/`latchGroup` are booleans enabling `groupLock` (0-3) and the
+signed `groupLatch`. Example — lock CapsLock:
+`LatchLockState(Xkb.UseCoreKbd, Xkb.ModMask.Lock, Xkb.ModMask.Lock, false, 0, 0, 0, false, 0)`.
+
+### GetControls(deviceSpec, cb)
+`cb(err, ctrls)` — `{deviceID, mouseKeysDfltBtn, numGroups, groupsWrap,
+internalModsMask, ignoreLockModsMask, internalModsRealMods,
+ignoreLockModsRealMods, internalModsVmods, ignoreLockModsVmods,
+repeatDelay, repeatInterval, slowKeysDelay, debounceDelay, mouseKeysDelay,
+mouseKeysInterval, mouseKeysTimeToMax, mouseKeysMaxSpeed, mouseKeysCurve,
+accessXOption, accessXTimeout, accessXTimeoutOptionsMask,
+accessXTimeoutOptionsValues, accessXTimeoutMask, accessXTimeoutValues,
+enabledControls, perKeyRepeat}`. Times are in milliseconds; `perKeyRepeat`
+is a 32-element byte array (keycode bitmap).
+
+### GetNames(deviceSpec, which, cb)
+`which` is a mask of `Xkb.NameDetail`. `cb(err, names)` — always contains
+`{deviceID, which, minKeyCode, maxKeyCode, nTypes, groupNames, virtualMods,
+firstKey, nKeys, indicators, nRadioGroups, nKeyAliases, nKTLevels}`, plus
+per requested bit (values are atoms unless noted — resolve with
+`X.GetAtomName`):
+
+- `Keycodes` → `keycodesName`, `Geometry` → `geometryName`,
+  `Symbols` → `symbolsName`, `PhysSymbols` → `physSymbolsName`,
+  `Types` → `typesName`, `Compat` → `compatName`
+- `KeyTypeNames` → `typeNames` (array of atoms)
+- `KTLevelNames` → `nLevelsPerType` (array of counts) and `ktLevelNames`
+  (flat array of atoms)
+- `IndicatorNames` → `indicatorNames`, `VirtualModNames` →
+  `virtualModNames`, `GroupNames` → `groupNamesList` (arrays of atoms,
+  one per set bit in `indicators`/`virtualMods`/`groupNames`)
+- `KeyNames` → `keyNames` (array of `nKeys` 4-char strings like `'AE01'`,
+  NUL-trimmed, starting at keycode `firstKey`)
+- `KeyAliases` → `keyAliases` (array of `{real, alias}` strings)
+- `RGNames` → `radioGroupNames` (array of atoms)
+
+## Events
+
+XKB multiplexes all its events on one event code; the wire "detail" byte is
+exposed as `event.xkbType` (`Xkb.events = {StateNotify: 2, BellNotify: 8}`).
+Common fields: `type`, `seq`, `xkbType`, `time`, `deviceID`.
+
+### XkbStateNotify (xkbType 2)
+Keyboard state changed. Extra fields: `mods`, `baseMods`, `latchedMods`,
+`lockedMods`, `group`, `baseGroup`, `latchedGroup`, `lockedGroup`,
+`compatState`, `grabMods`, `compatGrabMods`, `lookupMods`,
+`compatLookupMods`, `ptrBtnState`, `changed` (mask of what changed),
+`keycode`, `eventType`, `requestMajor`, `requestMinor`.
+
+### XkbBellNotify (xkbType 8)
+A bell rang (or `eventOnly` was requested). Extra fields: `bellClass`,
+`bellID`, `percent`, `pitch`, `duration`, `atomName` (atom or 0), `window`,
+`eventOnly` (0/1).
+
+Other selected XKB events are delivered unparsed as `XkbEvent` with the
+body in `event.raw`.
+
+## Notes
+
+- NOT implemented: GetMap (8) and the Set*/keymap family, plus every other
+  request not listed above (GetDeviceInfo, GetCompatMap, indicator/geometry
+  requests, ...). GetMap in particular is notoriously complex (dozens of
+  interdependent variable-length sections) and is skipped deliberately; use
+  core `GetKeyboardMapping` for keysym lookup.
+- DeviceSpec/BellClassSpec/IDSpec shorthands on the ext object:
+  `UseCoreKbd` 0x100, `UseCorePtr` 0x200, `DfltXIClass` 0x300, `DfltXIId`
+  0x400, `AllXIClass` 0x500, `AllXIId` 0x600, `XINone` 0xff00.
+- `Xkb.ModMask = {Shift: 1, Lock: 2, Control: 4, Mod1: 8, Mod2: 16,
+  Mod3: 32, Mod4: 64, Mod5: 128}`; `Xkb.EventType` has the 12 event bits
+  (NewKeyboardNotify 1<<0 ... ExtensionDeviceNotify 1<<11); `Xkb.NameDetail`
+  has the 14 GetNames bits (Keycodes 1<<0 ... RGNames 1<<13).
+- Wire layouts are cross-checked against `X11/extensions/XKBproto.h`;
+  xcb-proto's xkb.xml omits the modLatches byte of LatchLockState, so xcb
+  is not a reliable reference here.
+- GetNames value-list order matches the server's write order, which is NOT
+  ascending bit order for the last groups (VirtualModNames and GroupNames
+  are written before KeyNames/KeyAliases despite their higher bits).

--- a/docs/ext/xtest.md
+++ b/docs/ext/xtest.md
@@ -1,0 +1,68 @@
+# XTEST extension
+
+Synthesizes keyboard, mouse and motion input as if it came from the real
+devices, and provides cursor comparison plus grab immunity for test
+harnesses and automation tools (this is what `xdotool` uses).
+
+- Module: `X.require('xtest', cb)` (X name `XTEST`, version 2.2)
+- Source: [`lib/ext/xtest.js`](../../lib/ext/xtest.js) ·
+  Tests: [`test/xtest.js`](../../test/xtest.js)
+- Spec: [xtest.pdf](http://www.x.org/releases/X11R7.6/doc/xextproto/xtest.pdf)
+
+```js
+X.require('xtest', (err, XTest) => {
+    // move the pointer to absolute root coordinates (33, 44)
+    XTest.FakeInput(XTest.MotionNotify, 0, 0, 0, 33, 44);
+    // press and release keycode 38 ('a' on most layouts)
+    XTest.FakeInput(XTest.KeyPress, 38, 0, 0, 0, 0);
+    XTest.FakeInput(XTest.KeyRelease, 38, 0, 0, 0, 0);
+});
+```
+
+## Requests
+
+### GetVersion(clientMajor, clientMinor, cb)
+`cb(err, [major, minor])` — the XTEST version the server implements. Not
+called automatically.
+
+### CompareCursor(window, cursor, cb)
+Compares `cursor` against the cursor attribute of `window`.
+`cb(err, same)` — boolean. `cursor` is a CURSOR XID, or `XTest.Cursor.None`
+(0) to test that the window has no cursor, or `XTest.Cursor.Current` (1) to
+compare against the cursor currently being displayed.
+
+### FakeInput(type, detail, time, window, x, y)
+Injects one input event. No reply. Arguments by event `type`:
+
+- `XTest.KeyPress` / `XTest.KeyRelease` — `detail` is the keycode; pass 0
+  for `window`, `x`, `y`.
+- `XTest.ButtonPress` / `XTest.ButtonRelease` — `detail` is the button
+  number.
+- `XTest.MotionNotify` — `detail` 0 moves to absolute root coordinates
+  `x`,`y`; non-zero moves relative. `window` names the root window of the
+  screen to move on (0 = the screen the pointer is currently on).
+
+`time` is a delay in milliseconds before the event is processed (0 =
+CurrentTime, no delay).
+
+### GrabControl(impervious)
+When `impervious` is truthy, this client's requests keep executing even
+while other clients hold a server grab. No reply. Always pair with a later
+`GrabControl(false)` to return to normal behavior.
+
+## Events / errors
+
+None.
+
+## Notes
+
+- Constants on the extension object: `XTest.Cursor = {None: 0, Current: 1}`
+  and the fake-event types `XTest.KeyPress = 2`, `XTest.KeyRelease = 3`,
+  `XTest.ButtonPress = 4`, `XTest.ButtonRelease = 5`,
+  `XTest.MotionNotify = 6` (these are the core event codes, reused as the
+  `type` argument of `FakeInput`).
+- No version is negotiated at require time; call `GetVersion` yourself if
+  you need it.
+- Fake events go through normal event processing: grabs, event masks and
+  pointer barriers all apply, and `QueryPointer` immediately reflects a
+  faked motion (see the test).

--- a/docs/ext/xv.md
+++ b/docs/ext/xv.md
@@ -1,0 +1,122 @@
+# XVideo (Xv) extension
+
+Access to hardware video adaptors: scaled/color-converted image output
+(and video input) through per-adaptor "ports". This module implements the
+query/port-management half of the protocol; the actual video-path requests
+are not implemented (see Notes).
+
+- Module: `X.require('xv', cb)` (X name `XVideo`, version reported by the
+  server, 2.2 on current Xorg/Xvfb)
+- Source: [`lib/ext/xv.js`](../../lib/ext/xv.js) ·
+  Tests: [`test/xv.js`](../../test/xv.js)
+- Spec: [xv-protocol-v2.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/videoproto/xv-protocol-v2.txt)
+
+```js
+X.require('xv', (err, Xv) => {
+    Xv.QueryAdaptors(root, (err, adaptors) => {
+        // [] on Xvfb; on real hardware:
+        // [{baseId, numPorts, type, name, formats: [{visual, depth}]}, ...]
+        if (adaptors.length === 0) return;
+        const port = adaptors[0].baseId;
+        Xv.QueryEncodings(port, (err, encodings) => { /* ... */ });
+    });
+});
+```
+
+The version is negotiated automatically while requiring; it is available as
+`Xv.major` / `Xv.minor`.
+
+## Requests
+
+### QueryExtension(cb)
+`cb(err, [major, minor])` — the Xv protocol version spoken by the server.
+(The protocol calls its version request "QueryExtension".) Called
+automatically by `X.require`.
+
+### QueryAdaptors(window, cb)
+`cb(err, adaptors)` — array of
+`{baseId, numPorts, type, name, formats}` for the screen `window` is on.
+`baseId` is the first port XID (ports are `baseId .. baseId+numPorts-1`),
+`type` is a mask of `Xv.Type` values, `formats` is an array of
+`{visual, depth}`.
+
+### QueryEncodings(port, cb)
+`cb(err, encodings)` — array of
+`{encoding, width, height, rate: {numerator, denominator}, name}` supported
+by `port`. `encoding` is an XID usable as the `XV_ENCODING` attribute value.
+
+### GrabPort(port, time, cb)
+Grabs exclusive use of `port`. `time` 0 = CurrentTime. `cb(err, status)` —
+an `Xv.GrabPortStatus` value (`Success` = 0; note a non-Success status is a
+normal reply, not an X error).
+
+### UngrabPort(port, time)
+No reply. Releases a port grab.
+
+### QueryBestSize(port, vidW, vidH, drwW, drwH, motion, cb)
+`cb(err, {width, height})` — closest size the adaptor can scale
+`vidW x vidH` video to when asked for `drwW x drwH`. `motion` is a boolean
+(clipped to 0/1) hinting the video will move/resize continuously.
+
+### SetPortAttribute(port, attribute, value)
+No reply. Sets port attribute `attribute` (an atom, e.g. `XV_BRIGHTNESS`)
+to the signed 32-bit `value`. Raises `XvBadPort`/`BadMatch`/`BadValue` on
+the error event when invalid.
+
+### GetPortAttribute(port, attribute, cb)
+`cb(err, value)` — current signed 32-bit value of the attribute atom.
+
+### QueryPortAttributes(port, cb)
+`cb(err, attributes)` — array of `{flags, min, max, name}`. `flags` is a
+mask of `Xv.AttributeFlag` (`Gettable`/`Settable`); `name` is the attribute
+name string (intern it to get the atom for Get/SetPortAttribute).
+
+### ListImageFormats(port, cb)
+`cb(err, formats)` — array of XvImageFormatInfo objects:
+`{id, type, byteOrder, guid, bpp, numPlanes, depth, redMask, greenMask,
+blueMask, format, ySampleBits, uSampleBits, vSampleBits, horzYPeriod,
+horzUPeriod, horzVPeriod, vertYPeriod, vertUPeriod, vertVPeriod, compOrder,
+scanlineOrder}`. `id` is the FOURCC as a number, `guid` a 16-byte Buffer,
+`type` an `Xv.ImageFormatInfoType`, `format` an `Xv.ImageFormatInfoFormat`,
+`scanlineOrder` an `Xv.ScanlineOrder`, `compOrder` a string.
+
+## Events
+
+Selecting these requires SelectVideoNotify/SelectPortNotify, which are not
+implemented (see Notes); the parsers are registered for completeness.
+
+### XvVideoNotify
+Video started/stopped on a drawable. Fields: `type`, `seq`, `reason`
+(`Xv.VideoNotifyReason` value), `time`, `drawable`, `port`.
+
+### XvPortNotify
+A port attribute changed. Fields: `type`, `seq`, `time`, `port`,
+`attribute` (atom), `value`.
+
+## Errors
+
+`Xv.errors = {BadPort, BadEncoding, BadControl}` — extension error codes
+(`ext.firstError` based); compare against `err.error` in callbacks.
+
+## Notes
+
+- Enums attached to the ext object:
+  `Xv.Type = {InputMask: 1, OutputMask: 2, VideoMask: 4, StillMask: 8,
+  ImageMask: 16}`,
+  `Xv.ImageFormatInfoType = {RGB: 0, YUV: 1}`,
+  `Xv.ImageFormatInfoFormat = {Packed: 0, Planar: 1}`,
+  `Xv.AttributeFlag = {Gettable: 1, Settable: 2}`,
+  `Xv.ScanlineOrder = {TopToBottom: 0, BottomToTop: 1}`,
+  `Xv.GrabPortStatus = {Success: 0, BadExtension: 1, AlreadyGrabbed: 2,
+  InvalidTime: 3, BadReply: 4, BadAlloc: 5}`,
+  `Xv.VideoNotifyReason = {Started: 0, Stopped: 1, Busy: 2, Preempted: 3,
+  HardError: 4}`.
+- Not implemented: the video-path requests PutVideo (5), PutStill (6),
+  GetVideo (7), GetStill (8), StopVideo (9), SelectVideoNotify (10),
+  SelectPortNotify (11), QueryImageAttributes (17), PutImage (18),
+  ShmPutImage (19). These need a working port to do anything, and Xvfb
+  (the CI server) exposes the extension with zero adaptors, so they cannot
+  be exercised; they are omitted rather than shipped untested.
+- test/xv.js validates the port-based requests against a bogus port: a
+  controlled `XvBadPort` error proves correct request framing. With a real
+  adaptor present the same tests take the success path.

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -1481,7 +1481,7 @@ const templates = {
               if (typeof it == 'string')
               {
                   if (it.length > 254) // TODO: split string in set of items
-                      throw 'not supported yet';
+                      throw new Error('not supported yet');
                   const chunk = Buffer.alloc(2 + it.length);
                   chunk[0] = it.length;
                   chunk[1] = 0; // delta???
@@ -1489,7 +1489,7 @@ const templates = {
                   chunks.push(chunk);
                   reqLen += 2 + it.length;
               } else {
-                  throw 'not supported yet';
+                  throw new Error('not supported yet');
               }
           }
           const len4 = xutil.padded_length(reqLen) / 4;
@@ -1524,7 +1524,7 @@ const templates = {
               if (typeof it == 'string')
               {
                   if (it.length > 254) // TODO: split string in set of items
-                      throw 'not supported yet';
+                      throw new Error('not supported yet');
                   const chunk = Buffer.alloc(2 + 2 * it.length);
                   chunk[0] = it.length;
                   chunk[1] = 0; // delta
@@ -1536,7 +1536,7 @@ const templates = {
                   chunks.push(chunk);
                   reqLen += chunk.length;
               } else {
-                  throw 'not supported yet';
+                  throw new Error('not supported yet');
               }
           }
           const len4 = xutil.padded_length(reqLen) / 4;
@@ -1655,12 +1655,12 @@ const templates = {
        },
 
        buf => {
-           // SSSxL: red, green, blue, pad, pixel — note green/blue order matches prior API
+           // SSSxL: red, green, blue, pad, pixel
            const color = {};
            color.red   = buf.readUInt16LE(0);
-           color.blue  = buf.readUInt16LE(2);  // historically named blue but wire is green
-           color.green = buf.readUInt16LE(4);  // historically named green but wire is blue
-           color.pixel = buf.readUInt32LE(8) >> 8; // 3 first bytes contain RGB value in response
+           color.green = buf.readUInt16LE(2);
+           color.blue  = buf.readUInt16LE(4);
+           color.pixel = buf.readUInt32LE(8);
            return color;
        }
    ],

--- a/lib/ext/apple-wm.js
+++ b/lib/ext/apple-wm.js
@@ -23,7 +23,7 @@ exports.requireExt = (display, callback) => {
     X.QueryExtension('Apple-WM', (err, ext) => {
 
         if (!ext.present)
-            callback(new Error('extension not available'));
+            return callback(new Error('extension not available'));
 
         ext.QueryVersion = cb => {
             X.seq_num++;
@@ -245,11 +245,62 @@ exports.requireExt = (display, callback) => {
         // shortcut is single-byte ASCII (optional, 0=no shortcut)
         // items example: [ 'item1', 'some item', ['C', 'item with C shortcut'] ]
         ext.SetWindowMenu = items => {
-           const reqlen = 8;
-           const extlength = 0;
-           items.forEach(i => {
+            // wire format per item: 1 shortcut byte, then NUL-terminated label
+            let itemsLength = 0;
+            const norm = items.map(item => {
+                const shortcut = Array.isArray(item) ? item[0].charCodeAt(0) : 0;
+                const label = Array.isArray(item) ? item[1] : item;
+                itemsLength += 1 + Buffer.byteLength(label) + 1;
+                return [shortcut, label];
+            });
+            const reqlen = 2 + ((itemsLength + 3) >> 2);
+            X.seq_num++;
+            const b = Buffer.alloc(reqlen * 4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(11, 1);
+            b.writeUInt16LE(reqlen, 2);
+            b.writeUInt16LE(items.length, 4);
+            let off = 8;
+            norm.forEach(([shortcut, label]) => {
+                b.writeUInt8(shortcut, off++);
+                off += b.write(label, off);
+                b.writeUInt8(0, off++);
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
 
-           });
+        ext.SetWindowMenuCheck = index => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(7, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(index >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.DisableUpdate = screen => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE((screen || 0) >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.ReenableUpdate = screen => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE((screen || 0) >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
         }
 
         // https://developer.apple.com

--- a/lib/ext/damage.js
+++ b/lib/ext/damage.js
@@ -50,10 +50,10 @@ exports.requireExt = (display, callback) => {
 
         ext.Destroy = damage => {
             X.seq_num++;
-            const b = Buffer.alloc(12);
+            const b = Buffer.alloc(8);
             b.writeUInt8(ext.majorOpcode, 0);
             b.writeUInt8(2, 1);
-            b.writeUInt16LE(3, 2);
+            b.writeUInt16LE(2, 2);
             b.writeUInt32LE(damage >>> 0, 4);
             X.pack_stream.put(b);
             X.pack_stream.flush();

--- a/lib/ext/dbe.js
+++ b/lib/ext/dbe.js
@@ -1,0 +1,168 @@
+// DOUBLE-BUFFER (DBE) extension protocol, version 1.0
+// https://xorg.freedesktop.org/releases/X11R7.7/doc/xextproto/dbe.txt
+
+// TODO: move to templates
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('DOUBLE-BUFFER', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        ext.SwapAction = {
+            Undefined: 0,
+            Background: 1,
+            Untouched: 2,
+            Copied: 3
+        };
+
+        ext.GetVersion = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt8(clientMaj, 4);
+            b.writeUInt8(clientMin, 5);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => [buf.readUInt8(0), buf.readUInt8(1)],
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // Associate `backBuffer` (a fresh XID) with the back buffer of `window`.
+        // The back buffer is a drawable and can be used with core drawing requests.
+        ext.AllocateBackBufferName = (window, backBuffer, swapActionHint) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE(backBuffer >>> 0, 8);
+            b.writeUInt8(swapActionHint, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.DeallocateBackBufferName = backBuffer => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(backBuffer >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // swapInfos: array of { window: WINDOW, swapAction: ext.SwapAction.* }
+        ext.SwapBuffers = swapInfos => {
+            X.seq_num++;
+            const n = swapInfos.length;
+            const b = Buffer.alloc(8 + n * 8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(2 + 2 * n, 2);
+            b.writeUInt32LE(n, 4);
+            let off = 8;
+            swapInfos.forEach(info => {
+                b.writeUInt32LE(info.window >>> 0, off);
+                b.writeUInt8(info.swapAction, off + 4);
+                off += 8;
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.BeginIdiom = () => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.EndIdiom = () => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // drawables: array of screen specifiers (any drawable per screen, e.g. root windows).
+        // Callback gets an array (one entry per drawable) of arrays of
+        // { visual, depth, perfLevel } describing double-buffer capable visuals.
+        ext.GetVisualInfo = (drawables, cb) => {
+            X.seq_num++;
+            const n = drawables.length;
+            const b = Buffer.alloc(8 + n * 4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(6, 1);
+            b.writeUInt16LE(2 + n, 2);
+            b.writeUInt32LE(n, 4);
+            drawables.forEach((drawable, i) => {
+                b.writeUInt32LE(drawable >>> 0, 8 + i * 4);
+            });
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const m = buf.readUInt32LE(0);
+                    const screens = [];
+                    let off = 24;
+                    for (let i = 0; i < m; ++i) {
+                        const count = buf.readUInt32LE(off);
+                        off += 4;
+                        const visuals = [];
+                        for (let j = 0; j < count; ++j) {
+                            visuals.push({
+                                visual: buf.readUInt32LE(off),
+                                depth: buf.readUInt8(off + 4),
+                                perfLevel: buf.readUInt8(off + 5)
+                            });
+                            off += 8;
+                        }
+                        screens.push(visuals);
+                    }
+                    return screens;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.GetBackBufferAttributes = (backBuffer, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(7, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(backBuffer >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                // BUFFER_ATTRIBUTES: the window this back buffer belongs to
+                // (None if the window was destroyed)
+                (buf, opt) => ({ window: buf.readUInt32LE(0) }),
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // The spec requires GetVersion to be issued before any other DBE request
+        ext.GetVersion(1, 0, (err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/fixes.js
+++ b/lib/ext/fixes.js
@@ -1,4 +1,5 @@
-// http://www.x.org/releases/X11R7.6/doc/fixesproto/fixesproto.txt
+// https://xorg.freedesktop.org/releases/X11R7.7/doc/fixesproto/fixesproto.txt
+// wire layout: autogen/proto/xfixes.xml
 
 const x11 = require('..');
 // TODO: move to templates
@@ -16,6 +17,8 @@ function parse_rectangle(buf, pos) {
     }
 }
 
+const pad4 = n => (n + 3) & ~3;
+
 exports.requireExt = (display, callback) => {
     const X = display.client;
     X.QueryExtension('XFIXES', (err, ext) => {
@@ -23,6 +26,17 @@ exports.requireExt = (display, callback) => {
         if (!ext.present)
             return callback(new Error('extension not available'));
 
+        const writeRectangles = (b, off, rects) => {
+            rects.forEach(rect => {
+                b.writeInt16LE(rect.x, off);
+                b.writeInt16LE(rect.y, off + 2);
+                b.writeUInt16LE(rect.width, off + 4);
+                b.writeUInt16LE(rect.height, off + 6);
+                off += 8;
+            });
+        };
+
+        // opcode 0
         ext.QueryVersion = (clientMaj, clientMin, callback) => {
             X.seq_num++;
             const b = Buffer.alloc(12);
@@ -45,6 +59,7 @@ exports.requireExt = (display, callback) => {
         ext.SaveSetTarget = { Nearest: 0, Root: 1 };
         ext.SaveSetMap = { Map: 0, Unmap: 1 };
 
+        // opcode 1
         ext.ChangeSaveSet = (window, mode, target, map) => {
             X.seq_num++;
             const b = Buffer.alloc(12);
@@ -54,15 +69,90 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(mode, 4);
             b.writeUInt8(target, 5);
             b.writeUInt8(map, 6);
+            b.writeUInt32LE(window >>> 0, 8);
             X.pack_stream.put(b);
             X.pack_stream.flush();
         };
+
+        ext.SelectionEvent = {
+            SetSelectionOwner: 0,
+            SelectionWindowDestroy: 1,
+            SelectionClientClose: 2
+        };
+
+        ext.SelectionEventMask = {
+            SetSelectionOwner: 1,
+            SelectionWindowDestroy: 2,
+            SelectionClientClose: 4
+        };
+
+        // opcode 2
+        ext.SelectSelectionInput = (window, selection, eventMask) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE(selection >>> 0, 8);
+            b.writeUInt32LE(eventMask >>> 0, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.CursorNotify = { DisplayCursor: 0 };
+        ext.CursorNotifyMask = { DisplayCursor: 1 };
+
+        // opcode 3
+        ext.SelectCursorInput = (window, eventMask) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE(eventMask >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        const parseCursorImageReply = buf => {
+            const width = buf.readUInt16LE(4);
+            const height = buf.readUInt16LE(6);
+            return {
+                x: buf.readInt16LE(0),
+                y: buf.readInt16LE(2),
+                width: width,
+                height: height,
+                xhot: buf.readUInt16LE(8),
+                yhot: buf.readUInt16LE(10),
+                cursorSerial: buf.readUInt32LE(12),
+                // width*height packed ARGB32 pixels, premultiplied alpha
+                cursorImage: Buffer.from(buf.slice(24, 24 + width * height * 4))
+            };
+        };
+
+        // opcode 4
+        ext.GetCursorImage = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => parseCursorImageReply(buf),
+                cb
+            ];
+            X.pack_stream.flush();
+        }
 
         ext.WindowRegionKind = {
             Bounding : 0,
             Clip : 1
         };
 
+        // opcode 5
         ext.CreateRegion = (region, rects) => {
             X.seq_num ++;
             const b = Buffer.alloc(8 + rects.length * 8);
@@ -70,18 +160,25 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(5, 1);
             b.writeUInt16LE(2 + (rects.length << 1), 2);
             b.writeUInt32LE(region >>> 0, 4);
-            let off = 8;
-            rects.forEach(rect => {
-                b.writeInt16LE(rect.x, off);
-                b.writeInt16LE(rect.y, off + 2);
-                b.writeUInt16LE(rect.width, off + 4);
-                b.writeUInt16LE(rect.height, off + 6);
-                off += 8;
-            });
+            writeRectangles(b, 8, rects);
             X.pack_stream.put(b);
             X.pack_stream.flush();
         }
 
+        // opcode 6
+        ext.CreateRegionFromBitmap = (region, bitmap) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(6, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(region >>> 0, 4);
+            b.writeUInt32LE(bitmap >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 7
         ext.CreateRegionFromWindow = (region, wid, kind) => {
             X.seq_num ++;
             const b = Buffer.alloc(16);
@@ -95,6 +192,33 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
+        // opcode 8
+        ext.CreateRegionFromGC = (region, gc) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(8, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(region >>> 0, 4);
+            b.writeUInt32LE(gc >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 9
+        ext.CreateRegionFromPicture = (region, picture) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(9, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(region >>> 0, 4);
+            b.writeUInt32LE(picture >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 10
         ext.DestroyRegion = region => {
             X.seq_num ++;
             const b = Buffer.alloc(8);
@@ -106,6 +230,33 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
+        // opcode 11
+        ext.SetRegion = (region, rects) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8 + rects.length * 8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(11, 1);
+            b.writeUInt16LE(2 + (rects.length << 1), 2);
+            b.writeUInt32LE(region >>> 0, 4);
+            writeRectangles(b, 8, rects);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 12
+        ext.CopyRegion = (src, dst) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(12, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(src >>> 0, 4);
+            b.writeUInt32LE(dst >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 13
         ext.UnionRegion = (src1, src2, dst) => {
             X.seq_num ++;
             const b = Buffer.alloc(16);
@@ -119,6 +270,49 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
+        // opcode 14
+        ext.IntersectRegion = (src1, src2, dst) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(14, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(src1 >>> 0, 4);
+            b.writeUInt32LE(src2 >>> 0, 8);
+            b.writeUInt32LE(dst >>> 0, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 15
+        ext.SubtractRegion = (src1, src2, dst) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(15, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(src1 >>> 0, 4);
+            b.writeUInt32LE(src2 >>> 0, 8);
+            b.writeUInt32LE(dst >>> 0, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 16; bounds is { x, y, width, height }
+        ext.InvertRegion = (src, bounds, dst) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(20);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(16, 1);
+            b.writeUInt16LE(5, 2);
+            b.writeUInt32LE(src >>> 0, 4);
+            writeRectangles(b, 8, [bounds]);
+            b.writeUInt32LE(dst >>> 0, 16);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 17
         ext.TranslateRegion = (region, dx, dy) => {
             X.seq_num ++;
             const b = Buffer.alloc(12);
@@ -132,6 +326,20 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
+        // opcode 18
+        ext.RegionExtents = (src, dst) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(18, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(src >>> 0, 4);
+            b.writeUInt32LE(dst >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 19
         ext.FetchRegion = (region, cb) => {
             X.seq_num ++;
             const b = Buffer.alloc(8);
@@ -175,6 +383,255 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
+        // opcode 20; region 0 = None (remove clip)
+        ext.SetGCClipRegion = (gc, region, xOrigin, yOrigin) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(20, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(gc >>> 0, 4);
+            b.writeUInt32LE(region >>> 0, 8);
+            b.writeInt16LE(xOrigin, 12);
+            b.writeInt16LE(yOrigin, 14);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 21; kind from ext.WindowRegionKind (+ Input: 2 with SHAPE), region 0 = None
+        ext.SetWindowShapeRegion = (dest, destKind, xOffset, yOffset, region) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(20);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(21, 1);
+            b.writeUInt16LE(5, 2);
+            b.writeUInt32LE(dest >>> 0, 4);
+            b.writeUInt8(destKind, 8);
+            b.writeInt16LE(xOffset, 12);
+            b.writeInt16LE(yOffset, 14);
+            b.writeUInt32LE(region >>> 0, 16);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 22; region 0 = None
+        ext.SetPictureClipRegion = (picture, region, xOrigin, yOrigin) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(22, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(picture >>> 0, 4);
+            b.writeUInt32LE(region >>> 0, 8);
+            b.writeInt16LE(xOrigin, 12);
+            b.writeInt16LE(yOrigin, 14);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 23
+        ext.SetCursorName = (cursor, name) => {
+            X.seq_num ++;
+            const nameBuf = Buffer.from(name, 'latin1');
+            const b = Buffer.alloc(12 + pad4(nameBuf.length));
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(23, 1);
+            b.writeUInt16LE(b.length >> 2, 2);
+            b.writeUInt32LE(cursor >>> 0, 4);
+            b.writeUInt16LE(nameBuf.length, 8);
+            nameBuf.copy(b, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 24
+        ext.GetCursorName = (cursor, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(24, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(cursor >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const nbytes = buf.readUInt16LE(4);
+                    return {
+                        atom: buf.readUInt32LE(0),
+                        name: buf.toString('latin1', 24, 24 + nbytes)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // opcode 25
+        ext.GetCursorImageAndName = cb => {
+            X.seq_num ++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(25, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const res = parseCursorImageReply(buf);
+                    res.cursorAtom = buf.readUInt32LE(16);
+                    const nbytes = buf.readUInt16LE(20);
+                    // the server sends the image first, the name after it
+                    const nameOff = 24 + res.width * res.height * 4;
+                    res.cursorName = buf.toString('latin1', nameOff, nameOff + nbytes);
+                    return res;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // opcode 26
+        ext.ChangeCursor = (src, dst) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(26, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(src >>> 0, 4);
+            b.writeUInt32LE(dst >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 27
+        ext.ChangeCursorByName = (src, name) => {
+            X.seq_num ++;
+            const nameBuf = Buffer.from(name, 'latin1');
+            const b = Buffer.alloc(12 + pad4(nameBuf.length));
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(27, 1);
+            b.writeUInt16LE(b.length >> 2, 2);
+            b.writeUInt32LE(src >>> 0, 4);
+            b.writeUInt16LE(nameBuf.length, 8);
+            nameBuf.copy(b, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 28
+        ext.ExpandRegion = (src, dst, left, right, top, bottom) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(20);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(28, 1);
+            b.writeUInt16LE(5, 2);
+            b.writeUInt32LE(src >>> 0, 4);
+            b.writeUInt32LE(dst >>> 0, 8);
+            b.writeUInt16LE(left, 12);
+            b.writeUInt16LE(right, 14);
+            b.writeUInt16LE(top, 16);
+            b.writeUInt16LE(bottom, 18);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 29
+        ext.HideCursor = window => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(29, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 30
+        ext.ShowCursor = window => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(30, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.BarrierDirections = {
+            PositiveX: 1,
+            PositiveY: 2,
+            NegativeX: 4,
+            NegativeY: 8
+        };
+
+        // opcode 31 (XFIXES 5.0); devices: optional array of XInput2 device ids
+        // (empty/omitted = all master pointers)
+        ext.CreatePointerBarrier = (barrier, window, x1, y1, x2, y2, directions, devices) => {
+            if (!devices)
+                devices = [];
+            X.seq_num ++;
+            const b = Buffer.alloc(28 + pad4(devices.length * 2));
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(31, 1);
+            b.writeUInt16LE(b.length >> 2, 2);
+            b.writeUInt32LE(barrier >>> 0, 4);
+            b.writeUInt32LE(window >>> 0, 8);
+            b.writeUInt16LE(x1, 12);
+            b.writeUInt16LE(y1, 14);
+            b.writeUInt16LE(x2, 16);
+            b.writeUInt16LE(y2, 18);
+            b.writeUInt32LE(directions >>> 0, 20);
+            b.writeUInt16LE(devices.length, 26);
+            devices.forEach((dev, i) => b.writeUInt16LE(dev, 28 + i * 2));
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // opcode 32 (XFIXES 5.0)
+        ext.DeletePointerBarrier = barrier => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(32, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(barrier >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.events = {
+            SelectionNotify: 0,
+            CursorNotify: 1
+        }
+
+        X.eventParsers[ext.firstEvent + ext.events.SelectionNotify] = (type, seq, extra, code, raw) => {
+            const event = {};
+            event.type = type;
+            event.seq = seq;
+            event.subtype = code;       // ext.SelectionEvent
+            event.window = extra;
+            event.owner = raw.readUInt32LE(0);
+            event.selection = raw.readUInt32LE(4);
+            event.timestamp = raw.readUInt32LE(8);
+            event.selectionTimestamp = raw.readUInt32LE(12);
+            event.name = 'SelectionNotify';
+            return event;
+        };
+
+        X.eventParsers[ext.firstEvent + ext.events.CursorNotify] = (type, seq, extra, code, raw) => {
+            const event = {};
+            event.type = type;
+            event.seq = seq;
+            event.subtype = code;       // ext.CursorNotify
+            event.window = extra;
+            event.cursorSerial = raw.readUInt32LE(0);
+            event.timestamp = raw.readUInt32LE(4);
+            event.cursorName = raw.readUInt32LE(8); // atom, 0 if unnamed (XFIXES >= 2)
+            event.name = 'CursorNotify';
+            return event;
+        };
+
         ext.QueryVersion(5, 0, (err, vers) => {
             if (err)
                 return callback(err);
@@ -182,32 +639,5 @@ exports.requireExt = (display, callback) => {
             ext.minor = vers[1];
             callback(null, ext);
         });
-
-        ext.events = {
-            DamageNotify: 0
-        }
-
-        X.eventParsers[ext.firstEvent + ext.events.DamageNotify] = (type, seq, extra, code, raw) => {
-            const event = {};
-            event.level = code;
-            event.seq = seq;
-            event.drawable = extra;
-            event.damage = raw.readUInt32LE(0);
-            event.time = raw.readUInt32LE(4);
-            event.area = {
-              x: raw.readInt16LE(8),
-              y: raw.readInt16LE(10),
-              w: raw.readUInt16LE(12),
-              h: raw.readUInt16LE(14)
-            };
-            event.geometry = {
-              x: raw.readInt16LE(16),
-              y: raw.readInt16LE(18),
-              w: raw.readUInt16LE(20),
-              h: raw.readUInt16LE(22)
-            };
-            event.name = 'DamageNotify';
-            return event;
-        };
     });
 }

--- a/lib/ext/ge.js
+++ b/lib/ext/ge.js
@@ -1,0 +1,47 @@
+// Generic Event Extension (X Generic Events, "GE")
+// spec: https://www.x.org/releases/X11R7.7/doc/xextproto/geproto.html
+// xcb:  autogen/proto/ge.xml
+//
+// The extension itself only carries a version handshake; its purpose is the
+// GenericEvent (type 35) wire event that other extensions (Present, XInput2...)
+// use for events longer than 32 bytes.
+//
+// Event delivery: lib/xcore.js frames type-35 events by their length field
+// and dispatches them via X.geEventParsers[extension major opcode]; register
+// a parser there to receive an extension's GenericEvents (see present.js).
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('Generic Event Extension', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        ext.QueryVersion = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt16LE(clientMaj, 4);
+            b.writeUInt16LE(clientMin, 6);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return [buf.readUInt16LE(0), buf.readUInt16LE(2)];
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // the spec requires clients to negotiate the version before use
+        ext.QueryVersion(1, 0, (err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/present.js
+++ b/lib/ext/present.js
@@ -1,0 +1,234 @@
+// Present extension
+// spec: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/presentproto.txt
+// xcb:  https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/master/src/present.xml
+//
+// NOTE on events: Present has no classic (32-byte) events. All of its events
+// (ConfigureNotify, CompleteNotify, IdleNotify) are delivered as X Generic
+// Events (type 35, byte 1 = Present major opcode, variable length) and are
+// dispatched through X.geEventParsers, keyed by major opcode.
+
+// 64-bit protocol fields (target_msc, divisor, remainder) are plain JS
+// numbers composed from two 32-bit halves; values above 2^53 - 1 lose
+// precision (irrelevant in practice for msc counters).
+const writeUInt64LE = (b, value, offset) => {
+    const lo = value % 0x100000000;
+    const hi = Math.floor(value / 0x100000000);
+    b.writeUInt32LE(lo >>> 0, offset);
+    b.writeUInt32LE(hi >>> 0, offset + 4);
+};
+
+const readUInt64LE = (b, offset) =>
+    b.readUInt32LE(offset + 4) * 0x100000000 + b.readUInt32LE(offset);
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('Present', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        ext.EventMask = {
+            NoEvent: 0,
+            ConfigureNotify: 1,
+            CompleteNotify: 2,
+            IdleNotify: 4,
+            RedirectNotify: 8
+        };
+
+        ext.Option = {
+            None: 0,
+            Async: 1,
+            Copy: 2,
+            UST: 4,
+            Suboptimal: 8
+        };
+
+        ext.Capability = {
+            None: 0,
+            Async: 1,
+            Fence: 2,
+            UST: 4
+        };
+
+        ext.CompleteKind = {
+            Pixmap: 0,
+            NotifyMSC: 1
+        };
+
+        ext.CompleteMode = {
+            Copy: 0,
+            Flip: 1,
+            Skip: 2,
+            SuboptimalCopy: 3
+        };
+
+        ext.QueryVersion = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(clientMaj >>> 0, 4);
+            b.writeUInt32LE(clientMin >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return [buf.readUInt32LE(0), buf.readUInt32LE(4)];
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // PresentPixmap: copy `pixmap` to `window` at the target msc.
+        // opts (all optional): serial, valid, update (XFIXES regions), xOff,
+        // yOff, targetCrtc, waitFence, idleFence (SYNC fences), options
+        // (ext.Option mask), targetMsc, divisor, remainder,
+        // notifies ([{window, serial}, ...]).
+        ext.Pixmap = (window, pixmap, opts) => {
+            if (opts === undefined)
+                opts = {};
+            const notifies = opts.notifies || [];
+            X.seq_num++;
+            const b = Buffer.alloc(72 + notifies.length * 8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(18 + notifies.length * 2, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE(pixmap >>> 0, 8);
+            b.writeUInt32LE((opts.serial || 0) >>> 0, 12);
+            b.writeUInt32LE((opts.valid || 0) >>> 0, 16);
+            b.writeUInt32LE((opts.update || 0) >>> 0, 20);
+            b.writeInt16LE(opts.xOff || 0, 24);
+            b.writeInt16LE(opts.yOff || 0, 26);
+            b.writeUInt32LE((opts.targetCrtc || 0) >>> 0, 28);
+            b.writeUInt32LE((opts.waitFence || 0) >>> 0, 32);
+            b.writeUInt32LE((opts.idleFence || 0) >>> 0, 36);
+            b.writeUInt32LE((opts.options || 0) >>> 0, 40);
+            // 4 bytes pad at 44
+            writeUInt64LE(b, opts.targetMsc || 0, 48);
+            writeUInt64LE(b, opts.divisor || 0, 56);
+            writeUInt64LE(b, opts.remainder || 0, 64);
+            let off = 72;
+            notifies.forEach(n => {
+                b.writeUInt32LE(n.window >>> 0, off);
+                b.writeUInt32LE((n.serial || 0) >>> 0, off + 4);
+                off += 8;
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // Request a CompleteNotify(kind=NotifyMSC) event when the msc reaches
+        // target_msc (clients that selected CompleteNotify on `window`).
+        ext.NotifyMSC = (window, serial, targetMsc, divisor, remainder) => {
+            X.seq_num++;
+            const b = Buffer.alloc(40);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(10, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE((serial || 0) >>> 0, 8);
+            // 4 bytes pad at 12
+            writeUInt64LE(b, targetMsc || 0, 16);
+            writeUInt64LE(b, divisor || 0, 24);
+            writeUInt64LE(b, remainder || 0, 32);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // eid is a fresh XID (X.AllocID()) naming the event context;
+        // eventMask is a mask of ext.EventMask values. Events arrive on the
+        // client as GenericEvents parsed by the registrations below.
+        ext.SelectInput = (eid, window, eventMask) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(eid >>> 0, 4);
+            b.writeUInt32LE(window >>> 0, 8);
+            b.writeUInt32LE((eventMask || 0) >>> 0, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // target is a window (or RandR crtc); returns an ext.Capability mask
+        ext.QueryCapabilities = (target, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(target >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => buf.readUInt32LE(0),
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // GenericEvent parsers; raw is the event from byte 8 on, so absolute
+        // struct offsets (presentproto.h) minus 8. evtype is raw bytes 0-1.
+        ext.events = {
+            ConfigureNotify: 0,
+            CompleteNotify: 1,
+            IdleNotify: 2
+        };
+
+        X.geEventParsers[ext.majorOpcode] = (type, seq, extra, code, raw) => {
+            const evtype = raw.readUInt16LE(0);
+            const event = {
+                type: type,
+                seq: seq,
+                extension: code,
+                evtype: evtype,
+                eid: raw.readUInt32LE(4),
+                wid: raw.readUInt32LE(8),
+                window: raw.readUInt32LE(8)
+            };
+            switch (evtype) {
+            case ext.events.ConfigureNotify:
+                event.name = 'PresentConfigureNotify';
+                event.x = raw.readInt16LE(12);
+                event.y = raw.readInt16LE(14);
+                event.width = raw.readUInt16LE(16);
+                event.height = raw.readUInt16LE(18);
+                event.offX = raw.readInt16LE(20);
+                event.offY = raw.readInt16LE(22);
+                event.pixmapWidth = raw.readUInt16LE(24);
+                event.pixmapHeight = raw.readUInt16LE(26);
+                event.pixmapFlags = raw.readUInt32LE(28);
+                break;
+            case ext.events.CompleteNotify:
+                event.name = 'PresentCompleteNotify';
+                event.kind = raw.readUInt8(2);
+                event.mode = raw.readUInt8(3);
+                event.serial = raw.readUInt32LE(12);
+                event.ust = readUInt64LE(raw, 16);
+                event.msc = readUInt64LE(raw, 24);
+                break;
+            case ext.events.IdleNotify:
+                event.name = 'PresentIdleNotify';
+                event.serial = raw.readUInt32LE(12);
+                event.pixmap = raw.readUInt32LE(16);
+                event.idleFence = raw.readUInt32LE(20);
+                break;
+            default:
+                event.name = 'PresentGenericEvent';
+                event.raw = raw;
+            }
+            return event;
+        };
+
+        // the spec requires clients to negotiate the version before use
+        ext.QueryVersion(1, 2, (err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/randr.js
+++ b/lib/ext/randr.js
@@ -7,11 +7,70 @@ exports.requireExt = (display, callback) => {
     const X = display.client;
     X.QueryExtension('RANDR', (err, ext) => {
 
-        // shared between GetScreenResources and GetOutputInfo unpackers
-        let res_modes;
-
         if (!ext.present)
             return callback(new Error('extension not available'));
+
+        // shared reply unpacker for GetScreenResources (8) and GetScreenResourcesCurrent (25)
+        const unpackScreenResources = (buf) => {
+            const numCrtcs = buf.readUInt16LE(8);
+            const numOutputs = buf.readUInt16LE(10);
+            const numModes = buf.readUInt16LE(12);
+            const resources = {
+                timestamp : buf.readUInt32LE(0),
+                config_timestamp : buf.readUInt32LE(4),
+                crtcs : [],
+                outputs : [],
+                modeinfos : []
+            };
+
+            let pos = 24;
+            for (let i = 0; i < numCrtcs; ++i)
+                resources.crtcs.push(buf.readUInt32LE(pos + i * 4));
+            pos += numCrtcs << 2;
+            for (let i = 0; i < numOutputs; ++i)
+                resources.outputs.push(buf.readUInt32LE(pos + i * 4));
+            pos += numOutputs << 2;
+            for (let i = 0; i < numModes; ++i) {
+                const o = pos + i * 32;
+                resources.modeinfos.push({
+                    id : buf.readUInt32LE(o),
+                    width : buf.readUInt16LE(o + 4),
+                    height : buf.readUInt16LE(o + 6),
+                    dot_clock : buf.readUInt32LE(o + 8),
+                    h_sync_start : buf.readUInt16LE(o + 12),
+                    h_sync_end : buf.readUInt16LE(o + 14),
+                    h_total : buf.readUInt16LE(o + 16),
+                    h_skew : buf.readUInt16LE(o + 18),
+                    v_sync_start : buf.readUInt16LE(o + 20),
+                    v_sync_end : buf.readUInt16LE(o + 22),
+                    v_total : buf.readUInt16LE(o + 24),
+                    name_len : buf.readUInt16LE(o + 26),
+                    modeflags : buf.readUInt32LE(o + 28)
+                });
+            }
+            pos += numModes << 5;
+            // mode names are concatenated without separators; use each name_len
+            resources.modeinfos.forEach(mode => {
+                mode.name = buf.slice(pos, pos + mode.name_len).toString('binary');
+                pos += mode.name_len;
+            });
+
+            return resources;
+        };
+
+        // render TRANSFORM: 3x3 matrix of FIXED (16.16) values, row-major,
+        // exposed as an array of 9 JS floats
+        const writeTransform = (b, off, matrix) => {
+            for (let i = 0; i < 9; ++i)
+                b.writeInt32LE(Math.round(matrix[i] * 65536), off + i * 4);
+        };
+
+        const readTransform = (buf, off) => {
+            const matrix = [];
+            for (let i = 0; i < 9; ++i)
+                matrix.push(buf.readInt32LE(off + i * 4) / 65536);
+            return matrix;
+        };
 
         //ext.ReportLevel	= {
         //};
@@ -56,10 +115,16 @@ exports.requireExt = (display, callback) => {
         };
 
         ext.ConfigStatus = {
-            Sucess: 0,
+            Success: 0,
             InvalidConfigTime: 1,
             InvalidTime: 2,
             Failed: 3
+        };
+
+        ext.Connection = {
+            Connected: 0,
+            Disconnected: 1,
+            Unknown: 2
         };
 
         ext.ModeFlag = {
@@ -205,74 +270,22 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(win >>> 0, 4);
             X.pack_stream.put(b);
             X.replies[X.seq_num] = [
-                (buf, opt) => {
-                    let i;
-                    let pos = 0;
-                    const res = [
-                        buf.readUInt32LE(0),
-                        buf.readUInt32LE(4),
-                        buf.readUInt16LE(8),
-                        buf.readUInt16LE(10),
-                        buf.readUInt16LE(12),
-                        buf.readUInt16LE(14)
-                    ];
-                    const resources = {
-                        timestamp : res[0],
-                        config_timestamp : res[1],
-                        modeinfos : []
-                    };
+                unpackScreenResources,
+                cb
+            ];
 
-                    pos += 24;
-                    resources.crtcs = [];
-                    for (i = 0; i < res[2]; ++i)
-                        resources.crtcs.push(buf.readUInt32LE(pos + i * 4));
-                    pos +=  res[2] << 2;
-                    resources.outputs = [];
-                    for (i = 0; i < res[3]; ++i)
-                        resources.outputs.push(buf.readUInt32LE(pos + i * 4));
-                    pos +=  res[3] << 2;
-                    res_modes = [];
-                    for (i = 0; i < res[4]; ++i) {
-                        const o = pos + i * 32;
-                        res_modes.push(
-                            buf.readUInt32LE(o),
-                            buf.readUInt16LE(o + 4),
-                            buf.readUInt16LE(o + 6),
-                            buf.readUInt32LE(o + 8),
-                            buf.readUInt16LE(o + 12),
-                            buf.readUInt16LE(o + 14),
-                            buf.readUInt16LE(o + 16),
-                            buf.readUInt16LE(o + 18),
-                            buf.readUInt16LE(o + 20),
-                            buf.readUInt16LE(o + 22),
-                            buf.readUInt16LE(o + 24),
-                            buf.readUInt16LE(o + 26),
-                            buf.readUInt32LE(o + 28)
-                        );
-                    }
-                    pos +=  res[4] << 5;
-                    for (i = 0; i < res[4]; i+= 13) {
-                        resources.modeinfos.push({
-                            id : res_modes[i + 0],
-                            width : res_modes[i + 1],
-                            height : res_modes[i + 2],
-                            dot_clock : res_modes[i + 3],
-                            h_sync_start : res_modes[i + 4],
-                            h_sync_end : res_modes[i + 5],
-                            h_total : res_modes[i + 6],
-                            h_skew : res_modes[i + 7],
-                            v_sync_start : res_modes[i + 8],
-                            v_sync_end : res_modes[i + 9],
-                            v_total : res_modes[i + 10],
-                            modeflags : res_modes[i + 12],
-                            name : buf.slice(pos, pos + res_modes[i + 11]).toString()
-                        });
-
-                        pos += res_modes[i + 11];
-                    }
-
-                    return resources;
-                },
+            X.pack_stream.flush();
+        },
+        ext.GetScreenResourcesCurrent = (win, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(25, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(win >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                unpackScreenResources,
                 cb
             ];
 
@@ -327,7 +340,7 @@ exports.requireExt = (display, callback) => {
                     for (i = 0; i < res[9]; ++i)
                         info.clones.push(buf.readUInt32LE(pos + i * 4));
                     pos +=  res[9] << 2;
-                    info.name = buf.slice(pos, pos + res_modes[10]).toString('binary');
+                    info.name = buf.slice(pos, pos + res[10]).toString('binary');
                     return info;
                 },
                 cb
@@ -375,6 +388,7 @@ exports.requireExt = (display, callback) => {
                     info.output = [];
                     for (let i = 0; i < res[8]; ++i)
                         info.output.push(buf.readUInt32LE(pos + i * 4));
+                    pos += res[8] << 2;
                     info.possible = [];
                     for (let i = 0; i < res[9]; ++i)
                         info.possible.push(buf.readUInt32LE(pos + i * 4));
@@ -383,6 +397,504 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
 
+            X.pack_stream.flush();
+        },
+
+        ext.GetScreenSizeRange = (win, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(6, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(win >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        minWidth : buf.readUInt16LE(0),
+                        minHeight : buf.readUInt16LE(2),
+                        maxWidth : buf.readUInt16LE(4),
+                        maxHeight : buf.readUInt16LE(6)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        // width/height in pixels, mmWidth/mmHeight in millimeters
+        ext.SetScreenSize = (win, width, height, mmWidth, mmHeight) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(20);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(7, 1);
+            b.writeUInt16LE(5, 2);
+            b.writeUInt32LE(win >>> 0, 4);
+            b.writeUInt16LE(width, 8);
+            b.writeUInt16LE(height, 10);
+            b.writeUInt32LE(mmWidth >>> 0, 12);
+            b.writeUInt32LE(mmHeight >>> 0, 16);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        ext.ListOutputProperties = (output, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(10, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numAtoms = buf.readUInt16LE(0);
+                    const atoms = [];
+                    for (let i = 0; i < numAtoms; ++i)
+                        atoms.push(buf.readUInt32LE(24 + i * 4));
+                    return atoms;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        ext.QueryOutputProperty = (output, property, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(11, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            b.writeUInt32LE(property >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const info = {
+                        pending : !!buf.readUInt8(0),
+                        range : !!buf.readUInt8(1),
+                        immutable : !!buf.readUInt8(2),
+                        validValues : []
+                    };
+                    // list length == reply length field == (buf.length - 24) / 4
+                    for (let pos = 24; pos + 4 <= buf.length; pos += 4)
+                        info.validValues.push(buf.readInt32LE(pos));
+                    return info;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        // values: array of INT32 (min/max pair when range, else list of valid values)
+        ext.ConfigureOutputProperty = (output, property, pending, range, values) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(16 + values.length * 4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(12, 1);
+            b.writeUInt16LE(4 + values.length, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            b.writeUInt32LE(property >>> 0, 8);
+            b.writeUInt8(pending ? 1 : 0, 12);
+            b.writeUInt8(range ? 1 : 0, 13);
+            values.forEach((v, i) => {
+                b.writeInt32LE(v, 16 + i * 4);
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        // mode: 0 replace, 1 prepend, 2 append; format: 8/16/32
+        // data: Buffer (raw bytes), array of numbers (format units) or string
+        ext.ChangeOutputProperty = (output, property, type, format, mode, data) => {
+            X.seq_num ++;
+            let payload;
+            if (Buffer.isBuffer(data)) {
+                payload = data;
+            } else if (Array.isArray(data)) {
+                payload = Buffer.alloc(data.length * (format >> 3));
+                data.forEach((v, i) => {
+                    if (format === 32)
+                        payload.writeUInt32LE(v >>> 0, i * 4);
+                    else if (format === 16)
+                        payload.writeUInt16LE(v, i * 2);
+                    else
+                        payload.writeUInt8(v, i);
+                });
+            } else {
+                payload = Buffer.from(String(data), 'latin1');
+            }
+
+            const padded = (payload.length + 3) & ~3;
+            const b = Buffer.alloc(24 + padded);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(13, 1);
+            b.writeUInt16LE((24 + padded) >> 2, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            b.writeUInt32LE(property >>> 0, 8);
+            b.writeUInt32LE(type >>> 0, 12);
+            b.writeUInt8(format, 16);
+            b.writeUInt8(mode, 17);
+            b.writeUInt32LE((payload.length / (format >> 3)) >>> 0, 20);
+            payload.copy(b, 24);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        ext.DeleteOutputProperty = (output, property) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(14, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            b.writeUInt32LE(property >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        // longOffset/longLength in 4-byte units (as in core GetProperty)
+        ext.GetOutputProperty = (output, property, type, longOffset, longLength, del, pending, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(28);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(15, 1);
+            b.writeUInt16LE(7, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            b.writeUInt32LE(property >>> 0, 8);
+            b.writeUInt32LE(type >>> 0, 12);
+            b.writeUInt32LE(longOffset >>> 0, 16);
+            b.writeUInt32LE(longLength >>> 0, 20);
+            b.writeUInt8(del ? 1 : 0, 24);
+            b.writeUInt8(pending ? 1 : 0, 25);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const format = opt;
+                    const numItems = buf.readUInt32LE(8);
+                    return {
+                        format : format,
+                        type : buf.readUInt32LE(0),
+                        bytesAfter : buf.readUInt32LE(4),
+                        numItems : numItems,
+                        data : buf.slice(24, 24 + numItems * (format >> 3))
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        // modeInfo: { width, height, dot_clock, h_sync_start, h_sync_end, h_total, h_skew,
+        //             v_sync_start, v_sync_end, v_total, modeflags, name } (id chosen by server)
+        ext.CreateMode = (win, modeInfo, cb) => {
+            X.seq_num ++;
+            const name = modeInfo.name || '';
+            const padded = (name.length + 3) & ~3;
+            const b = Buffer.alloc(40 + padded);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(16, 1);
+            b.writeUInt16LE((40 + padded) >> 2, 2);
+            b.writeUInt32LE(win >>> 0, 4);
+            b.writeUInt32LE((modeInfo.id || 0) >>> 0, 8);
+            b.writeUInt16LE(modeInfo.width, 12);
+            b.writeUInt16LE(modeInfo.height, 14);
+            b.writeUInt32LE((modeInfo.dot_clock || 0) >>> 0, 16);
+            b.writeUInt16LE(modeInfo.h_sync_start || 0, 20);
+            b.writeUInt16LE(modeInfo.h_sync_end || 0, 22);
+            b.writeUInt16LE(modeInfo.h_total || 0, 24);
+            b.writeUInt16LE(modeInfo.h_skew || 0, 26);
+            b.writeUInt16LE(modeInfo.v_sync_start || 0, 28);
+            b.writeUInt16LE(modeInfo.v_sync_end || 0, 30);
+            b.writeUInt16LE(modeInfo.v_total || 0, 32);
+            b.writeUInt16LE(name.length, 34);
+            b.writeUInt32LE((modeInfo.modeflags || 0) >>> 0, 36);
+            b.write(name, 40, 'latin1');
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => buf.readUInt32LE(0),
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        ext.DestroyMode = (mode) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(17, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(mode >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        ext.AddOutputMode = (output, mode) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(18, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            b.writeUInt32LE(mode >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        ext.DeleteOutputMode = (output, mode) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(19, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(output >>> 0, 4);
+            b.writeUInt32LE(mode >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        // status is ext.ConfigStatus; mode 0 disables the crtc (outputs must be [])
+        ext.SetCrtcConfig = (crtc, ts, configTs, x, y, mode, rotation, outputs, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(28 + outputs.length * 4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(21, 1);
+            b.writeUInt16LE(7 + outputs.length, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            b.writeUInt32LE(ts >>> 0, 8);
+            b.writeUInt32LE(configTs >>> 0, 12);
+            b.writeInt16LE(x, 16);
+            b.writeInt16LE(y, 18);
+            b.writeUInt32LE(mode >>> 0, 20);
+            b.writeUInt16LE(rotation, 24);
+            outputs.forEach((o, i) => {
+                b.writeUInt32LE(o >>> 0, 28 + i * 4);
+            });
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        status : opt,
+                        timestamp : buf.readUInt32LE(0)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        ext.GetCrtcGammaSize = (crtc, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(22, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => buf.readUInt16LE(0),
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        ext.GetCrtcGamma = (crtc, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(23, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const size = buf.readUInt16LE(0);
+                    const gamma = { size : size, red : [], green : [], blue : [] };
+                    for (let i = 0; i < size; ++i) {
+                        gamma.red.push(buf.readUInt16LE(24 + i * 2));
+                        gamma.green.push(buf.readUInt16LE(24 + (size + i) * 2));
+                        gamma.blue.push(buf.readUInt16LE(24 + (2 * size + i) * 2));
+                    }
+                    return gamma;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        // red/green/blue: equal-length arrays of CARD16 (length == GetCrtcGammaSize)
+        ext.SetCrtcGamma = (crtc, red, green, blue) => {
+            X.seq_num ++;
+            const size = red.length;
+            const padded = (size * 6 + 3) & ~3;
+            const b = Buffer.alloc(12 + padded);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(24, 1);
+            b.writeUInt16LE((12 + padded) >> 2, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            b.writeUInt16LE(size, 8);
+            for (let i = 0; i < size; ++i) {
+                b.writeUInt16LE(red[i], 12 + i * 2);
+                b.writeUInt16LE(green[i], 12 + (size + i) * 2);
+                b.writeUInt16LE(blue[i], 12 + (2 * size + i) * 2);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        // transform: array of 9 floats (3x3 row-major matrix, converted to 16.16 FIXED —
+        // values are rounded to 1/65536); filterParams: array of floats (FIXED on the wire)
+        ext.SetCrtcTransform = (crtc, transform, filterName, filterParams) => {
+            X.seq_num ++;
+            filterName = filterName || '';
+            filterParams = filterParams || [];
+            const padded = (filterName.length + 3) & ~3;
+            const total = 48 + padded + filterParams.length * 4;
+            const b = Buffer.alloc(total);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(26, 1);
+            b.writeUInt16LE(total >> 2, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            writeTransform(b, 8, transform);
+            b.writeUInt16LE(filterName.length, 44);
+            b.write(filterName, 48, 'latin1');
+            filterParams.forEach((v, i) => {
+                b.writeInt32LE(Math.round(v * 65536), 48 + padded + i * 4);
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        ext.GetCrtcTransform = (crtc, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(27, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const info = {
+                        pendingTransform : readTransform(buf, 0),
+                        hasTransforms : !!buf.readUInt8(36),
+                        currentTransform : readTransform(buf, 40)
+                    };
+                    const pendingLen = buf.readUInt16LE(80);
+                    const pendingNparams = buf.readUInt16LE(82);
+                    const currentLen = buf.readUInt16LE(84);
+                    const currentNparams = buf.readUInt16LE(86);
+                    let pos = 88;
+                    info.pendingFilter = buf.slice(pos, pos + pendingLen).toString('binary');
+                    pos += (pendingLen + 3) & ~3;
+                    info.pendingParams = [];
+                    for (let i = 0; i < pendingNparams; ++i)
+                        info.pendingParams.push(buf.readInt32LE(pos + i * 4) / 65536);
+                    pos += pendingNparams * 4;
+                    info.currentFilter = buf.slice(pos, pos + currentLen).toString('binary');
+                    pos += (currentLen + 3) & ~3;
+                    info.currentParams = [];
+                    for (let i = 0; i < currentNparams; ++i)
+                        info.currentParams.push(buf.readInt32LE(pos + i * 4) / 65536);
+                    return info;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        ext.GetPanning = (crtc, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(28, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        status : opt,
+                        timestamp : buf.readUInt32LE(0),
+                        left : buf.readUInt16LE(4),
+                        top : buf.readUInt16LE(6),
+                        width : buf.readUInt16LE(8),
+                        height : buf.readUInt16LE(10),
+                        trackLeft : buf.readUInt16LE(12),
+                        trackTop : buf.readUInt16LE(14),
+                        trackWidth : buf.readUInt16LE(16),
+                        trackHeight : buf.readUInt16LE(18),
+                        borderLeft : buf.readInt16LE(20),
+                        borderTop : buf.readInt16LE(22),
+                        borderRight : buf.readInt16LE(24),
+                        borderBottom : buf.readInt16LE(26)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        // panning: object with the same fields GetPanning returns (left, top, width, height,
+        // trackLeft, trackTop, trackWidth, trackHeight, borderLeft/Top/Right/Bottom)
+        ext.SetPanning = (crtc, ts, panning, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(36);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(29, 1);
+            b.writeUInt16LE(9, 2);
+            b.writeUInt32LE(crtc >>> 0, 4);
+            b.writeUInt32LE(ts >>> 0, 8);
+            b.writeUInt16LE(panning.left, 12);
+            b.writeUInt16LE(panning.top, 14);
+            b.writeUInt16LE(panning.width, 16);
+            b.writeUInt16LE(panning.height, 18);
+            b.writeUInt16LE(panning.trackLeft, 20);
+            b.writeUInt16LE(panning.trackTop, 22);
+            b.writeUInt16LE(panning.trackWidth, 24);
+            b.writeUInt16LE(panning.trackHeight, 26);
+            b.writeInt16LE(panning.borderLeft, 28);
+            b.writeInt16LE(panning.borderTop, 30);
+            b.writeInt16LE(panning.borderRight, 32);
+            b.writeInt16LE(panning.borderBottom, 34);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        status : opt,
+                        timestamp : buf.readUInt32LE(0)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        },
+
+        // output = 0 (None) clears the primary output
+        ext.SetOutputPrimary = (win, output) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(30, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(win >>> 0, 4);
+            b.writeUInt32LE(output >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        },
+
+        ext.GetOutputPrimary = (win, cb) => {
+            X.seq_num ++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(31, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(win >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => buf.readUInt32LE(0),
+                cb
+            ];
             X.pack_stream.flush();
         },
 

--- a/lib/ext/record.js
+++ b/lib/ext/record.js
@@ -1,0 +1,302 @@
+// RECORD extension: https://xorg.freedesktop.org/releases/X11R7.7/doc/recordproto/record.txt
+// xcb-proto: autogen/proto/record.xml
+
+// A RANGE struct is 24 bytes on the wire:
+//   Range8  core_requests   (first, last)                 2
+//   Range8  core_replies                                  2
+//   ExtRange ext_requests   (Range8 major, Range16 minor) 6
+//   ExtRange ext_replies                                  6
+//   Range8  delivered_events                              2
+//   Range8  device_events                                 2
+//   Range8  errors                                        2
+//   BOOL    client_started                                1
+//   BOOL    client_died                                   1
+const RANGE_SIZE = 24;
+
+// range8: {first, last}; extRange: {major: {first, last}, minor: {first, last}}
+function range8(r) {
+    r = r || {};
+    return { first: r.first || 0, last: r.last || 0 };
+}
+
+function extRange(r) {
+    r = r || {};
+    return { major: range8(r.major), minor: range8(r.minor) };
+}
+
+function packRange(b, off, range) {
+    range = range || {};
+    const cr = range8(range.coreRequests);
+    b.writeUInt8(cr.first, off);
+    b.writeUInt8(cr.last, off + 1);
+    const cp = range8(range.coreReplies);
+    b.writeUInt8(cp.first, off + 2);
+    b.writeUInt8(cp.last, off + 3);
+    const er = extRange(range.extRequests);
+    b.writeUInt8(er.major.first, off + 4);
+    b.writeUInt8(er.major.last, off + 5);
+    b.writeUInt16LE(er.minor.first, off + 6);
+    b.writeUInt16LE(er.minor.last, off + 8);
+    const ep = extRange(range.extReplies);
+    b.writeUInt8(ep.major.first, off + 10);
+    b.writeUInt8(ep.major.last, off + 11);
+    b.writeUInt16LE(ep.minor.first, off + 12);
+    b.writeUInt16LE(ep.minor.last, off + 14);
+    const de = range8(range.deliveredEvents);
+    b.writeUInt8(de.first, off + 16);
+    b.writeUInt8(de.last, off + 17);
+    const dv = range8(range.deviceEvents);
+    b.writeUInt8(dv.first, off + 18);
+    b.writeUInt8(dv.last, off + 19);
+    const en = range8(range.errors);
+    b.writeUInt8(en.first, off + 20);
+    b.writeUInt8(en.last, off + 21);
+    b.writeUInt8(range.clientStarted ? 1 : 0, off + 22);
+    b.writeUInt8(range.clientDied ? 1 : 0, off + 23);
+}
+
+function parseRange8(buf, off) {
+    return { first: buf.readUInt8(off), last: buf.readUInt8(off + 1) };
+}
+
+function parseRange(buf, off) {
+    return {
+        coreRequests: parseRange8(buf, off),
+        coreReplies: parseRange8(buf, off + 2),
+        extRequests: {
+            major: parseRange8(buf, off + 4),
+            minor: { first: buf.readUInt16LE(off + 6), last: buf.readUInt16LE(off + 8) }
+        },
+        extReplies: {
+            major: parseRange8(buf, off + 10),
+            minor: { first: buf.readUInt16LE(off + 12), last: buf.readUInt16LE(off + 14) }
+        },
+        deliveredEvents: parseRange8(buf, off + 16),
+        deviceEvents: parseRange8(buf, off + 18),
+        errors: parseRange8(buf, off + 20),
+        clientStarted: buf.readUInt8(off + 22) !== 0,
+        clientDied: buf.readUInt8(off + 23) !== 0
+    };
+}
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('RECORD', (err, ext) => {
+
+        if (err)
+            return callback(err);
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        // HType: bitmask used in element headers
+        ext.HType = {
+            FromServerTime: 1,      // bit 0
+            FromClientTime: 2,      // bit 1
+            FromClientSequence: 4   // bit 2
+        };
+
+        // ClientSpec pseudo-clients
+        ext.CS = {
+            CurrentClients: 1,
+            FutureClients: 2,
+            AllClients: 3
+        };
+
+        // EnableContext reply category (the "data1" byte of each reply)
+        ext.Category = {
+            FromServer: 0,
+            FromClient: 1,
+            ClientStarted: 2,
+            ClientDied: 3,
+            StartOfData: 4,
+            EndOfData: 5
+        };
+
+        ext.QueryVersion = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt16LE(clientMaj, 4);
+            b.writeUInt16LE(clientMin, 6);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => [buf.readUInt16LE(0), buf.readUInt16LE(2)],
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        // shared body for CreateContext (opcode 1) and RegisterClients (opcode 2)
+        const packContextRanges = (minor, context, elementHeader, clientSpecs, ranges) => {
+            clientSpecs = clientSpecs || [];
+            ranges = ranges || [];
+            const len = 20 + clientSpecs.length * 4 + ranges.length * RANGE_SIZE;
+            const b = Buffer.alloc(len);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(minor, 1);
+            b.writeUInt16LE(len >> 2, 2);
+            b.writeUInt32LE(context >>> 0, 4);
+            b.writeUInt8(elementHeader || 0, 8);
+            // 3 bytes pad
+            b.writeUInt32LE(clientSpecs.length, 12);
+            b.writeUInt32LE(ranges.length, 16);
+            let off = 20;
+            clientSpecs.forEach(cs => {
+                b.writeUInt32LE(cs >>> 0, off);
+                off += 4;
+            });
+            ranges.forEach(r => {
+                packRange(b, off, r);
+                off += RANGE_SIZE;
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.CreateContext = (context, elementHeader, clientSpecs, ranges) => {
+            X.seq_num++;
+            packContextRanges(1, context, elementHeader, clientSpecs, ranges);
+        };
+
+        ext.RegisterClients = (context, elementHeader, clientSpecs, ranges) => {
+            X.seq_num++;
+            packContextRanges(2, context, elementHeader, clientSpecs, ranges);
+        };
+
+        ext.UnregisterClients = (context, clientSpecs) => {
+            X.seq_num++;
+            clientSpecs = clientSpecs || [];
+            const len = 12 + clientSpecs.length * 4;
+            const b = Buffer.alloc(len);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(len >> 2, 2);
+            b.writeUInt32LE(context >>> 0, 4);
+            b.writeUInt32LE(clientSpecs.length, 8);
+            let off = 12;
+            clientSpecs.forEach(cs => {
+                b.writeUInt32LE(cs >>> 0, off);
+                off += 4;
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.GetContext = (context, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(context >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    // opt === enabled (BOOL, the data1 byte)
+                    const num = buf.readUInt32LE(4);
+                    const clients = [];
+                    // intercepted_clients list begins at reply offset 32 => buf offset 24
+                    let off = 24;
+                    for (let i = 0; i < num; ++i) {
+                        const clientResource = buf.readUInt32LE(off);
+                        const numRanges = buf.readUInt32LE(off + 4);
+                        off += 8;
+                        const ranges = [];
+                        for (let j = 0; j < numRanges; ++j) {
+                            ranges.push(parseRange(buf, off));
+                            off += RANGE_SIZE;
+                        }
+                        clients.push({ clientResource, ranges });
+                    }
+                    return {
+                        enabled: opt !== 0,
+                        elementHeader: buf.readUInt8(0),
+                        interceptedClients: clients
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        // EnableContext is a multi-reply request. RECORD keeps sending replies on
+        // the connection this is issued on until DisableContext/FreeContext is
+        // called (from ANOTHER connection). The connection used here must be
+        // dedicated to recording.
+        //
+        // onData(reply) is invoked for each reply as it arrives; cb(err, replies)
+        // fires once EndOfData terminates the series.
+        ext.EnableContext = (context, onData, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(context >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, category) => {
+                    // category is the data1 byte (ext.Category.*)
+                    if (category === ext.Category.EndOfData) {
+                        return; // undefined => terminate the multi-reply series
+                    }
+                    const reply = {
+                        category,
+                        elementHeader: buf.readUInt8(0),
+                        clientSwapped: buf.readUInt8(1) !== 0,
+                        xidBase: buf.readUInt32LE(4),
+                        serverTime: buf.readUInt32LE(8),
+                        recSequenceNum: buf.readUInt32LE(12),
+                        // recorded protocol bytes begin at reply offset 32 => buf offset 24
+                        data: buf.slice(24)
+                    };
+                    if (onData)
+                        onData(reply);
+                    return reply;
+                },
+                cb,
+                true // multi-reply
+            ];
+            X.pack_stream.flush();
+        };
+
+        ext.DisableContext = context => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(6, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(context >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.FreeContext = context => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(7, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(context >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        // BadContext error (number 0): carries the invalid record context id
+        X.errorParsers[ext.firstError + 0] = (error, code, seq, badValue, buf) => {
+            error.badContext = badValue;
+            error.message = 'RECORD BadContext';
+            return error;
+        };
+
+        ext.QueryVersion(1, 13, (err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+};

--- a/lib/ext/render.js
+++ b/lib/ext/render.js
@@ -73,6 +73,9 @@ exports.requireExt = (display, callback) => {
       X.pack_stream.flush();
     };
 
+    // protocol-name alias (spec: QueryPictFormats)
+    ext.QueryPictFormats = callback => ext.QueryPictFormat(callback);
+
     ext.QueryFilters = callback => {
       const b = Buffer.alloc(8);
       b.writeUInt8(ext.majorOpcode, 0);
@@ -100,6 +103,38 @@ exports.requireExt = (display, callback) => {
             offset += len;
           }
           return [aliases, filters];
+        },
+        callback
+      ];
+      X.pack_stream.flush();
+    };
+
+    // only valid for indexed pictformats; on TrueColor-only servers
+    // (e.g. Xvfb) the server answers with a Match error
+    ext.QueryPictIndexValues = (pictformat, callback) => {
+      const b = Buffer.alloc(8);
+      b.writeUInt8(ext.majorOpcode, 0);
+      b.writeUInt8(2, 1);
+      b.writeUInt16LE(2, 2);
+      b.writeUInt32LE(pictformat >>> 0, 4);
+      X.pack_stream.put(b);
+      X.seq_num++;
+      X.replies[X.seq_num] = [
+        (buf, opt) => {
+          const numValues = buf.readUInt32LE(0);
+          const values = [];
+          let offset = 24; // reply offset 32
+          for (let i = 0; i < numValues; ++i) {
+            values.push({
+              pixel: buf.readUInt32LE(offset),
+              red: buf.readUInt16LE(offset + 4),
+              green: buf.readUInt16LE(offset + 6),
+              blue: buf.readUInt16LE(offset + 8),
+              alpha: buf.readUInt16LE(offset + 10)
+            });
+            offset += 12;
+          }
+          return values;
         },
         callback
       ];
@@ -147,7 +182,7 @@ exports.requireExt = (display, callback) => {
         for (let i = 0; i < valueList.length; ++i) {
           const name = valueList[i][0];
           const val = values[name];
-          if (val) {
+          if (val !== undefined) {
             mask |= 1 << i;
             selected.push({ fmt: valueList[i][1], val });
             valuesLength += 4;
@@ -167,6 +202,55 @@ exports.requireExt = (display, callback) => {
       let off = 20;
       for (let i = 0; i < selected.length; ++i)
         off = writeValueField(b, off, selected[i].fmt, selected[i].val);
+      X.pack_stream.put(b);
+      X.pack_stream.flush();
+      X.seq_num++;
+    };
+
+    ext.ChangePicture = (pid, values) => {
+      let mask = 0;
+      const selected = [];
+      for (let i = 0; i < valueList.length; ++i) {
+        const name = valueList[i][0];
+        const val = values[name];
+        if (val !== undefined) {
+          mask |= 1 << i;
+          selected.push({ fmt: valueList[i][1], val });
+        }
+      }
+      const reqLen = 3 + selected.length;
+      const b = Buffer.alloc(reqLen * 4);
+      b.writeUInt8(ext.majorOpcode, 0);
+      b.writeUInt8(5, 1);
+      b.writeUInt16LE(reqLen, 2);
+      b.writeUInt32LE(pid >>> 0, 4);
+      b.writeUInt32LE(mask >>> 0, 8);
+      let off = 12;
+      for (let i = 0; i < selected.length; ++i)
+        off = writeValueField(b, off, selected[i].fmt, selected[i].val);
+      X.pack_stream.put(b);
+      X.pack_stream.flush();
+      X.seq_num++;
+    };
+
+    // rects - flat array [ x1, y1, w1, h1, x2, y2, w2, h2, ... ]
+    ext.SetPictureClipRectangles = (pid, clipXOrigin, clipYOrigin, rects) => {
+      const reqLen = 3 + rects.length / 2;
+      const b = Buffer.alloc(reqLen * 4);
+      b.writeUInt8(ext.majorOpcode, 0);
+      b.writeUInt8(6, 1);
+      b.writeUInt16LE(reqLen, 2);
+      b.writeUInt32LE(pid >>> 0, 4);
+      b.writeInt16LE(clipXOrigin, 8);
+      b.writeInt16LE(clipYOrigin, 10);
+      let off = 12;
+      for (let i = 0; i < rects.length; i += 4) {
+        b.writeInt16LE(rects[i], off);
+        b.writeInt16LE(rects[i + 1], off + 2);
+        b.writeUInt16LE(rects[i + 2], off + 4);
+        b.writeUInt16LE(rects[i + 3], off + 6);
+        off += 8;
+      }
       X.pack_stream.put(b);
       X.pack_stream.flush();
       X.seq_num++;
@@ -346,6 +430,11 @@ exports.requireExt = (display, callback) => {
       ], stops);
     };
 
+    // protocol-name aliases (spec: CreateLinearGradient etc.)
+    ext.CreateLinearGradient = (pid, p1, p2, stops) => ext.LinearGradient(pid, p1, p2, stops);
+    ext.CreateRadialGradient = (pid, p1, p2, r1, r2, stops) => ext.RadialGradient(pid, p1, p2, r1, r2, stops);
+    ext.CreateConicalGradient = (pid, center, angle, stops) => ext.ConicalGradient(pid, center, angle, stops);
+
     ext.FillRectangles = (op, pid, color, rects) => {
       const reqLen = 5 + rects.length / 2;
       const b = Buffer.alloc(reqLen * 4);
@@ -358,10 +447,10 @@ exports.requireExt = (display, callback) => {
         b.writeUInt16LE(colorToFix(color[j]), 12 + j * 2);
       let off = 20;
       for (let i = 0; i < rects.length; i += 4) {
-        b.writeInt16LE(rects[i * 4], off);
-        b.writeInt16LE(rects[i * 4 + 1], off + 2);
-        b.writeUInt16LE(rects[i * 4 + 2], off + 4);
-        b.writeUInt16LE(rects[i * 4 + 3], off + 6);
+        b.writeInt16LE(rects[i], off);
+        b.writeInt16LE(rects[i + 1], off + 2);
+        b.writeUInt16LE(rects[i + 2], off + 4);
+        b.writeUInt16LE(rects[i + 3], off + 6);
         off += 8;
       }
       X.pack_stream.put(b);
@@ -405,11 +494,11 @@ exports.requireExt = (display, callback) => {
       b.writeInt16LE(srcX, 20);
       b.writeInt16LE(srcY, 22);
       let off = 24;
+      // flat list of 10 FIXED values per trapezoid:
+      // top, bottom, left x1,y1,x2,y2, right x1,y1,x2,y2
       for (let i = 0; i < trapz.length; i++) {
-        for (let j = 0; j < 10; ++j) {
-          b.writeInt32LE(floatToFix(trapz[i * 10 + j]), off);
-          off += 4;
-        }
+        b.writeInt32LE(floatToFix(trapz[i]), off);
+        off += 4;
       }
       X.pack_stream.put(b);
       X.pack_stream.flush();
@@ -462,6 +551,33 @@ exports.requireExt = (display, callback) => {
       X.seq_num++;
     };
 
+    // points - flat array of coordinates [ x1, y1, x2, y2, ... ]
+    function putTriPoints(minorOpcode, op, src, srcX, srcY, dst, maskFormat, points) {
+      const reqLen = 6 + points.length;
+      const b = Buffer.alloc(reqLen * 4);
+      b.writeUInt8(ext.majorOpcode, 0);
+      b.writeUInt8(minorOpcode, 1);
+      b.writeUInt16LE(reqLen, 2);
+      b.writeUInt8(op, 4);
+      b.writeUInt32LE(src >>> 0, 8);
+      b.writeUInt32LE(dst >>> 0, 12);
+      b.writeUInt32LE(maskFormat >>> 0, 16);
+      b.writeInt16LE(srcX, 20);
+      b.writeInt16LE(srcY, 22);
+      let off = 24;
+      for (let i = 0; i < points.length; ++i) {
+        b.writeInt32LE(floatToFix(points[i]), off);
+        off += 4;
+      }
+      X.pack_stream.put(b);
+      X.pack_stream.flush();
+      X.seq_num++;
+    }
+
+    ext.TriStrip = (op, src, srcX, srcY, dst, maskFormat, points) => putTriPoints(12, op, src, srcX, srcY, dst, maskFormat, points);
+
+    ext.TriFan = (op, src, srcX, srcY, dst, maskFormat, points) => putTriPoints(13, op, src, srcX, srcY, dst, maskFormat, points);
+
     ext.CreateGlyphSet = (gsid, format) => {
       const b = Buffer.alloc(12);
       b.writeUInt8(ext.majorOpcode, 0);
@@ -492,6 +608,20 @@ exports.requireExt = (display, callback) => {
       b.writeUInt8(19, 1);
       b.writeUInt16LE(2, 2);
       b.writeUInt32LE(gsid >>> 0, 4);
+      X.pack_stream.put(b);
+      X.pack_stream.flush();
+      X.seq_num++;
+    };
+
+    ext.FreeGlyphs = (gsid, glyphIds) => {
+      const reqLen = 2 + glyphIds.length;
+      const b = Buffer.alloc(reqLen * 4);
+      b.writeUInt8(ext.majorOpcode, 0);
+      b.writeUInt8(22, 1);
+      b.writeUInt16LE(reqLen, 2);
+      b.writeUInt32LE(gsid >>> 0, 4);
+      for (let i = 0; i < glyphIds.length; ++i)
+        b.writeUInt32LE(glyphIds[i] >>> 0, 8 + i * 4);
       X.pack_stream.put(b);
       X.pack_stream.flush();
       X.seq_num++;
@@ -798,6 +928,43 @@ exports.requireExt = (display, callback) => {
     ext.CompositeGlyphs16 = (op, src, dst, maskFormat, gsid, srcX, srcY, glyphs) => ext.CompositeGlyphs(16, op, src, dst, maskFormat, gsid, srcX, srcY, glyphs);
 
     ext.CompositeGlyphs32 = (op, src, dst, maskFormat, gsid, srcX, srcY, glyphs) => ext.CompositeGlyphs(32, op, src, dst, maskFormat, gsid, srcX, srcY, glyphs);
+
+    // source must be an ARGB32 picture; x, y - hotspot
+    ext.CreateCursor = (cid, source, x, y) => {
+      const b = Buffer.alloc(16);
+      b.writeUInt8(ext.majorOpcode, 0);
+      b.writeUInt8(27, 1);
+      b.writeUInt16LE(4, 2);
+      b.writeUInt32LE(cid >>> 0, 4);
+      b.writeUInt32LE(source >>> 0, 8);
+      b.writeUInt16LE(x, 12);
+      b.writeUInt16LE(y, 14);
+      X.pack_stream.put(b);
+      X.pack_stream.flush();
+      X.seq_num++;
+    };
+
+    // cursors - array of [ cursor, delayMs ] pairs (or { cursor, delay } objects)
+    ext.CreateAnimCursor = (cid, cursors) => {
+      const reqLen = 2 + cursors.length * 2;
+      const b = Buffer.alloc(reqLen * 4);
+      b.writeUInt8(ext.majorOpcode, 0);
+      b.writeUInt8(31, 1);
+      b.writeUInt16LE(reqLen, 2);
+      b.writeUInt32LE(cid >>> 0, 4);
+      let off = 8;
+      for (let i = 0; i < cursors.length; ++i) {
+        const c = cursors[i];
+        const cursor = Array.isArray(c) ? c[0] : c.cursor;
+        const delay = Array.isArray(c) ? c[1] : c.delay;
+        b.writeUInt32LE(cursor >>> 0, off);
+        b.writeUInt32LE(delay >>> 0, off + 4);
+        off += 8;
+      }
+      X.pack_stream.put(b);
+      X.pack_stream.flush();
+      X.seq_num++;
+    };
 
     // TODO: implement xutil-like code https://github.com/alexer/python-xlib-render/blob/master/xutil.py
 

--- a/lib/ext/res.js
+++ b/lib/ext/res.js
@@ -1,0 +1,208 @@
+// X-Resource extension protocol, version 1.2
+// https://xorg.freedesktop.org/releases/X11R7.7/doc/resourceproto/resproto.txt
+// wire format: autogen/proto/res.xml (v1.0) + xcb-proto res.xml (v1.2)
+
+// TODO: move to templates
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('X-Resource', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        ext.ClientIdMask = {
+            ClientXID: 1,
+            LocalClientPID: 2
+        };
+
+        ext.QueryVersion = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt8(clientMaj, 4);
+            b.writeUInt8(clientMin, 5);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => [buf.readUInt16LE(0), buf.readUInt16LE(2)],
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // Lists all connected clients as { resourceBase, resourceMask } XID ranges
+        ext.QueryClients = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numClients = buf.readUInt32LE(0);
+                    const clients = [];
+                    for (let i = 0; i < numClients; ++i) {
+                        const off = 24 + i * 8;
+                        clients.push({
+                            resourceBase: buf.readUInt32LE(off),
+                            resourceMask: buf.readUInt32LE(off + 4)
+                        });
+                    }
+                    return clients;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // xid: any XID in the client's resource range. Returns a list of
+        // { resourceType (atom), count } for each resource type the client owns.
+        ext.QueryClientResources = (xid, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(xid >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numTypes = buf.readUInt32LE(0);
+                    const types = [];
+                    for (let i = 0; i < numTypes; ++i) {
+                        const off = 24 + i * 8;
+                        types.push({
+                            resourceType: buf.readUInt32LE(off),
+                            count: buf.readUInt32LE(off + 4)
+                        });
+                    }
+                    return types;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // Estimated pixmap memory usage of the client owning `xid`, in bytes.
+        // The 64-bit bytes/bytesOverflow pair is composed into a plain JS number,
+        // exact only up to 2^53 - 1 bytes.
+        ext.QueryClientPixmapBytes = (xid, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(xid >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => buf.readUInt32LE(4) * 0x100000000 + buf.readUInt32LE(0),
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // Since 1.2. specs: array of { client: XID or 0 (all clients),
+        // mask: SETof ext.ClientIdMask or 0 (all methods) }.
+        // Callback gets an array of { client, mask, value } where value is a
+        // list of CARD32s (a single PID for LocalClientPID, empty for ClientXID).
+        ext.QueryClientIds = (specs, cb) => {
+            X.seq_num++;
+            const n = specs.length;
+            const b = Buffer.alloc(8 + n * 8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(2 + 2 * n, 2);
+            b.writeUInt32LE(n, 4);
+            specs.forEach((spec, i) => {
+                b.writeUInt32LE(spec.client >>> 0, 8 + i * 8);
+                b.writeUInt32LE(spec.mask >>> 0, 12 + i * 8);
+            });
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numIds = buf.readUInt32LE(0);
+                    const ids = [];
+                    let off = 24;
+                    for (let i = 0; i < numIds; ++i) {
+                        const id = {
+                            client: buf.readUInt32LE(off),
+                            mask: buf.readUInt32LE(off + 4),
+                            value: []
+                        };
+                        const length = buf.readUInt32LE(off + 8); // in bytes
+                        off += 12;
+                        for (let j = 0; j < length >> 2; ++j) {
+                            id.value.push(buf.readUInt32LE(off));
+                            off += 4;
+                        }
+                        ids.push(id);
+                    }
+                    return ids;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        const parseResourceSizeSpec = (buf, off) => ({
+            resource: buf.readUInt32LE(off),
+            type: buf.readUInt32LE(off + 4),
+            bytes: buf.readUInt32LE(off + 8),
+            refCount: buf.readUInt32LE(off + 12),
+            useCount: buf.readUInt32LE(off + 16)
+        });
+
+        // Since 1.2. client: XID of a client to restrict the query to, or 0.
+        // specs: array of { resource: XID or 0 (all), type: atom or 0 (any type) }.
+        // Callback gets an array of size records; each has the fields of the
+        // main resource ({ resource, type, bytes, refCount, useCount }) plus
+        // crossReferences: a list of the same shape for referenced resources.
+        ext.QueryResourceBytes = (client, specs, cb) => {
+            X.seq_num++;
+            const n = specs.length;
+            const b = Buffer.alloc(12 + n * 8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(3 + 2 * n, 2);
+            b.writeUInt32LE(client >>> 0, 4);
+            b.writeUInt32LE(n, 8);
+            specs.forEach((spec, i) => {
+                b.writeUInt32LE(spec.resource >>> 0, 12 + i * 8);
+                b.writeUInt32LE(spec.type >>> 0, 16 + i * 8);
+            });
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numSizes = buf.readUInt32LE(0);
+                    const sizes = [];
+                    let off = 24;
+                    for (let i = 0; i < numSizes; ++i) {
+                        const size = parseResourceSizeSpec(buf, off);
+                        const numCrossReferences = buf.readUInt32LE(off + 20);
+                        off += 24;
+                        size.crossReferences = [];
+                        for (let j = 0; j < numCrossReferences; ++j) {
+                            size.crossReferences.push(parseResourceSizeSpec(buf, off));
+                            off += 20;
+                        }
+                        sizes.push(size);
+                    }
+                    return sizes;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.QueryVersion(1, 2, (err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/screen-saver.js
+++ b/lib/ext/screen-saver.js
@@ -22,7 +22,8 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.put(b);
             X.replies[X.seq_num] = [
                 (buf, opt) => {
-                    return [buf.readUInt8(0), buf.readUInt8(1)];
+                    // server major/minor are CARD16 at reply offsets 8 and 10
+                    return [buf.readUInt16LE(0), buf.readUInt16LE(2)];
                 },
                 cb
             ];
@@ -31,13 +32,14 @@ exports.requireExt = (display, callback) => {
 
         ext.State = {
             Off: 0,
-	    On: 1,
-            Disabled: 2
+            On: 1,
+            Cycle: 2,
+            Disabled: 3
         };
 
         ext.Kind = {
             Blanked: 0,
-	    Internal: 1,
+            Internal: 1,
             External: 2
         };
 
@@ -72,13 +74,91 @@ exports.requireExt = (display, callback) => {
 
         ext.SelectInput = (drawable, eventMask) => {
             X.seq_num++;
-            console.log('CCSLL', [ext.majorOpcode, 2, 3, drawable, eventMask]);
             const b = Buffer.alloc(12);
             b.writeUInt8(ext.majorOpcode, 0);
             b.writeUInt8(2, 1);
             b.writeUInt16LE(3, 2);
             b.writeUInt32LE(drawable >>> 0, 4);
             b.writeUInt32LE(eventMask >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // Window attribute value-mask bits (same set as core CreateWindow /
+        // ChangeWindowAttributes), packed in ascending mask order, 4 bytes each.
+        const attributeMask = [
+            ['backgroundPixmap',   0x00000001],
+            ['backgroundPixel',    0x00000002],
+            ['borderPixmap',       0x00000004],
+            ['borderPixel',        0x00000008],
+            ['bitGravity',         0x00000010],
+            ['winGravity',         0x00000020],
+            ['backingStore',       0x00000040],
+            ['backingPlanes',      0x00000080],
+            ['backingPixel',       0x00000100],
+            ['overrideRedirect',   0x00000200],
+            ['saveUnder',          0x00000400],
+            ['eventMask',          0x00000800],
+            ['doNotPropagateMask', 0x00001000],
+            ['colormap',           0x00002000],
+            ['cursor',             0x00004000]
+        ];
+
+        // windowClass/depth/visual: 0 = CopyFromParent
+        // values: optional object with CreateWindow-style attribute names
+        ext.SetAttributes = (drawable, x, y, width, height, borderWidth, windowClass, depth, visual, values) => {
+            const list = [];
+            let mask = 0;
+            if (values) {
+                for (let i = 0; i < attributeMask.length; ++i) {
+                    const name = attributeMask[i][0];
+                    if (name in values) {
+                        mask |= attributeMask[i][1];
+                        list.push(values[name]);
+                    }
+                }
+            }
+            X.seq_num++;
+            const b = Buffer.alloc(28 + list.length * 4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(7 + list.length, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeInt16LE(x, 8);
+            b.writeInt16LE(y, 10);
+            b.writeUInt16LE(width, 12);
+            b.writeUInt16LE(height, 14);
+            b.writeUInt16LE(borderWidth, 16);
+            b.writeUInt8(windowClass, 18);
+            b.writeUInt8(depth, 19);
+            b.writeUInt32LE(visual >>> 0, 20);
+            b.writeUInt32LE(mask >>> 0, 24);
+            for (let i = 0; i < list.length; ++i)
+                b.writeUInt32LE(list[i] >>> 0, 28 + i * 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.UnsetAttributes = drawable => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // suspend is a bool; suspensions of one client are counted by the
+        // server, so always pair Suspend(true) with a later Suspend(false)
+        ext.Suspend = suspend => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(suspend ? 1 : 0, 4);
             X.pack_stream.put(b);
             X.pack_stream.flush();
         }
@@ -104,7 +184,7 @@ exports.requireExt = (display, callback) => {
             event.root = raw.readUInt32LE(0);
             event.saverWindow = raw.readUInt32LE(4);
             event.kind = raw.readUInt8(8);
-            event.forced = raw.readUInt32LE(4);
+            event.forced = raw.readUInt8(9);
             event.name = 'ScreenSaverNotify';
             return event;
         };

--- a/lib/ext/shape.js
+++ b/lib/ext/shape.js
@@ -104,6 +104,104 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
+        ext.Combine = (op, destKind, srcKind, destWindow, x, y, srcWindow) => {
+            X.seq_num++;
+//            captureStack();
+            const b = Buffer.alloc(20);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(5, 2);
+            b.writeUInt8(op, 4);
+            b.writeUInt8(destKind, 5);
+            b.writeUInt8(srcKind, 6);
+            b.writeUInt32LE(destWindow >>> 0, 8);
+            b.writeInt16LE(x, 12);
+            b.writeInt16LE(y, 14);
+            b.writeUInt32LE(srcWindow >>> 0, 16);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.Offset = (kind, window, x, y) => {
+            X.seq_num++;
+//            captureStack();
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt8(kind, 4);
+            b.writeUInt32LE(window >>> 0, 8);
+            b.writeInt16LE(x, 12);
+            b.writeInt16LE(y, 14);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.QueryExtents = (window, cb) => {
+            X.seq_num++;
+//            captureStack();
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        boundingShaped: !!buf.readUInt8(0),
+                        clipShaped: !!buf.readUInt8(1),
+                        bounding: {
+                            x: buf.readInt16LE(4),
+                            y: buf.readInt16LE(6),
+                            width: buf.readUInt16LE(8),
+                            height: buf.readUInt16LE(10)
+                        },
+                        clip: {
+                            x: buf.readInt16LE(12),
+                            y: buf.readInt16LE(14),
+                            width: buf.readUInt16LE(16),
+                            height: buf.readUInt16LE(18)
+                        }
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // Returns { ordering, rectangles: [[x, y, width, height]] }
+        ext.GetRectangles = (window, kind, cb) => {
+            X.seq_num++;
+//            captureStack();
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(8, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt8(kind, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const nrects = buf.readUInt32LE(0);
+                    const rectangles = [];
+                    let off = 24; // rectangles start at reply offset 32
+                    for (let i = 0; i < nrects; ++i) {
+                        rectangles.push([
+                            buf.readInt16LE(off),
+                            buf.readInt16LE(off + 2),
+                            buf.readUInt16LE(off + 4),
+                            buf.readUInt16LE(off + 6)
+                        ]);
+                        off += 8;
+                    }
+                    return { ordering: opt, rectangles: rectangles };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
         ext.SelectInput = (window, enable) => {
             X.seq_num++;
 //            captureStack();
@@ -133,16 +231,6 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
-        callback(null, ext);
-
-        /*
-        ext.QueryVersion(function(err, version) {
-            ext.major = version[0];
-            ext.minor = version[1];
-            callback(null, ext);
-        });
-        */
-
         ext.events = {
             ShapeNotify: 0
         }
@@ -165,5 +253,15 @@ exports.requireExt = (display, callback) => {
 
             return event;
         };
+
+        callback(null, ext);
+
+        /*
+        ext.QueryVersion(function(err, version) {
+            ext.major = version[0];
+            ext.minor = version[1];
+            callback(null, ext);
+        });
+        */
     });
 }

--- a/lib/ext/shm.js
+++ b/lib/ext/shm.js
@@ -1,0 +1,194 @@
+// MIT-SHM (shared memory) extension
+// https://xorg.freedesktop.org/releases/X11R7.7/doc/xextproto/shm.txt
+// wire format: autogen/proto/shm.xml
+//
+// NOTE: Node.js has no built-in binding to SysV shared memory (shmget/shmat),
+// and the zero-runtime-dependency rule rules out native addons, so this module
+// only implements the wire protocol; creating/attaching real segments is up to
+// the caller (e.g. via an optional native module providing a shmid).
+//
+// AttachFd (minor opcode 6, SHM 1.2) is NOT implemented: it requires passing
+// a file descriptor over the unix socket with SCM_RIGHTS ancillary data,
+// which plain Node net.Socket cannot do.
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('MIT-SHM', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        // image formats (core protocol values, used by PutImage/GetImage)
+        ext.ImageFormat = {
+            XYBitmap: 0,
+            XYPixmap: 1,
+            ZPixmap: 2
+        };
+
+        ext.QueryVersion = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        sharedPixmaps: !!opt,
+                        majorVersion: buf.readUInt16LE(0),
+                        minorVersion: buf.readUInt16LE(2),
+                        uid: buf.readUInt16LE(4),
+                        gid: buf.readUInt16LE(6),
+                        pixmapFormat: buf.readUInt8(8)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // shmseg: client-allocated XID (X.AllocID()), shmid: SysV segment id
+        ext.Attach = (shmseg, shmid, readOnly) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(shmseg >>> 0, 4);
+            b.writeUInt32LE(shmid >>> 0, 8);
+            b.writeUInt8(readOnly ? 1 : 0, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.Detach = shmseg => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(shmseg >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // img: { totalWidth, totalHeight, srcX, srcY, srcWidth, srcHeight,
+        //        dstX, dstY, depth, format, sendEvent, shmseg, offset }
+        // If sendEvent is true the server sends a ShmCompletion event when
+        // it has finished reading the segment.
+        ext.PutImage = (drawable, gc, img) => {
+            X.seq_num++;
+            const b = Buffer.alloc(40);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(10, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeUInt32LE(gc >>> 0, 8);
+            b.writeUInt16LE(img.totalWidth, 12);
+            b.writeUInt16LE(img.totalHeight, 14);
+            b.writeUInt16LE(img.srcX, 16);
+            b.writeUInt16LE(img.srcY, 18);
+            b.writeUInt16LE(img.srcWidth, 20);
+            b.writeUInt16LE(img.srcHeight, 22);
+            b.writeInt16LE(img.dstX, 24);
+            b.writeInt16LE(img.dstY, 26);
+            b.writeUInt8(img.depth, 28);
+            b.writeUInt8(img.format, 29);
+            b.writeUInt8(img.sendEvent ? 1 : 0, 30);
+            b.writeUInt32LE(img.shmseg >>> 0, 32);
+            b.writeUInt32LE(img.offset >>> 0, 36);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // The image data is written into the shared segment at `offset`;
+        // the reply only carries depth/visual/size.
+        ext.GetImage = (drawable, x, y, width, height, planeMask, format, shmseg, offset, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(32);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(8, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeInt16LE(x, 8);
+            b.writeInt16LE(y, 10);
+            b.writeUInt16LE(width, 12);
+            b.writeUInt16LE(height, 14);
+            b.writeUInt32LE(planeMask >>> 0, 16);
+            b.writeUInt8(format, 20);
+            b.writeUInt32LE(shmseg >>> 0, 24);
+            b.writeUInt32LE(offset >>> 0, 28);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        depth: opt,
+                        visual: buf.readUInt32LE(0),
+                        size: buf.readUInt32LE(4)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // pid: client-allocated pixmap XID backed by the shared segment
+        ext.CreatePixmap = (pid, drawable, width, height, depth, shmseg, offset) => {
+            X.seq_num++;
+            const b = Buffer.alloc(28);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(7, 2);
+            b.writeUInt32LE(pid >>> 0, 4);
+            b.writeUInt32LE(drawable >>> 0, 8);
+            b.writeUInt16LE(width, 12);
+            b.writeUInt16LE(height, 14);
+            b.writeUInt8(depth, 16);
+            b.writeUInt32LE(shmseg >>> 0, 20);
+            b.writeUInt32LE(offset >>> 0, 24);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // AttachFd (minor opcode 6): intentionally not implemented, see note
+        // at the top of this file.
+
+        ext.events = {
+            ShmCompletion: 0
+        };
+
+        X.eventParsers[ext.firstEvent + ext.events.ShmCompletion] = (type, seq, extra, code, raw) => {
+            const event = {};
+            event.name = 'ShmCompletion';
+            event.type = type;
+            event.seq = seq;
+            event.drawable = extra;
+            event.minorEvent = raw.readUInt16LE(0);
+            event.majorEvent = raw.readUInt8(2);
+            event.shmseg = raw.readUInt32LE(4);
+            event.offset = raw.readUInt32LE(8);
+            return event;
+        };
+
+        ext.errors = {
+            BadSeg: 0
+        };
+
+        X.errorParsers[ext.firstError + ext.errors.BadSeg] = err => {
+            err.message = 'MIT-SHM: SEG argument does not name a defined shared memory segment';
+        };
+
+        ext.QueryVersion((err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers.majorVersion;
+            ext.minor = vers.minorVersion;
+            ext.sharedPixmaps = vers.sharedPixmaps;
+            ext.pixmapFormat = vers.pixmapFormat;
+            ext.uid = vers.uid;
+            ext.gid = vers.gid;
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/sync.js
+++ b/lib/ext/sync.js
@@ -1,0 +1,415 @@
+// SYNC extension protocol
+// https://xorg.freedesktop.org/releases/X11R7.7/doc/xextproto/sync.txt
+// wire format: autogen/proto/sync.xml
+
+// INT64 values are transported as (hi: INT32, lo: CARD32) pairs and composed
+// into plain JS numbers. Values with |value| > 2^53 lose precision (the public
+// API deliberately avoids BigInt).
+const readInt64 = (buf, offset) => {
+    const hi = buf.readInt32LE(offset);
+    const lo = buf.readUInt32LE(offset + 4);
+    return hi * 0x100000000 + lo;
+};
+
+const writeInt64 = (buf, value, offset) => {
+    const hi = Math.floor(value / 0x100000000);
+    const lo = value - hi * 0x100000000;
+    buf.writeInt32LE(hi, offset);
+    buf.writeUInt32LE(lo >>> 0, offset + 4);
+};
+
+// [ attribute name, CA mask bit, is INT64 ] — order is the wire order of the
+// value-list, INT64 entries occupy 8 bytes in the list.
+const alarmAttributes = [
+    ['counter',   1 << 0, false],
+    ['valueType', 1 << 1, false],
+    ['value',     1 << 2, true],
+    ['testType',  1 << 3, false],
+    ['delta',     1 << 4, true],
+    ['events',    1 << 5, false]
+];
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('SYNC', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        ext.ValueType = {
+            Absolute: 0,
+            Relative: 1
+        };
+
+        ext.TestType = {
+            PositiveTransition: 0,
+            NegativeTransition: 1,
+            PositiveComparison: 2,
+            NegativeComparison: 3
+        };
+
+        ext.AlarmState = {
+            Active: 0,
+            Inactive: 1,
+            Destroyed: 2
+        };
+
+        ext.CA = {
+            Counter: 1 << 0,
+            ValueType: 1 << 1,
+            Value: 1 << 2,
+            TestType: 1 << 3,
+            Delta: 1 << 4,
+            Events: 1 << 5
+        };
+
+        ext.Initialize = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt8(clientMaj, 4);
+            b.writeUInt8(clientMin, 5);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return [buf.readUInt8(0), buf.readUInt8(1)];
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        ext.ListSystemCounters = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const nCounters = buf.readUInt32LE(0);
+                    const counters = [];
+                    let off = 24;
+                    for (let i = 0; i < nCounters; ++i) {
+                        const counter = buf.readUInt32LE(off);
+                        const resolution = readInt64(buf, off + 4);
+                        const nameLen = buf.readUInt16LE(off + 12);
+                        const name = buf.toString('ascii', off + 14, off + 14 + nameLen);
+                        counters.push({ counter, resolution, name });
+                        off += 14 + nameLen;
+                        off += (4 - (off & 3)) & 3; // each entry is padded to 4 bytes
+                    }
+                    return counters;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        ext.CreateCounter = (id, initialValue) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(id >>> 0, 4);
+            writeInt64(b, initialValue, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.SetCounter = (counter, value) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(counter >>> 0, 4);
+            writeInt64(b, value, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.ChangeCounter = (counter, amount) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(counter >>> 0, 4);
+            writeInt64(b, amount, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.QueryCounter = (counter, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(counter >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return readInt64(buf, 0);
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        ext.DestroyCounter = counter => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(6, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(counter >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        // waitList: array of { counter, valueType, value, testType, eventThreshold }
+        // Blocks (server side) further request processing for this client until
+        // at least one condition is satisfied.
+        ext.Await = waitList => {
+            X.seq_num++;
+            const b = Buffer.alloc(4 + waitList.length * 28);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(7, 1);
+            b.writeUInt16LE(1 + waitList.length * 7, 2);
+            let off = 4;
+            waitList.forEach(cond => {
+                b.writeUInt32LE(cond.counter >>> 0, off);
+                b.writeUInt32LE(cond.valueType || 0, off + 4);
+                writeInt64(b, cond.value || 0, off + 8);
+                b.writeUInt32LE(cond.testType || 0, off + 16);
+                writeInt64(b, cond.eventThreshold || 0, off + 20);
+                off += 28;
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        const packAlarmRequest = (minorOpcode, id, values) => {
+            let mask = 0;
+            let size = 0;
+            alarmAttributes.forEach(attr => {
+                if (values[attr[0]] !== undefined) {
+                    mask |= attr[1];
+                    size += attr[2] ? 8 : 4;
+                }
+            });
+            const b = Buffer.alloc(12 + size);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(minorOpcode, 1);
+            b.writeUInt16LE((12 + size) >> 2, 2);
+            b.writeUInt32LE(id >>> 0, 4);
+            b.writeUInt32LE(mask >>> 0, 8);
+            let off = 12;
+            alarmAttributes.forEach(attr => {
+                const value = values[attr[0]];
+                if (value === undefined)
+                    return;
+                if (attr[2]) {
+                    writeInt64(b, value, off);
+                    off += 8;
+                } else {
+                    b.writeUInt32LE(+value >>> 0, off);
+                    off += 4;
+                }
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        // values: { counter, valueType, value, testType, delta, events }
+        // omitted attributes keep server defaults (value-mask style request)
+        ext.CreateAlarm = (id, values) => {
+            X.seq_num++;
+            packAlarmRequest(8, id, values || {});
+        };
+
+        ext.ChangeAlarm = (id, values) => {
+            X.seq_num++;
+            packAlarmRequest(9, id, values || {});
+        };
+
+        ext.QueryAlarm = (alarm, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(10, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(alarm >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        trigger: {
+                            counter: buf.readUInt32LE(0),
+                            waitType: buf.readUInt32LE(4),
+                            waitValue: readInt64(buf, 8),
+                            testType: buf.readUInt32LE(16)
+                        },
+                        delta: readInt64(buf, 20),
+                        events: !!buf.readUInt8(28),
+                        state: buf.readUInt8(29)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        ext.DestroyAlarm = alarm => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(11, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(alarm >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        // id: client resource XID, or 0 for the requesting client
+        ext.SetPriority = (id, priority) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(12, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(id >>> 0, 4);
+            b.writeInt32LE(priority, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.GetPriority = (id, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(13, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(id >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return buf.readInt32LE(0);
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        // Fence requests (SYNC 3.1)
+
+        ext.CreateFence = (drawable, fence, initiallyTriggered) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(14, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeUInt32LE(fence >>> 0, 8);
+            b.writeUInt8(initiallyTriggered ? 1 : 0, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        const simpleFenceRequest = minorOpcode => fence => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(minorOpcode, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(fence >>> 0, 4);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.TriggerFence = simpleFenceRequest(15);
+        ext.ResetFence = simpleFenceRequest(16);
+        ext.DestroyFence = simpleFenceRequest(17);
+
+        ext.QueryFence = (fence, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(18, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(fence >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return !!buf.readUInt8(0);
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        };
+
+        // Blocks (server side) further request processing for this client until
+        // all fences in the list are in the triggered state.
+        ext.AwaitFence = fenceList => {
+            X.seq_num++;
+            const b = Buffer.alloc(4 + fenceList.length * 4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(19, 1);
+            b.writeUInt16LE(1 + fenceList.length, 2);
+            fenceList.forEach((fence, i) => {
+                b.writeUInt32LE(fence >>> 0, 4 + i * 4);
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        };
+
+        ext.events = {
+            CounterNotify: 0,
+            AlarmNotify: 1
+        };
+
+        X.eventParsers[ext.firstEvent + ext.events.CounterNotify] = (type, seq, extra, code, raw) => {
+            return {
+                type,
+                seq,
+                name: 'CounterNotify',
+                kind: code,
+                counter: extra,
+                waitValue: readInt64(raw, 0),
+                counterValue: readInt64(raw, 8),
+                time: raw.readUInt32LE(16),
+                count: raw.readUInt16LE(20),
+                destroyed: !!raw.readUInt8(22)
+            };
+        };
+
+        X.eventParsers[ext.firstEvent + ext.events.AlarmNotify] = (type, seq, extra, code, raw) => {
+            return {
+                type,
+                seq,
+                name: 'AlarmNotify',
+                kind: code,
+                alarm: extra,
+                counterValue: readInt64(raw, 0),
+                alarmValue: readInt64(raw, 8),
+                time: raw.readUInt32LE(16),
+                state: raw.readUInt8(20)
+            };
+        };
+
+        // the protocol requires Initialize before any other SYNC request
+        ext.Initialize(3, 1, (err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+};

--- a/lib/ext/xc-misc.js
+++ b/lib/ext/xc-misc.js
@@ -10,7 +10,9 @@ exports.requireExt = (display, callback) => {
         if (!ext.present)
             return callback(new Error('extension not available'));
 
-        ext.QueryVersion = (clientMaj, clientMin, cb) => {
+        // spec name is GetVersion; QueryVersion kept as an alias for
+        // backwards compatibility
+        ext.GetVersion = (clientMaj, clientMin, cb) => {
             X.seq_num++;
             const b = Buffer.alloc(8);
             b.writeUInt8(ext.majorOpcode, 0);
@@ -27,6 +29,7 @@ exports.requireExt = (display, callback) => {
             ];
             X.pack_stream.flush();
         }
+        ext.QueryVersion = ext.GetVersion;
 
         ext.GetXIDRange = cb => {
             X.seq_num++;
@@ -60,7 +63,7 @@ exports.requireExt = (display, callback) => {
                     const numIds = buf.readUInt32LE(0);
                     const res = [];
                     for (let i = 0; i < numIds; ++i)
-                        res.push([buf.readUInt32LE(24 + i * 4)]);
+                        res.push(buf.readUInt32LE(24 + i * 4));
                     return res;
                 },
                 cb
@@ -68,7 +71,7 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
-        ext.QueryVersion(1, 1, (err, vers) => {
+        ext.GetVersion(1, 1, (err, vers) => {
             if (err)
                 return callback(err);
             ext.major = vers[0];

--- a/lib/ext/xinerama.js
+++ b/lib/ext/xinerama.js
@@ -1,0 +1,130 @@
+// PanoramiX/Xinerama protocol: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/specs/xinerama/xinerama.txt
+
+// TODO: move to templates
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('XINERAMA', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        ext.QueryVersion = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt8(clientMaj, 4);
+            b.writeUInt8(clientMin, 5);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return [buf.readUInt16LE(0), buf.readUInt16LE(2)];
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.GetState = (window, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => opt,
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.GetScreenCount = (window, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => opt,
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.GetScreenSize = (window, screen, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE(screen >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        width: buf.readUInt32LE(0),
+                        height: buf.readUInt32LE(4)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.IsActive = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => buf.readUInt32LE(0),
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.QueryScreens = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const number = buf.readUInt32LE(0);
+                    const screens = [];
+                    for (let i = 0; i < number; ++i) {
+                        const off = 24 + i * 8;
+                        screens.push({
+                            x: buf.readInt16LE(off),
+                            y: buf.readInt16LE(off + 2),
+                            width: buf.readUInt16LE(off + 4),
+                            height: buf.readUInt16LE(off + 6)
+                        });
+                    }
+                    return screens;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.QueryVersion(1, 1, (err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/xinput.js
+++ b/lib/ext/xinput.js
@@ -1,0 +1,257 @@
+// XInputExtension (partial): XI1 GetExtensionVersion / ListInputDevices
+// plus XI2 XIQueryVersion / XIQueryDevice.
+// https://xorg.freedesktop.org/releases/X11R7.7/doc/inputproto/XIproto.txt
+// Wire layouts cross-checked against X11/extensions/XIproto.h and XI2proto.h.
+
+const extName = 'XInputExtension';
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension(extName, (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        // XI1 device use
+        ext.DeviceUse = {
+            IsXPointer: 0,
+            IsXKeyboard: 1,
+            IsXExtensionDevice: 2,
+            IsXExtensionKeyboard: 3,
+            IsXExtensionPointer: 4
+        };
+        // XI1 input class ids
+        ext.InputClass = {
+            Key: 0, Button: 1, Valuator: 2,
+            Feedback: 3, Proximity: 4, Focus: 5, Other: 6
+        };
+        // XI2 device types
+        ext.DeviceType = {
+            MasterPointer: 1,
+            MasterKeyboard: 2,
+            SlavePointer: 3,
+            SlaveKeyboard: 4,
+            FloatingSlave: 5
+        };
+        // XI2 device class types
+        ext.ClassType = {
+            Key: 0, Button: 1, Valuator: 2, Scroll: 3, Touch: 8, Gesture: 9
+        };
+        ext.AllDevices = 0;
+        ext.AllMasterDevices = 1;
+
+        // XI1 GetExtensionVersion (opcode 1)
+        ext.GetExtensionVersion = cb => {
+            X.seq_num++;
+            const nameLen = extName.length;
+            const b = Buffer.alloc(8 + ((nameLen + 3) & ~3));
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(b.length / 4, 2);
+            b.writeUInt16LE(nameLen, 4);
+            b.write(extName, 8, 'latin1');
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        serverMajor: buf.readUInt16LE(0),
+                        serverMinor: buf.readUInt16LE(2),
+                        present: buf[4]
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // XI1 ListInputDevices (opcode 2)
+        ext.ListInputDevices = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const nDevices = buf[0];
+                    const devices = [];
+                    let off = 24;
+                    for (let i = 0; i < nDevices; ++i) {
+                        devices.push({
+                            type: buf.readUInt32LE(off),
+                            id: buf[off + 4],
+                            numClasses: buf[off + 5],
+                            use: buf[off + 6],
+                            attached: buf[off + 7],
+                            classes: []
+                        });
+                        off += 8;
+                    }
+                    // class info structs, per device, in device order
+                    devices.forEach(dev => {
+                        for (let i = 0; i < dev.numClasses; ++i) {
+                            const classId = buf[off];
+                            const len = buf[off + 1]; // length in bytes
+                            const cls = { classId: classId };
+                            if (classId === ext.InputClass.Key) {
+                                cls.minKeycode = buf[off + 2];
+                                cls.maxKeycode = buf[off + 3];
+                                cls.numKeys = buf.readUInt16LE(off + 4);
+                            } else if (classId === ext.InputClass.Button) {
+                                cls.numButtons = buf.readUInt16LE(off + 2);
+                            } else if (classId === ext.InputClass.Valuator) {
+                                cls.mode = buf[off + 3];
+                                cls.motionBufferSize = buf.readUInt32LE(off + 4);
+                                cls.axes = [];
+                                const numAxes = buf[off + 2];
+                                for (let a = 0; a < numAxes; ++a) {
+                                    const aoff = off + 8 + a * 12;
+                                    cls.axes.push({
+                                        resolution: buf.readUInt32LE(aoff),
+                                        min: buf.readInt32LE(aoff + 4),
+                                        max: buf.readInt32LE(aoff + 8)
+                                    });
+                                }
+                            }
+                            dev.classes.push(cls);
+                            off += len;
+                        }
+                    });
+                    // names: one counted (Pascal-style) string per device
+                    devices.forEach(dev => {
+                        const nameLen = buf[off];
+                        dev.name = buf.toString('latin1', off + 1, off + 1 + nameLen);
+                        off += 1 + nameLen;
+                    });
+                    return devices;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // XI2 XIQueryVersion (opcode 47). Announces the client's supported
+        // version; must precede any other XI2 request.
+        ext.XIQueryVersion = (clientMajor, clientMinor, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(47, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt16LE(clientMajor, 4);
+            b.writeUInt16LE(clientMinor, 6);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        majorVersion: buf.readUInt16LE(0),
+                        minorVersion: buf.readUInt16LE(2)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // FP3232 fixed point -> Number (53-bit mantissa: fine for input axes)
+        const fp3232 = (buf, off) =>
+            buf.readInt32LE(off) + buf.readUInt32LE(off + 4) / 0x100000000;
+
+        const parseDeviceClass = (buf, off) => {
+            const cls = {
+                type: buf.readUInt16LE(off),
+                sourceId: buf.readUInt16LE(off + 4)
+            };
+            if (cls.type === ext.ClassType.Key) {
+                const numKeycodes = buf.readUInt16LE(off + 6);
+                cls.keycodes = [];
+                for (let i = 0; i < numKeycodes; ++i)
+                    cls.keycodes.push(buf.readUInt32LE(off + 8 + i * 4));
+            } else if (cls.type === ext.ClassType.Button) {
+                const numButtons = buf.readUInt16LE(off + 6);
+                cls.numButtons = numButtons;
+                const maskWords = (numButtons + 31) >> 5;
+                cls.state = [];
+                for (let i = 0; i < maskWords; ++i)
+                    cls.state.push(buf.readUInt32LE(off + 8 + i * 4));
+                cls.labels = [];
+                for (let i = 0; i < numButtons; ++i)
+                    cls.labels.push(buf.readUInt32LE(off + 8 + maskWords * 4 + i * 4));
+            } else if (cls.type === ext.ClassType.Valuator) {
+                cls.number = buf.readUInt16LE(off + 6);
+                cls.label = buf.readUInt32LE(off + 8);
+                cls.min = fp3232(buf, off + 12);
+                cls.max = fp3232(buf, off + 20);
+                cls.value = fp3232(buf, off + 28);
+                cls.resolution = buf.readUInt32LE(off + 36);
+                cls.mode = buf[off + 40];
+            } else if (cls.type === ext.ClassType.Scroll) {
+                cls.number = buf.readUInt16LE(off + 6);
+                cls.scrollType = buf.readUInt16LE(off + 8);
+                cls.flags = buf.readUInt32LE(off + 12);
+                cls.increment = fp3232(buf, off + 16);
+            }
+            return cls;
+        }
+
+        // XI2 XIQueryDevice (opcode 48).
+        // deviceId: a device id, or AllDevices (0) / AllMasterDevices (1).
+        ext.XIQueryDevice = (deviceId, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(48, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt16LE(deviceId, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const nDevices = buf.readUInt16LE(0);
+                    const devices = [];
+                    let off = 24;
+                    for (let i = 0; i < nDevices; ++i) {
+                        const dev = {
+                            deviceId: buf.readUInt16LE(off),
+                            use: buf.readUInt16LE(off + 2),
+                            attachment: buf.readUInt16LE(off + 4),
+                            enabled: buf[off + 10],
+                            classes: []
+                        };
+                        const numClasses = buf.readUInt16LE(off + 6);
+                        const nameLen = buf.readUInt16LE(off + 8);
+                        off += 12;
+                        dev.name = buf.toString('latin1', off, off + nameLen);
+                        off += (nameLen + 3) & ~3;
+                        for (let c = 0; c < numClasses; ++c) {
+                            dev.classes.push(parseDeviceClass(buf, off));
+                            off += buf.readUInt16LE(off + 2) * 4; // length is in 4-byte units
+                        }
+                        devices.push(dev);
+                    }
+                    return devices;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // Announce XI2 support (required by the XI2 spec before other XI2
+        // requests), then report the XI1 extension version.
+        ext.XIQueryVersion(2, 2, (err, xi2) => {
+            if (err) {
+                // pre-XI2 server: still usable for the XI1 requests
+                ext.xi2 = null;
+            } else {
+                ext.xi2 = xi2;
+            }
+            ext.GetExtensionVersion((err, vers) => {
+                if (err)
+                    return callback(err);
+                ext.serverMajor = vers.serverMajor;
+                ext.serverMinor = vers.serverMinor;
+                callback(null, ext);
+            });
+        });
+    });
+}

--- a/lib/ext/xkb.js
+++ b/lib/ext/xkb.js
@@ -1,0 +1,437 @@
+// XKEYBOARD extension (partial)
+// https://xorg.freedesktop.org/releases/X11R7.7/doc/kbproto/xkbproto.txt
+// Wire layouts cross-checked against X11/extensions/XKBproto.h
+// (note: xcb-proto xkb.xml omits the modLatches byte of LatchLockState).
+//
+// Implemented requests: UseExtension:0, SelectEvents:1, Bell:3, GetState:4,
+// LatchLockState:5, GetControls:6, GetNames:17.
+// The notoriously complex GetMap:8 (and Set* siblings) are NOT implemented.
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('XKEYBOARD', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        // DeviceSpec / BellClassSpec / IDSpec shorthands
+        ext.UseCoreKbd = 0x100;
+        ext.UseCorePtr = 0x200;
+        ext.DfltXIClass = 0x300;
+        ext.DfltXIId = 0x400;
+        ext.AllXIClass = 0x500;
+        ext.AllXIId = 0x600;
+        ext.XINone = 0xff00;
+
+        ext.ModMask = {
+            Shift: 1, Lock: 2, Control: 4,
+            Mod1: 8, Mod2: 16, Mod3: 32, Mod4: 64, Mod5: 128
+        };
+
+        ext.EventType = {
+            NewKeyboardNotify: 1 << 0,
+            MapNotify: 1 << 1,
+            StateNotify: 1 << 2,
+            ControlsNotify: 1 << 3,
+            IndicatorStateNotify: 1 << 4,
+            IndicatorMapNotify: 1 << 5,
+            NamesNotify: 1 << 6,
+            CompatMapNotify: 1 << 7,
+            BellNotify: 1 << 8,
+            ActionMessage: 1 << 9,
+            AccessXNotify: 1 << 10,
+            ExtensionDeviceNotify: 1 << 11
+        };
+
+        ext.NameDetail = {
+            Keycodes: 1 << 0,
+            Geometry: 1 << 1,
+            Symbols: 1 << 2,
+            PhysSymbols: 1 << 3,
+            Types: 1 << 4,
+            Compat: 1 << 5,
+            KeyTypeNames: 1 << 6,
+            KTLevelNames: 1 << 7,
+            IndicatorNames: 1 << 8,
+            KeyNames: 1 << 9,
+            KeyAliases: 1 << 10,
+            VirtualModNames: 1 << 11,
+            GroupNames: 1 << 12,
+            RGNames: 1 << 13
+        };
+
+        // UseExtension: must be the first XKB request a client issues.
+        ext.UseExtension = (wantedMajor, wantedMinor, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt16LE(wantedMajor, 4);
+            b.writeUInt16LE(wantedMinor, 6);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        supported: opt,
+                        serverMajor: buf.readUInt16LE(0),
+                        serverMinor: buf.readUInt16LE(2)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // Per-event detail payloads of SelectEvents, in wire (= bit) order.
+        // [ EventType bit, details key, per-item byte width ]
+        // MapNotify (bit 1) is controlled by affectMap/map, not by the switch.
+        const selectEventsDetails = [
+            [ext.EventType.NewKeyboardNotify, 'newKeyboardNotify', 2],
+            [ext.EventType.StateNotify, 'stateNotify', 2],
+            [ext.EventType.ControlsNotify, 'controlsNotify', 4],
+            [ext.EventType.IndicatorStateNotify, 'indicatorStateNotify', 4],
+            [ext.EventType.IndicatorMapNotify, 'indicatorMapNotify', 4],
+            [ext.EventType.NamesNotify, 'namesNotify', 2],
+            [ext.EventType.CompatMapNotify, 'compatMapNotify', 1],
+            [ext.EventType.BellNotify, 'bellNotify', 1],
+            [ext.EventType.ActionMessage, 'actionMessage', 1],
+            [ext.EventType.AccessXNotify, 'accessXNotify', 2],
+            [ext.EventType.ExtensionDeviceNotify, 'extensionDeviceNotify', 2]
+        ];
+
+        // SelectEvents. For every bit in (affectWhich & ~clear & ~selectAll)
+        // an [ affect, details ] pair must be supplied in the `details` object,
+        // keyed by event name (e.g. { stateNotify: [ 0x3fff, 0x3fff ] }).
+        // Bits in `clear` / `selectAll` need no detail pair, so the common
+        // "select everything about these events" call is simply
+        //     SelectEvents(deviceSpec, mask, 0, mask, 0, 0)
+        ext.SelectEvents = (deviceSpec, affectWhich, clear, selectAll, affectMap, map, details) => {
+            const detailBits = affectWhich & ~clear & ~selectAll;
+            let extraLen = 0;
+            selectEventsDetails.forEach(spec => {
+                if (detailBits & spec[0]) {
+                    if (!details || !details[spec[1]])
+                        throw new Error('xkb.SelectEvents: missing details.' + spec[1]);
+                    extraLen += 2 * spec[2];
+                }
+            });
+            const b = Buffer.alloc(16 + ((extraLen + 3) & ~3));
+            X.seq_num++;
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(b.length / 4, 2);
+            b.writeUInt16LE(deviceSpec, 4);
+            b.writeUInt16LE(affectWhich, 6);
+            b.writeUInt16LE(clear, 8);
+            b.writeUInt16LE(selectAll, 10);
+            b.writeUInt16LE(affectMap, 12);
+            b.writeUInt16LE(map, 14);
+            let off = 16;
+            selectEventsDetails.forEach(spec => {
+                if (!(detailBits & spec[0]))
+                    return;
+                const pair = details[spec[1]];
+                for (let i = 0; i < 2; ++i) {
+                    if (spec[2] === 1)
+                        b.writeUInt8(pair[i], off);
+                    else if (spec[2] === 2)
+                        b.writeUInt16LE(pair[i], off);
+                    else
+                        b.writeUInt32LE(pair[i] >>> 0, off);
+                    off += spec[2];
+                }
+            });
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // Bell. name/window may be 0 (None).
+        ext.Bell = (deviceSpec, bellClass, bellID, percent, forceSound, eventOnly, pitch, duration, name, window) => {
+            X.seq_num++;
+            const b = Buffer.alloc(28);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(7, 2);
+            b.writeUInt16LE(deviceSpec, 4);
+            b.writeUInt16LE(bellClass, 6);
+            b.writeUInt16LE(bellID, 8);
+            b.writeInt8(percent, 10);
+            b.writeUInt8(forceSound ? 1 : 0, 11);
+            b.writeUInt8(eventOnly ? 1 : 0, 12);
+            b.writeInt16LE(pitch, 14);
+            b.writeInt16LE(duration, 16);
+            b.writeUInt32LE(name >>> 0, 20);
+            b.writeUInt32LE(window >>> 0, 24);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.GetState = (deviceSpec, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt16LE(deviceSpec, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        deviceID: opt,
+                        mods: buf[0],
+                        baseMods: buf[1],
+                        latchedMods: buf[2],
+                        lockedMods: buf[3],
+                        group: buf[4],
+                        lockedGroup: buf[5],
+                        baseGroup: buf.readInt16LE(6),
+                        latchedGroup: buf.readInt16LE(8),
+                        compatState: buf[10],
+                        grabMods: buf[11],
+                        compatGrabMods: buf[12],
+                        lookupMods: buf[13],
+                        compatLookupMods: buf[14],
+                        ptrBtnState: buf.readUInt16LE(16)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.LatchLockState = (deviceSpec, affectModLocks, modLocks, lockGroup, groupLock, affectModLatches, modLatches, latchGroup, groupLatch) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt16LE(deviceSpec, 4);
+            b.writeUInt8(affectModLocks, 6);
+            b.writeUInt8(modLocks, 7);
+            b.writeUInt8(lockGroup ? 1 : 0, 8);
+            b.writeUInt8(groupLock, 9);
+            b.writeUInt8(affectModLatches, 10);
+            b.writeUInt8(modLatches, 11);
+            b.writeUInt8(latchGroup ? 1 : 0, 13);
+            b.writeInt16LE(groupLatch, 14);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.GetControls = (deviceSpec, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(6, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt16LE(deviceSpec, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const perKeyRepeat = [];
+                    for (let i = 0; i < 32; ++i)
+                        perKeyRepeat.push(buf[52 + i]);
+                    return {
+                        deviceID: opt,
+                        mouseKeysDfltBtn: buf[0],
+                        numGroups: buf[1],
+                        groupsWrap: buf[2],
+                        internalModsMask: buf[3],
+                        ignoreLockModsMask: buf[4],
+                        internalModsRealMods: buf[5],
+                        ignoreLockModsRealMods: buf[6],
+                        internalModsVmods: buf.readUInt16LE(8),
+                        ignoreLockModsVmods: buf.readUInt16LE(10),
+                        repeatDelay: buf.readUInt16LE(12),
+                        repeatInterval: buf.readUInt16LE(14),
+                        slowKeysDelay: buf.readUInt16LE(16),
+                        debounceDelay: buf.readUInt16LE(18),
+                        mouseKeysDelay: buf.readUInt16LE(20),
+                        mouseKeysInterval: buf.readUInt16LE(22),
+                        mouseKeysTimeToMax: buf.readUInt16LE(24),
+                        mouseKeysMaxSpeed: buf.readUInt16LE(26),
+                        mouseKeysCurve: buf.readInt16LE(28),
+                        accessXOption: buf.readUInt16LE(30),
+                        accessXTimeout: buf.readUInt16LE(32),
+                        accessXTimeoutOptionsMask: buf.readUInt16LE(34),
+                        accessXTimeoutOptionsValues: buf.readUInt16LE(36),
+                        accessXTimeoutMask: buf.readUInt32LE(40),
+                        accessXTimeoutValues: buf.readUInt32LE(44),
+                        enabledControls: buf.readUInt32LE(48),
+                        perKeyRepeat: perKeyRepeat
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        const popcount = v => {
+            let n = 0;
+            for (; v; v >>>= 1)
+                n += v & 1;
+            return n;
+        }
+
+        ext.GetNames = (deviceSpec, which, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(17, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt16LE(deviceSpec, 4);
+            b.writeUInt32LE(which >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const names = {
+                        deviceID: opt,
+                        which: buf.readUInt32LE(0),
+                        minKeyCode: buf[4],
+                        maxKeyCode: buf[5],
+                        nTypes: buf[6],
+                        groupNames: buf[7],
+                        virtualMods: buf.readUInt16LE(8),
+                        firstKey: buf[10],
+                        nKeys: buf[11],
+                        indicators: buf.readUInt32LE(12),
+                        nRadioGroups: buf[16],
+                        nKeyAliases: buf[17],
+                        nKTLevels: buf.readUInt16LE(18)
+                    };
+                    let off = 24;
+                    const atom = () => {
+                        const v = buf.readUInt32LE(off);
+                        off += 4;
+                        return v;
+                    };
+                    const atoms = n => {
+                        const list = [];
+                        for (let i = 0; i < n; ++i)
+                            list.push(atom());
+                        return list;
+                    };
+                    const w = names.which;
+                    const nd = ext.NameDetail;
+                    // value-list order matches the server's write order
+                    // (which is NOT ascending bit order for the last groups)
+                    if (w & nd.Keycodes)
+                        names.keycodesName = atom();
+                    if (w & nd.Geometry)
+                        names.geometryName = atom();
+                    if (w & nd.Symbols)
+                        names.symbolsName = atom();
+                    if (w & nd.PhysSymbols)
+                        names.physSymbolsName = atom();
+                    if (w & nd.Types)
+                        names.typesName = atom();
+                    if (w & nd.Compat)
+                        names.compatName = atom();
+                    if (w & nd.KeyTypeNames)
+                        names.typeNames = atoms(names.nTypes);
+                    if (w & nd.KTLevelNames) {
+                        const nLevelsPerType = [];
+                        for (let i = 0; i < names.nTypes; ++i)
+                            nLevelsPerType.push(buf[off + i]);
+                        off += (names.nTypes + 3) & ~3;
+                        names.nLevelsPerType = nLevelsPerType;
+                        names.ktLevelNames = atoms(nLevelsPerType.reduce((a, v) => a + v, 0));
+                    }
+                    if (w & nd.IndicatorNames)
+                        names.indicatorNames = atoms(popcount(names.indicators));
+                    if (w & nd.VirtualModNames)
+                        names.virtualModNames = atoms(popcount(names.virtualMods));
+                    if (w & nd.GroupNames)
+                        names.groupNamesList = atoms(popcount(names.groupNames));
+                    if (w & nd.KeyNames) {
+                        names.keyNames = [];
+                        for (let i = 0; i < names.nKeys; ++i) {
+                            const raw = buf.toString('latin1', off, off + 4);
+                            names.keyNames.push(raw.replace(/\0+$/, ''));
+                            off += 4;
+                        }
+                    }
+                    if (w & nd.KeyAliases) {
+                        names.keyAliases = [];
+                        for (let i = 0; i < names.nKeyAliases; ++i) {
+                            names.keyAliases.push({
+                                real: buf.toString('latin1', off, off + 4).replace(/\0+$/, ''),
+                                alias: buf.toString('latin1', off + 4, off + 8).replace(/\0+$/, '')
+                            });
+                            off += 8;
+                        }
+                    }
+                    if (w & nd.RGNames)
+                        names.radioGroupNames = atoms(names.nRadioGroups);
+                    return names;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // XKB multiplexes all its events on one event code; byte 1 of the
+        // event ("code" here) is the xkbType.
+        ext.events = {
+            StateNotify: 2,
+            BellNotify: 8
+        };
+
+        X.eventParsers[ext.firstEvent] = (type, seq, extra, code, raw) => {
+            const event = {
+                type: type,
+                seq: seq,
+                xkbType: code,
+                time: extra,
+                deviceID: raw[0]
+            };
+            if (code === ext.events.StateNotify) {
+                event.name = 'XkbStateNotify';
+                event.mods = raw[1];
+                event.baseMods = raw[2];
+                event.latchedMods = raw[3];
+                event.lockedMods = raw[4];
+                event.group = raw[5];
+                event.baseGroup = raw.readInt16LE(6);
+                event.latchedGroup = raw.readInt16LE(8);
+                event.lockedGroup = raw[10];
+                event.compatState = raw[11];
+                event.grabMods = raw[12];
+                event.compatGrabMods = raw[13];
+                event.lookupMods = raw[14];
+                event.compatLookupMods = raw[15];
+                event.ptrBtnState = raw.readUInt16LE(16);
+                event.changed = raw.readUInt16LE(18);
+                event.keycode = raw[20];
+                event.eventType = raw[21];
+                event.requestMajor = raw[22];
+                event.requestMinor = raw[23];
+            } else if (code === ext.events.BellNotify) {
+                event.name = 'XkbBellNotify';
+                event.bellClass = raw[1];
+                event.bellID = raw[2];
+                event.percent = raw[3];
+                event.pitch = raw.readUInt16LE(4);
+                event.duration = raw.readUInt16LE(6);
+                event.atomName = raw.readUInt32LE(8);
+                event.window = raw.readUInt32LE(12);
+                event.eventOnly = raw[16];
+            } else {
+                event.name = 'XkbEvent';
+                event.raw = raw;
+            }
+            return event;
+        };
+
+        // The protocol requires UseExtension before any other XKB request.
+        ext.UseExtension(1, 0, (err, res) => {
+            if (err)
+                return callback(err);
+            ext.supported = res.supported;
+            ext.serverMajor = res.serverMajor;
+            ext.serverMinor = res.serverMinor;
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/xtest.js
+++ b/lib/ext/xtest.js
@@ -29,6 +29,30 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
+        ext.Cursor = {
+            None: 0,
+            Current: 1
+        };
+
+        // cursor: a CURSOR id, or Cursor.None to test that the window has no
+        // cursor attribute, or Cursor.Current to compare against the cursor
+        // currently being displayed. cb(err, same:boolean)
+        ext.CompareCursor = (window, cursor, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE(cursor >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => !!opt, // "same" is in byte 1 of the reply header
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
         ext.KeyPress = 2;
         ext.KeyRelease = 3;
         ext.ButtonPress = 4;
@@ -45,8 +69,24 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(keycode, 5);
             b.writeUInt32LE(time >>> 0, 8);
             b.writeUInt32LE(wid >>> 0, 12);
-            b.writeInt16LE(x, 32);
-            b.writeInt16LE(y, 34);
+            // rootX/rootY live at offsets 20/22 of the embedded xEvent,
+            // i.e. request offsets 24/26 (offsets 32/34 used before were wrong:
+            // they fell into padding and MotionNotify always moved to 0,0)
+            b.writeInt16LE(x, 24);
+            b.writeInt16LE(y, 26);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        // impervious=true makes this client immune to server grabs by other
+        // clients; ALWAYS pair with a later GrabControl(false)
+        ext.GrabControl = impervious => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt8(impervious ? 1 : 0, 4);
             X.pack_stream.put(b);
             X.pack_stream.flush();
         }

--- a/lib/ext/xv.js
+++ b/lib/ext/xv.js
@@ -1,0 +1,352 @@
+// XVideo (Xv) extension
+// spec: https://xorg.freedesktop.org/releases/X11R7.7/doc/videoproto/xv-protocol-v2.txt
+// xcb:  autogen/proto/xv.xml
+
+const pad4 = n => (n + 3) & ~3;
+
+const readString = (buf, off, len) => {
+    let s = buf.toString('binary', off, off + len);
+    const nul = s.indexOf('\0');
+    if (nul !== -1)
+        s = s.substring(0, nul);
+    return s;
+};
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('XVideo', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        ext.Type = {
+            InputMask: 1,
+            OutputMask: 2,
+            VideoMask: 4,
+            StillMask: 8,
+            ImageMask: 16
+        };
+
+        ext.ImageFormatInfoType = { RGB: 0, YUV: 1 };
+        ext.ImageFormatInfoFormat = { Packed: 0, Planar: 1 };
+        ext.AttributeFlag = { Gettable: 1, Settable: 2 };
+        ext.ScanlineOrder = { TopToBottom: 0, BottomToTop: 1 };
+
+        ext.GrabPortStatus = {
+            Success: 0,
+            BadExtension: 1,
+            AlreadyGrabbed: 2,
+            InvalidTime: 3,
+            BadReply: 4,
+            BadAlloc: 5
+        };
+
+        ext.errors = {
+            BadPort: ext.firstError,
+            BadEncoding: ext.firstError + 1,
+            BadControl: ext.firstError + 2
+        };
+
+        // Xv version request (named QueryExtension in the protocol)
+        ext.QueryExtension = cb => {
+            X.seq_num++;
+            const b = Buffer.alloc(4);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(1, 2);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return [buf.readUInt16LE(0), buf.readUInt16LE(2)];
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.QueryAdaptors = (window, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numAdaptors = buf.readUInt16LE(0);
+                    const adaptors = [];
+                    let off = 24;
+                    for (let i = 0; i < numAdaptors; ++i) {
+                        const adaptor = {
+                            baseId: buf.readUInt32LE(off),
+                            numPorts: buf.readUInt16LE(off + 6),
+                            type: buf.readUInt8(off + 10)
+                        };
+                        const nameSize = buf.readUInt16LE(off + 4);
+                        const numFormats = buf.readUInt16LE(off + 8);
+                        off += 12;
+                        adaptor.name = readString(buf, off, nameSize);
+                        off += pad4(nameSize);
+                        adaptor.formats = [];
+                        for (let j = 0; j < numFormats; ++j) {
+                            adaptor.formats.push({
+                                visual: buf.readUInt32LE(off),
+                                depth: buf.readUInt8(off + 4)
+                            });
+                            off += 8;
+                        }
+                        adaptors.push(adaptor);
+                    }
+                    return adaptors;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.QueryEncodings = (port, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numEncodings = buf.readUInt16LE(0);
+                    const encodings = [];
+                    let off = 24;
+                    for (let i = 0; i < numEncodings; ++i) {
+                        const encoding = {
+                            encoding: buf.readUInt32LE(off),
+                            width: buf.readUInt16LE(off + 6),
+                            height: buf.readUInt16LE(off + 8),
+                            rate: {
+                                numerator: buf.readInt32LE(off + 12),
+                                denominator: buf.readInt32LE(off + 16)
+                            }
+                        };
+                        const nameSize = buf.readUInt16LE(off + 4);
+                        off += 20;
+                        encoding.name = readString(buf, off, nameSize);
+                        off += pad4(nameSize);
+                        encodings.push(encoding);
+                    }
+                    return encodings;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        // time: 0 = CurrentTime; reply is an ext.GrabPortStatus value
+        ext.GrabPort = (port, time, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt32LE(time >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => opt,
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.UngrabPort = (port, time) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt32LE(time >>> 0, 8);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.QueryBestSize = (port, vidW, vidH, drwW, drwH, motion, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(20);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(12, 1);
+            b.writeUInt16LE(5, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt16LE(vidW, 8);
+            b.writeUInt16LE(vidH, 10);
+            b.writeUInt16LE(drwW, 12);
+            b.writeUInt16LE(drwH, 14);
+            b.writeUInt8(motion ? 1 : 0, 16);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    return {
+                        width: buf.readUInt16LE(0),
+                        height: buf.readUInt16LE(2)
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.SetPortAttribute = (port, attribute, value) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(13, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt32LE(attribute >>> 0, 8);
+            b.writeInt32LE(value, 12);
+            X.pack_stream.put(b);
+            X.pack_stream.flush();
+        }
+
+        ext.GetPortAttribute = (port, attribute, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(14, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt32LE(attribute >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => buf.readInt32LE(0),
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.QueryPortAttributes = (port, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(15, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numAttributes = buf.readUInt32LE(0);
+                    const attributes = [];
+                    let off = 24;
+                    for (let i = 0; i < numAttributes; ++i) {
+                        const attr = {
+                            flags: buf.readUInt32LE(off),
+                            min: buf.readInt32LE(off + 4),
+                            max: buf.readInt32LE(off + 8)
+                        };
+                        const size = buf.readUInt32LE(off + 12);
+                        off += 16;
+                        attr.name = readString(buf, off, size);
+                        off += pad4(size);
+                        attributes.push(attr);
+                    }
+                    return attributes;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.ListImageFormats = (port, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(16, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numFormats = buf.readUInt32LE(0);
+                    const formats = [];
+                    let off = 24;
+                    for (let i = 0; i < numFormats; ++i) {
+                        // 128-byte XvImageFormatInfo
+                        formats.push({
+                            id: buf.readUInt32LE(off),
+                            type: buf.readUInt8(off + 4),
+                            byteOrder: buf.readUInt8(off + 5),
+                            guid: Buffer.from(buf.subarray(off + 8, off + 24)),
+                            bpp: buf.readUInt8(off + 24),
+                            numPlanes: buf.readUInt8(off + 25),
+                            depth: buf.readUInt8(off + 28),
+                            redMask: buf.readUInt32LE(off + 32),
+                            greenMask: buf.readUInt32LE(off + 36),
+                            blueMask: buf.readUInt32LE(off + 40),
+                            format: buf.readUInt8(off + 44),
+                            ySampleBits: buf.readUInt32LE(off + 48),
+                            uSampleBits: buf.readUInt32LE(off + 52),
+                            vSampleBits: buf.readUInt32LE(off + 56),
+                            horzYPeriod: buf.readUInt32LE(off + 60),
+                            horzUPeriod: buf.readUInt32LE(off + 64),
+                            horzVPeriod: buf.readUInt32LE(off + 68),
+                            vertYPeriod: buf.readUInt32LE(off + 72),
+                            vertUPeriod: buf.readUInt32LE(off + 76),
+                            vertVPeriod: buf.readUInt32LE(off + 80),
+                            compOrder: readString(buf, off + 84, 32),
+                            scanlineOrder: buf.readUInt8(off + 116)
+                        });
+                        off += 128;
+                    }
+                    return formats;
+                },
+                cb
+            ];
+            X.pack_stream.flush();
+        }
+
+        ext.events = {
+            VideoNotify: 0,
+            PortNotify: 1
+        };
+
+        ext.VideoNotifyReason = {
+            Started: 0,
+            Stopped: 1,
+            Busy: 2,
+            Preempted: 3,
+            HardError: 4
+        };
+
+        X.eventParsers[ext.firstEvent + ext.events.VideoNotify] = (type, seq, extra, code, raw) => {
+            return {
+                name: 'XvVideoNotify',
+                type: type,
+                seq: seq,
+                reason: code,
+                time: extra,
+                drawable: raw.readUInt32LE(0),
+                port: raw.readUInt32LE(4)
+            };
+        };
+
+        X.eventParsers[ext.firstEvent + ext.events.PortNotify] = (type, seq, extra, code, raw) => {
+            return {
+                name: 'XvPortNotify',
+                type: type,
+                seq: seq,
+                time: extra,
+                port: raw.readUInt32LE(0),
+                attribute: raw.readUInt32LE(4),
+                value: raw.readInt32LE(8)
+            };
+        };
+
+        ext.QueryExtension((err, vers) => {
+            if (err)
+                return callback(err);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/generated/core-replies.js
+++ b/lib/generated/core-replies.js
@@ -17,7 +17,7 @@ function unpackGetWindowAttributes(buf, backingStore) {
   result.colormap = buf.readUInt32LE(20);
   result.allEventMasks = buf.readUInt32LE(24);
   result.myEventMasks = buf.readUInt32LE(28);
-  result.doNotPropogateMask = buf.readUInt16LE(32);
+  result.doNotPropagateMask = buf.readUInt16LE(32);
   return result;
 }
 

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -23,17 +23,28 @@ function stash ()
     require('./ext/big-requests');
     require('./ext/composite');
     require('./ext/damage');
+    require('./ext/dbe');
     require('./ext/dpms');
     require('./ext/fixes');
+    require('./ext/ge');
     require('./ext/glxconstants');
     require('./ext/glx');
     require('./ext/glxrender');
+    require('./ext/present');
     require('./ext/randr');
+    require('./ext/record');
     require('./ext/render');
+    require('./ext/res');
     require('./ext/screen-saver');
     require('./ext/shape');
+    require('./ext/shm');
+    require('./ext/sync');
     require('./ext/xc-misc');
+    require('./ext/xinerama');
+    require('./ext/xinput');
+    require('./ext/xkb');
     require('./ext/xtest');
+    require('./ext/xv');
 }
 
 function XClient(displayNum, screenNum, options)
@@ -113,6 +124,8 @@ XClient.prototype.init = function(stream)
 
     this.event_consumers = {}; // maps window id to eventemitter TODO: bad name
     this.eventParsers = {};
+    // GenericEvent (type 35) parsers, keyed by extension major opcode
+    this.geEventParsers = {};
     this.errorParsers = {};
     this._extensions = {};
 
@@ -250,6 +263,14 @@ XClient.prototype.ReleaseID = function(id) {
 XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
 {
     type = type & 0x7F;
+    if (type === 35) {
+        // GenericEvent: code = extension major opcode, extra = extra length
+        // in 4-byte units, raw = event bytes 8+ (evtype at raw offset 0)
+        const geUnpacker = this.geEventParsers[code];
+        if (geUnpacker)
+            return geUnpacker(type, seq, extra, code, raw);
+        return { type: type, seq: seq, extension: code, evtype: raw.readUInt16LE(0), raw: raw };
+    }
     const extUnpacker = this.eventParsers[type];
     if (extUnpacker)
         return extUnpacker(type, seq, extra, code, raw);
@@ -307,14 +328,18 @@ XClient.prototype.expectReplyHeader = function()
                 return;
             } else if (type > 1)
             {
-                client.pack_stream.get(24, buf => {
+                // GenericEvent (35) carries its extra length (in 4-byte units)
+                // where other events keep 32-bit event data
+                const event_body_length = (type & 0x7f) === 35 ? 24 + bad_value * 4 : 24;
+                client.pack_stream.get(event_body_length, buf => {
                     const extra = bad_value;
                     const code = detail;
                     const ev = client.unpackEvent(type, seq_num, extra, code, buf, headerBuf);
 
-                    // raw event 32-bytes packet (primarily for use in SendEvent);
+                    // raw event packet, 32 bytes unless GenericEvent (primarily
+                    // for use in SendEvent);
                     // TODO: Event::pack based on event parameters, inverse to unpackEvent
-                    ev.rawData = Buffer.alloc(32);
+                    ev.rawData = Buffer.alloc(8 + buf.length);
                     headerBuf.copy(ev.rawData);
                     buf.copy(ev.rawData, 8);
 

--- a/test-runner.js
+++ b/test-runner.js
@@ -9,6 +9,31 @@ const mocha = new Mocha({
     reporter : 'spec'
 });
 
+// Extension-specific test files are only added when the server advertises the
+// extension (checked with QueryExtension by on-the-wire name).
+const extensionTests = {
+    'damage.js': 'DAMAGE',
+    'dbe.js': 'DOUBLE-BUFFER',
+    'dpms.js': 'DPMS',
+    'fixes.js': 'XFIXES',
+    'ge.js': 'Generic Event Extension',
+    'present.js': 'Present',
+    'randr.js': 'RANDR',
+    'record.js': 'RECORD',
+    'render.js': 'RENDER',
+    'res.js': 'X-Resource',
+    'screen-saver.js': 'MIT-SCREEN-SAVER',
+    'shape.js': 'SHAPE',
+    'shm.js': 'MIT-SHM',
+    'sync.js': 'SYNC',
+    'xc-misc.js': 'XC-MISC',
+    'xinerama.js': 'XINERAMA',
+    'xinput.js': 'XInputExtension',
+    'xkb.js': 'XKEYBOARD',
+    'xtest.js': 'XTEST',
+    'xv.js': 'XVideo'
+};
+
 // To be able to perform the tests we need the server:
 // 1 - to support the dpms extension.
 // 2 - dpms version is 1.1.
@@ -30,13 +55,6 @@ const run_dpms_test = (X, cb) => {
         } else {
             cb(false);
         }
-    });
-};
-
-const run_xtest_test = (X, cb) => {
-    X.require('xtest', err => {
-        if (!err) cb(true);
-        else cb(false);
     });
 };
 
@@ -68,33 +86,24 @@ x11.createClient((err, display) => {
     async.forEach(
         fs.readdirSync('./test'),
         (file, cb) => {
+            const addIf = run => {
+                if (run) {
+                    mocha.addFile(path.join('./test', file));
+                }
+
+                cb();
+            };
+
             if (file === 'dpms.js') {
-                run_dpms_test(X, run => {
-                    if (run) {
-                        mocha.addFile(path.join('./test', file));
-                    }
-
-                    cb();
-                });
-            } else if (file === 'xtest.js') {
-                run_xtest_test(X, run => {
-                    if (run) {
-                        mocha.addFile(path.join('./test', file));
-                    }
-
-                    cb();
-                });
+                run_dpms_test(X, addIf);
             } else if (file === 'randr.js') {
-                run_randr_test(X, run => {
-                    if (run) {
-                        mocha.addFile(path.join('./test', file));
-                    }
-
-                    cb();
+                run_randr_test(X, addIf);
+            } else if (extensionTests[file]) {
+                X.QueryExtension(extensionTests[file], (err, ext) => {
+                    addIf(!err && ext.present);
                 });
             } else {
-                mocha.addFile(path.join('./test', file));
-                cb();
+                addIf(true);
             }
         },
         () => {

--- a/test/core-colormaps.js
+++ b/test/core-colormaps.js
@@ -56,6 +56,22 @@ describe('Colormap requests', () => {
       });
   });
 
+  it('AllocColor should return closest rgb and a queryable pixel', done => {
+      X.AllocColor(defaultCmap, 0xffff, 0x8080, 0, (err, color) => {
+          should.not.exist(err);
+          color.red.should.equal(0xffff);
+          color.green.should.be.approximately(0x8080, 0x200);
+          color.blue.should.equal(0);
+          X.QueryColors(defaultCmap, [color.pixel], (err2, colors) => {
+              should.not.exist(err2);
+              colors[0].red.should.equal(color.red);
+              colors[0].green.should.equal(color.green);
+              colors[0].blue.should.equal(color.blue);
+              done();
+          });
+      });
+  });
+
   it('AllocNamedColor should allocate named color "blue"', done => {
       X.AllocNamedColor(defaultCmap, 'blue', (err, color) => {
           should.not.exist(err);

--- a/test/damage.js
+++ b/test/damage.js
@@ -1,0 +1,68 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('DAMAGE extension', () => {
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.root = dpy.screen[0].root;
+            self.white = dpy.screen[0].white_pixel;
+            self.black = dpy.screen[0].black_pixel;
+            self.X.require('damage', (err, ext) => {
+                should.not.exist(err);
+                self.damage = ext;
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    it('Create + drawing should deliver a DamageNotify event', function(done) {
+        const X = this.X;
+        const wid = X.AllocID();
+        X.CreateWindow(wid, this.root, 0, 0, 60, 60, 0, 0, 0, 0,
+            { backgroundPixel: this.white });
+        X.MapWindow(wid);
+        const damage = X.AllocID();
+        this.damage.Create(damage, wid, this.damage.ReportLevel.NonEmpty);
+        const gc = X.AllocID();
+        X.CreateGC(gc, wid, { foreground: this.black });
+        const listener = ev => {
+            if (ev.name !== 'DamageNotify' || ev.damage !== damage)
+                return;
+            X.removeListener('event', listener);
+            ev.drawable.should.equal(wid);
+            this.damage.Destroy(damage);
+            X.FreeGC(gc);
+            X.DestroyWindow(wid);
+            done();
+        };
+        X.on('event', listener);
+        X.PolyFillRectangle(wid, gc, [10, 10, 20, 20]);
+    });
+
+    it('Destroy should be accepted by the server (regression: was BadLength)', function(done) {
+        const X = this.X;
+        const damage = X.AllocID();
+        this.damage.Create(damage, this.root, this.damage.ReportLevel.NonEmpty);
+        this.damage.Destroy(damage);
+        const errors = [];
+        const onError = err => errors.push(err);
+        X.on('error', onError);
+        // round-trip to flush any pending error for the requests above
+        X.GetGeometry(this.root, err => {
+            should.not.exist(err);
+            X.removeListener('error', onError);
+            errors.should.have.length(0);
+            done();
+        });
+    });
+
+    after(function(done) {
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/dbe.js
+++ b/test/dbe.js
@@ -1,0 +1,111 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('DOUBLE-BUFFER extension', () => {
+
+    const W = 20;
+    const H = 20;
+
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.root = dpy.screen[0].root;
+            self.white = dpy.screen[0].white_pixel;
+            self.black = dpy.screen[0].black_pixel;
+            self.X.require('dbe', (err, ext) => {
+                should.not.exist(err);
+                self.dbe = ext;
+                self.wid = self.X.AllocID();
+                self.X.CreateWindow(self.wid, self.root, 0, 0, W, H, 0, 0, 0, 0,
+                    { backgroundPixel: self.black });
+                self.X.MapWindow(self.wid);
+                self.gc = self.X.AllocID();
+                self.X.CreateGC(self.gc, self.wid, { foreground: self.white });
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    it('GetVersion should report version 1.0', function() {
+        this.dbe.major.should.equal(1);
+        this.dbe.minor.should.be.aboveOrEqual(0);
+    });
+
+    it('AllocateBackBufferName + GetBackBufferAttributes should round-trip the window', function(done) {
+        const self = this;
+        this.backBuf = this.X.AllocID();
+        this.dbe.AllocateBackBufferName(this.wid, this.backBuf, this.dbe.SwapAction.Undefined);
+        this.dbe.GetBackBufferAttributes(this.backBuf, (err, attrs) => {
+            should.not.exist(err);
+            attrs.window.should.equal(self.wid);
+            done();
+        });
+    });
+
+    it('SwapBuffers should move back buffer contents to the front buffer', function(done) {
+        const self = this;
+        // the back buffer is a drawable: paint it white with a core request
+        this.X.PolyFillRectangle(this.backBuf, this.gc, [0, 0, W, H]);
+        this.X.GetImage(2, this.backBuf, 0, 0, W, H, 0xffffffff, (err, imgBack) => {
+            should.not.exist(err);
+            self.X.GetImage(2, self.wid, 0, 0, W, H, 0xffffffff, (err, imgFrontBefore) => {
+                should.not.exist(err);
+                // front buffer still shows the black window background
+                imgFrontBefore.data.equals(imgBack.data).should.be.false();
+                self.dbe.SwapBuffers([{ window: self.wid, swapAction: self.dbe.SwapAction.Untouched }]);
+                self.X.GetImage(2, self.wid, 0, 0, W, H, 0xffffffff, (err, imgFrontAfter) => {
+                    should.not.exist(err);
+                    imgFrontAfter.data.equals(imgBack.data).should.be.true();
+                    done();
+                });
+            });
+        });
+    });
+
+    it('GetVisualInfo should list double-buffer capable visuals for the root screen', function(done) {
+        this.dbe.GetVisualInfo([this.root], (err, screens) => {
+            should.not.exist(err);
+            screens.should.be.an.Array();
+            screens.length.should.equal(1);
+            screens[0].length.should.be.above(0);
+            screens[0].forEach(info => {
+                info.visual.should.be.above(0);
+                info.depth.should.be.above(0);
+                info.perfLevel.should.be.a.Number();
+            });
+            done();
+        });
+    });
+
+    it('BeginIdiom and EndIdiom should be accepted by the server', function(done) {
+        this.dbe.BeginIdiom();
+        this.dbe.EndIdiom();
+        // round trip to make sure neither request produced an error
+        this.dbe.GetVersion(1, 0, (err, vers) => {
+            should.not.exist(err);
+            vers[0].should.equal(1);
+            done();
+        });
+    });
+
+    it('DeallocateBackBufferName should invalidate the buffer name', function(done) {
+        const self = this;
+        this.dbe.DeallocateBackBufferName(this.backBuf);
+        this.dbe.GetBackBufferAttributes(this.backBuf, (err, attrs) => {
+            should.not.exist(err);
+            attrs.window.should.equal(0); // None: no longer attached to the window
+            done();
+        });
+    });
+
+    after(function(done) {
+        this.X.FreeGC(this.gc);
+        this.X.DestroyWindow(this.wid);
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/fixes.js
+++ b/test/fixes.js
@@ -1,0 +1,366 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('XFIXES extension', () => {
+
+    let display;
+    let X;
+    let F;
+    let root;
+    let xErrors;
+
+    before(done => {
+        const client = x11.createClient((err, dpy) => {
+            if (err)
+                return done(err);
+            display = dpy;
+            X = display.client;
+            root = display.screen[0].root;
+            xErrors = [];
+            X.on('error', e => xErrors.push(e));
+            X.require('fixes', (err, ext) => {
+                should.not.exist(err);
+                F = ext;
+                done();
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(done => {
+        X.terminate();
+        X.on('end', done);
+        X = null;
+        display = null;
+    });
+
+    // Any request with a reply acts as a barrier: once it completes, errors
+    // caused by earlier no-reply requests have already been delivered.
+    const sync = cb => {
+        F.QueryVersion(5, 0, err => {
+            should.not.exist(err);
+            cb();
+        });
+    };
+
+    const assertNoErrors = cb => {
+        sync(() => {
+            xErrors.should.be.empty();
+            cb();
+        });
+    };
+
+    const createRegion = rects => {
+        const region = X.AllocID();
+        F.CreateRegion(region, rects);
+        return region;
+    };
+
+    const white = { R: 0xffff, G: 0xffff, B: 0xffff };
+    const black = { R: 0, G: 0, B: 0 };
+
+    const createGlyphCursor = (sourceChar) => {
+        const fid = X.AllocID();
+        X.OpenFont(fid, 'cursor');
+        const cid = X.AllocID();
+        X.CreateGlyphCursor(cid, fid, fid, sourceChar, sourceChar + 1, black, white);
+        X.CloseFont(fid);
+        return cid;
+    };
+
+    beforeEach(() => {
+        xErrors = [];
+    });
+
+    it('negotiates at least version 5', () => {
+        F.major.should.be.aboveOrEqual(5);
+    });
+
+    it('SetRegion replaces the contents of a region', done => {
+        const region = createRegion([{ x: 0, y: 0, width: 100, height: 100 }]);
+        F.SetRegion(region, [{ x: 1, y: 2, width: 3, height: 4 }]);
+        F.FetchRegion(region, (err, reg) => {
+            should.not.exist(err);
+            reg.extents.should.eql({ x: 1, y: 2, width: 3, height: 4 });
+            reg.rectangles.should.eql([{ x: 1, y: 2, width: 3, height: 4 }]);
+            F.DestroyRegion(region);
+            done();
+        });
+    });
+
+    it('CopyRegion duplicates a region', done => {
+        const src = createRegion([{ x: 7, y: 8, width: 9, height: 10 }]);
+        const dst = createRegion([]);
+        F.CopyRegion(src, dst);
+        F.FetchRegion(dst, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 7, y: 8, width: 9, height: 10 }]);
+            F.DestroyRegion(src);
+            F.DestroyRegion(dst);
+            done();
+        });
+    });
+
+    it('IntersectRegion computes the overlap', done => {
+        const r1 = createRegion([{ x: 0, y: 0, width: 10, height: 10 }]);
+        const r2 = createRegion([{ x: 5, y: 5, width: 10, height: 10 }]);
+        const dst = createRegion([]);
+        F.IntersectRegion(r1, r2, dst);
+        F.FetchRegion(dst, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 5, y: 5, width: 5, height: 5 }]);
+            [r1, r2, dst].forEach(r => F.DestroyRegion(r));
+            done();
+        });
+    });
+
+    it('SubtractRegion computes the difference', done => {
+        const r1 = createRegion([{ x: 0, y: 0, width: 10, height: 10 }]);
+        const r2 = createRegion([{ x: 0, y: 5, width: 10, height: 10 }]);
+        const dst = createRegion([]);
+        F.SubtractRegion(r1, r2, dst);
+        F.FetchRegion(dst, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 0, y: 0, width: 10, height: 5 }]);
+            [r1, r2, dst].forEach(r => F.DestroyRegion(r));
+            done();
+        });
+    });
+
+    it('InvertRegion inverts within bounds', done => {
+        const src = createRegion([{ x: 0, y: 0, width: 10, height: 20 }]);
+        const dst = createRegion([]);
+        F.InvertRegion(src, { x: 0, y: 0, width: 20, height: 20 }, dst);
+        F.FetchRegion(dst, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 10, y: 0, width: 10, height: 20 }]);
+            F.DestroyRegion(src);
+            F.DestroyRegion(dst);
+            done();
+        });
+    });
+
+    it('ExpandRegion grows every rectangle', done => {
+        const region = createRegion([{ x: 10, y: 10, width: 5, height: 5 }]);
+        F.ExpandRegion(region, region, 1, 2, 3, 4);
+        F.FetchRegion(region, (err, reg) => {
+            should.not.exist(err);
+            reg.extents.should.eql({ x: 9, y: 7, width: 8, height: 12 });
+            F.DestroyRegion(region);
+            done();
+        });
+    });
+
+    it('RegionExtents reduces a region to its bounding box', done => {
+        const src = createRegion([
+            { x: 0, y: 0, width: 5, height: 5 },
+            { x: 20, y: 20, width: 5, height: 5 }
+        ]);
+        const dst = createRegion([]);
+        F.RegionExtents(src, dst);
+        F.FetchRegion(dst, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 0, y: 0, width: 25, height: 25 }]);
+            F.DestroyRegion(src);
+            F.DestroyRegion(dst);
+            done();
+        });
+    });
+
+    it('CreateRegionFromBitmap picks up the set bits of a depth-1 pixmap', done => {
+        const pix = X.AllocID();
+        X.CreatePixmap(pix, root, 1, 16, 16);
+        const gc = X.AllocID();
+        X.CreateGC(gc, pix, { foreground: 0 });
+        X.PolyFillRectangle(pix, gc, [0, 0, 16, 16]); // deterministic: clear all bits
+        X.ChangeGC(gc, { foreground: 1 });
+        X.PolyFillRectangle(pix, gc, [2, 3, 4, 5]);
+        const region = X.AllocID();
+        F.CreateRegionFromBitmap(region, pix);
+        F.FetchRegion(region, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 2, y: 3, width: 4, height: 5 }]);
+            F.DestroyRegion(region);
+            X.FreeGC(gc);
+            X.FreePixmap(pix);
+            done();
+        });
+    });
+
+    it('SetGCClipRegion / CreateRegionFromGC round-trip', done => {
+        const gc = X.AllocID();
+        X.CreateGC(gc, root);
+        const clip = createRegion([{ x: 2, y: 3, width: 4, height: 5 }]);
+        F.SetGCClipRegion(gc, clip, 0, 0);
+        const region = X.AllocID();
+        F.CreateRegionFromGC(region, gc);
+        F.FetchRegion(region, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 2, y: 3, width: 4, height: 5 }]);
+            F.SetGCClipRegion(gc, 0, 0, 0); // None: remove the clip again
+            F.DestroyRegion(region);
+            F.DestroyRegion(clip);
+            X.FreeGC(gc);
+            assertNoErrors(done);
+        });
+    });
+
+    it('SetWindowShapeRegion / CreateRegionFromWindow round-trip', done => {
+        const wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, 32, 32);
+        const shape = createRegion([{ x: 0, y: 0, width: 8, height: 8 }]);
+        F.SetWindowShapeRegion(wid, F.WindowRegionKind.Bounding, 0, 0, shape);
+        const region = X.AllocID();
+        F.CreateRegionFromWindow(region, wid, F.WindowRegionKind.Bounding);
+        F.FetchRegion(region, (err, reg) => {
+            should.not.exist(err);
+            reg.rectangles.should.eql([{ x: 0, y: 0, width: 8, height: 8 }]);
+            F.SetWindowShapeRegion(wid, F.WindowRegionKind.Bounding, 0, 0, 0); // None
+            F.DestroyRegion(region);
+            F.DestroyRegion(shape);
+            X.DestroyWindow(wid);
+            assertNoErrors(done);
+        });
+    });
+
+    it('SetPictureClipRegion / CreateRegionFromPicture round-trip', done => {
+        X.require('render', (err, Render) => {
+            should.not.exist(err);
+            const wid = X.AllocID();
+            X.CreateWindow(wid, root, 0, 0, 32, 32);
+            const pict = X.AllocID();
+            Render.CreatePicture(pict, wid, Render.rgb24);
+            const clip = createRegion([{ x: 1, y: 1, width: 6, height: 7 }]);
+            F.SetPictureClipRegion(pict, clip, 0, 0);
+            const region = X.AllocID();
+            F.CreateRegionFromPicture(region, pict);
+            F.FetchRegion(region, (err, reg) => {
+                should.not.exist(err);
+                reg.rectangles.should.eql([{ x: 1, y: 1, width: 6, height: 7 }]);
+                F.DestroyRegion(region);
+                F.DestroyRegion(clip);
+                Render.FreePicture(pict);
+                X.DestroyWindow(wid);
+                done();
+            });
+        });
+    });
+
+    it('SetCursorName / GetCursorName round-trip', done => {
+        const cid = createGlyphCursor(68);
+        F.SetCursorName(cid, 'node-x11-test-cursor');
+        F.GetCursorName(cid, (err, res) => {
+            should.not.exist(err);
+            res.name.should.equal('node-x11-test-cursor');
+            res.atom.should.be.above(0);
+            X.FreeCursor(cid);
+            done();
+        });
+    });
+
+    it('GetCursorImage returns the current cursor image', done => {
+        F.GetCursorImage((err, img) => {
+            should.not.exist(err);
+            img.width.should.be.above(0);
+            img.height.should.be.above(0);
+            img.cursorImage.length.should.equal(img.width * img.height * 4);
+            done();
+        });
+    });
+
+    it('GetCursorImageAndName reports the displayed cursor name; CursorNotify fires', done => {
+        const cid = createGlyphCursor(58);
+        F.SetCursorName(cid, 'node-x11-displayed-cursor');
+        let sawCursorNotify = false;
+        const listener = ev => {
+            if (ev.name === 'CursorNotify') {
+                ev.subtype.should.equal(F.CursorNotify.DisplayCursor);
+                sawCursorNotify = true;
+            }
+        };
+        X.on('event', listener);
+        F.SelectCursorInput(root, F.CursorNotifyMask.DisplayCursor);
+        X.ChangeWindowAttributes(root, { cursor: cid });
+        F.GetCursorImageAndName((err, img) => {
+            should.not.exist(err);
+            img.cursorName.should.equal('node-x11-displayed-cursor');
+            img.cursorAtom.should.be.above(0);
+            img.cursorImage.length.should.equal(img.width * img.height * 4);
+            sawCursorNotify.should.be.true();
+            // restore global state: default cursor, no cursor input events
+            F.SelectCursorInput(root, 0);
+            X.ChangeWindowAttributes(root, { cursor: 0 });
+            X.removeListener('event', listener);
+            X.FreeCursor(cid);
+            assertNoErrors(done);
+        });
+    });
+
+    it('ChangeCursor and ChangeCursorByName update cursor contents', done => {
+        const named = createGlyphCursor(68);
+        const src1 = createGlyphCursor(58);
+        const src2 = createGlyphCursor(130);
+        F.SetCursorName(named, 'node-x11-change-target');
+        F.ChangeCursor(src1, named);
+        F.ChangeCursorByName(src2, 'node-x11-change-target');
+        [named, src1, src2].forEach(c => X.FreeCursor(c));
+        assertNoErrors(done);
+    });
+
+    it('HideCursor / ShowCursor are accepted', done => {
+        F.HideCursor(root);
+        F.ShowCursor(root);
+        assertNoErrors(done);
+    });
+
+    it('CreatePointerBarrier / DeletePointerBarrier are accepted', done => {
+        const barrier = X.AllocID();
+        F.CreatePointerBarrier(barrier, root, 20, 0, 20, 100, F.BarrierDirections.PositiveX);
+        F.DeletePointerBarrier(barrier);
+        assertNoErrors(done);
+    });
+
+    it('SelectSelectionInput delivers SelectionNotify on SetSelectionOwner', done => {
+        const wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, 1, 1);
+        X.InternAtom(false, 'NODE_X11_FIXES_TEST_SELECTION', (err, selAtom) => {
+            should.not.exist(err);
+            const listener = ev => {
+                if (ev.name !== 'SelectionNotify')
+                    return;
+                ev.subtype.should.equal(F.SelectionEvent.SetSelectionOwner);
+                ev.window.should.equal(wid);
+                ev.owner.should.equal(wid);
+                ev.selection.should.equal(selAtom);
+                ev.timestamp.should.be.above(0);
+                X.removeListener('event', listener);
+                F.SelectSelectionInput(wid, selAtom, 0);
+                X.SetSelectionOwner(0, selAtom); // release the selection
+                X.DestroyWindow(wid);
+                assertNoErrors(done);
+            };
+            X.on('event', listener);
+            F.SelectSelectionInput(wid, selAtom, F.SelectionEventMask.SetSelectionOwner);
+            X.SetSelectionOwner(wid, selAtom);
+        });
+    });
+
+    it('ChangeSaveSet accepts a window of another client', done => {
+        const client2 = x11.createClient((err, dpy2) => {
+            should.not.exist(err);
+            const X2 = dpy2.client;
+            const wid2 = X2.AllocID();
+            X2.CreateWindow(wid2, dpy2.screen[0].root, 0, 0, 1, 1);
+            X2.GetGeometry(wid2, err => {   // sync client2 so wid2 exists server-side
+                should.not.exist(err);
+                F.ChangeSaveSet(wid2, F.SaveSetMode.Insert, F.SaveSetTarget.Root, F.SaveSetMap.Unmap);
+                F.ChangeSaveSet(wid2, F.SaveSetMode.Delete, F.SaveSetTarget.Root, F.SaveSetMap.Unmap);
+                assertNoErrors(() => {
+                    X2.terminate();
+                    X2.on('end', done);
+                });
+            });
+        });
+        client2.on('error', done);
+    });
+});

--- a/test/ge.js
+++ b/test/ge.js
@@ -1,0 +1,39 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('Generic Event extension', () => {
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.X.require('ge', (err, ext) => {
+                should.not.exist(err);
+                self.ge = ext;
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    it('QueryVersion should report at least 1.0', function() {
+        this.ge.major.should.be.aboveOrEqual(1);
+        this.ge.minor.should.be.aboveOrEqual(0);
+    });
+
+    it('explicit QueryVersion round-trip should agree with negotiated version', function(done) {
+        const self = this;
+        this.ge.QueryVersion(1, 0, (err, vers) => {
+            should.not.exist(err);
+            vers[0].should.equal(self.ge.major);
+            vers[1].should.equal(self.ge.minor);
+            done();
+        });
+    });
+
+    after(function(done) {
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/present.js
+++ b/test/present.js
@@ -1,0 +1,180 @@
+const x11 = require('../lib');
+const should = require('should');
+
+// Present events (CompleteNotify etc.) are GenericEvents, dispatched via
+// X.geEventParsers (see lib/ext/present.js); the last test below covers the
+// event path, the rest validate requests (PresentPixmap through a core
+// GetImage read-back).
+
+describe('Present extension', () => {
+
+    const W = 40;
+    const H = 40;
+
+    let display;
+    let X;
+    let root;
+    let white;
+    let black;
+    let depth;
+    let present;
+    let wid;
+    let pixmap;
+    let gc;
+    let bytesPP;
+
+    before(done => {
+        const client = x11.createClient((err, dpy) => {
+            if (err)
+                return done(err);
+            display = dpy;
+            X = display.client;
+            root = display.screen[0].root;
+            white = display.screen[0].white_pixel;
+            black = display.screen[0].black_pixel;
+            depth = display.screen[0].root_depth;
+            bytesPP = depth <= 8 ? 1 : (depth <= 16 ? 2 : 4);
+            X.require('present', (err, ext) => {
+                should.not.exist(err);
+                present = ext;
+                done();
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(done => {
+        if (gc) X.FreeGC(gc);
+        if (pixmap) X.FreePixmap(pixmap);
+        if (wid) X.DestroyWindow(wid);
+        X.terminate();
+        X.on('end', done);
+    });
+
+    function getPixel(imageData, x, y) {
+        const off = (y * W + x) * bytesPP;
+        let value = 0;
+        for (let i = 0; i < bytesPP; ++i)
+            value += imageData[off + i] << (8 * i);
+        return value >>> 0;
+    }
+
+    it('QueryVersion should report at least 1.0', () => {
+        present.major.should.be.aboveOrEqual(1);
+        present.minor.should.be.aboveOrEqual(0);
+    });
+
+    it('QueryCapabilities should return a capability mask for the root window', done => {
+        present.QueryCapabilities(root, (err, caps) => {
+            should.not.exist(err);
+            caps.should.be.a.Number();
+            const known = present.Capability.Async | present.Capability.Fence |
+                present.Capability.UST | 8 /* AsyncMayTear */ | 16 /* Syncobj */;
+            (caps & ~known).should.equal(0);
+            done();
+        });
+    });
+
+    it('PresentPixmap should copy pixmap contents onto a mapped window', function(done) {
+        this.timeout(5000);
+        wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, W, H, 0, 0, 0, 0, {
+            backgroundPixel: black,
+            eventMask: x11.eventMask.Exposure | x11.eventMask.StructureNotify
+        });
+        X.MapWindow(wid);
+
+        const onMapped = () => {
+            pixmap = X.AllocID();
+            X.CreatePixmap(pixmap, root, depth, W, H);
+            gc = X.AllocID();
+            X.CreateGC(gc, pixmap, { foreground: white, background: black });
+            X.PolyFillRectangle(pixmap, gc, [0, 0, W, H]); // all white
+
+            present.Pixmap(wid, pixmap, {
+                serial: 1,
+                options: present.Option.Async | present.Option.Copy
+            });
+
+            // the copy happens at the (fake) vblank - poll the window
+            let attempts = 0;
+            const poll = () => {
+                X.GetImage(2, wid, 0, 0, W, H, 0xffffffff, (err, img) => {
+                    should.not.exist(err);
+                    if (getPixel(img.data, W >> 1, H >> 1) === (white >>> 0))
+                        return done();
+                    if (++attempts > 40)
+                        return done(new Error('presented pixel never appeared on the window'));
+                    setTimeout(poll, 50);
+                });
+            };
+            poll();
+        };
+
+        // no WM on Xvfb: MapNotify arrives almost immediately
+        const listener = ev => {
+            if (ev.name === 'MapNotify' && ev.wid === wid) {
+                X.removeListener('event', listener);
+                onMapped();
+            }
+        };
+        X.on('event', listener);
+    });
+
+    it('NotifyMSC with no event selection should not error', function(done) {
+        this.timeout(3000);
+        const errors = [];
+        const onError = err => errors.push(err);
+        X.on('error', onError);
+        present.NotifyMSC(wid, 42, 0, 0, 0);
+        // nobody selected for Present events, so the completion event is
+        // dropped by the server; just verify the request itself is accepted
+        setTimeout(() => {
+            present.QueryCapabilities(root, (err, caps) => {
+                X.removeListener('error', onError);
+                should.not.exist(err);
+                errors.should.have.length(0);
+                done();
+            });
+        }, 100);
+    });
+
+    it('SelectInput with an empty mask should be accepted', done => {
+        const errors = [];
+        const onError = err => errors.push(err);
+        X.on('error', onError);
+        const eid = X.AllocID();
+        present.SelectInput(eid, wid, present.EventMask.NoEvent);
+        present.QueryCapabilities(root, (err, caps) => {
+            X.removeListener('error', onError);
+            should.not.exist(err);
+            errors.should.have.length(0);
+            done();
+        });
+    });
+
+    it('SelectInput + NotifyMSC should deliver a PresentCompleteNotify GenericEvent', function(done) {
+        this.timeout(3000);
+        const eid = X.AllocID();
+        const serial = 12345;
+        const listener = ev => {
+            if (ev.name !== 'PresentCompleteNotify')
+                return;
+            X.removeListener('event', listener);
+            ev.kind.should.equal(present.CompleteKind.NotifyMSC);
+            ev.window.should.equal(wid);
+            ev.serial.should.equal(serial);
+            ev.msc.should.be.a.Number();
+            // a later request must still round-trip: proves the variable-length
+            // GenericEvent did not corrupt the reply stream framing
+            present.QueryCapabilities(root, (err, caps) => {
+                should.not.exist(err);
+                present.SelectInput(eid, wid, present.EventMask.NoEvent);
+                done();
+            });
+        };
+        X.on('event', listener);
+        present.SelectInput(eid, wid, present.EventMask.CompleteNotify);
+        present.NotifyMSC(wid, serial, 0, 0, 0);
+    });
+});

--- a/test/randr.js
+++ b/test/randr.js
@@ -4,6 +4,8 @@ const should = require('should');
 const assert = require('assert');
 const util = require('util');
 
+const IDENTITY = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
 describe('RANDR extension', () => {
     before(function(done) {
         const self = this;
@@ -16,12 +18,35 @@ describe('RANDR extension', () => {
                 should.not.exist(err);
                 self.randr = ext;
                 /* We HAVE to QueryVersion before using it. Otherwise it does not work as expected */
-                self.randr.QueryVersion(1, 2, done);
+                self.randr.QueryVersion(1, 2, err => {
+                    should.not.exist(err);
+                    self.randr.GetScreenResources(self.root, (err, resources) => {
+                        should.not.exist(err);
+                        self.resources = resources;
+                        self.output = resources.outputs[0];
+                        self.crtc = resources.crtcs[0];
+                        done();
+                    });
+                });
             });
         });
 
-        client.on('error', done);
+        client.on('error', err => {
+            if (self.onXError) return self.onXError(err);
+            done(err);
+        });
     });
+
+    // issue a round-trip request and hand back any X error raised by
+    // no-reply requests sent before it
+    const syncError = (self, cb) => {
+        let caught = null;
+        self.onXError = err => { caught = err; };
+        self.X.GetGeometry(self.root, () => {
+            self.onXError = null;
+            cb(caught);
+        });
+    };
 
     it('GetScreenInfo should get same px and mm width and height as in display.screen[0]', function(done) {
         const self = this;
@@ -47,12 +72,320 @@ describe('RANDR extension', () => {
                     self.randr.GetOutputInfo(output, 0, (err, info) => {
                         should.not.exist(err);
                         should.exist(info);
+                        info.name.should.be.a.String();
+                        info.name.length.should.be.above(0);
                         cb();
                     });
                 },
                 done
             );
 
+        });
+    });
+
+    it('GetScreenSizeRange should contain the current screen size', function(done) {
+        const self = this;
+        this.randr.GetScreenSizeRange(this.root, (err, range) => {
+            should.not.exist(err);
+            range.minWidth.should.be.within(1, self.screen.pixel_width);
+            range.minHeight.should.be.within(1, self.screen.pixel_height);
+            range.maxWidth.should.not.be.below(self.screen.pixel_width);
+            range.maxHeight.should.not.be.below(self.screen.pixel_height);
+            done();
+        });
+    });
+
+    it('SetScreenSize to the current size should succeed and keep GetScreenInfo intact', function(done) {
+        const self = this;
+        // only ever set the CURRENT size: other tests share this server
+        this.randr.SetScreenSize(this.root, this.screen.pixel_width, this.screen.pixel_height,
+            this.screen.mm_width, this.screen.mm_height);
+        syncError(self, err => {
+            should.not.exist(err);
+            self.randr.GetScreenInfo(self.root, (err, info) => {
+                should.not.exist(err);
+                const active_screen = info.screens[info.sizeID];
+                active_screen.px_width.should.equal(self.screen.pixel_width);
+                active_screen.px_height.should.equal(self.screen.pixel_height);
+                done();
+            });
+        });
+    });
+
+    it('GetScreenResourcesCurrent should match GetScreenResources', function(done) {
+        const self = this;
+        this.randr.GetScreenResourcesCurrent(this.root, (err, current) => {
+            should.not.exist(err);
+            current.crtcs.should.eql(self.resources.crtcs);
+            current.outputs.should.eql(self.resources.outputs);
+            current.modeinfos.length.should.equal(self.resources.modeinfos.length);
+            current.modeinfos.forEach((mode, i) => {
+                mode.name.should.equal(self.resources.modeinfos[i].name);
+                mode.name.length.should.equal(mode.name_len);
+            });
+            done();
+        });
+    });
+
+    it('output property requests should round-trip create/query/get/delete', function(done) {
+        const self = this;
+        const X = this.X;
+        const randr = this.randr;
+        const output = this.output;
+        let atom;
+        async.series([
+            cb => X.InternAtom(false, 'NODE_X11_RANDR_TEST_PROP', (err, a) => { atom = a; cb(err); }),
+            cb => {
+                randr.ChangeOutputProperty(output, atom, X.atoms.INTEGER, 32, 0, [42, 7]);
+                syncError(self, cb);
+            },
+            cb => randr.GetOutputProperty(output, atom, 0, 0, 100, false, false, (err, prop) => {
+                should.not.exist(err);
+                prop.format.should.equal(32);
+                prop.type.should.equal(X.atoms.INTEGER);
+                prop.bytesAfter.should.equal(0);
+                prop.numItems.should.equal(2);
+                prop.data.readUInt32LE(0).should.equal(42);
+                prop.data.readUInt32LE(4).should.equal(7);
+                cb();
+            }),
+            cb => randr.ListOutputProperties(output, (err, atoms) => {
+                should.not.exist(err);
+                atoms.should.containEql(atom);
+                cb();
+            }),
+            cb => {
+                randr.ConfigureOutputProperty(output, atom, false, true, [0, 100]);
+                syncError(self, cb);
+            },
+            cb => randr.QueryOutputProperty(output, atom, (err, info) => {
+                should.not.exist(err);
+                info.pending.should.equal(false);
+                info.range.should.equal(true);
+                info.immutable.should.equal(false);
+                info.validValues.should.eql([0, 100]);
+                cb();
+            }),
+            cb => {
+                randr.DeleteOutputProperty(output, atom);
+                syncError(self, cb);
+            },
+            cb => randr.ListOutputProperties(output, (err, atoms) => {
+                should.not.exist(err);
+                atoms.should.not.containEql(atom);
+                cb();
+            }),
+            cb => randr.QueryOutputProperty(output, atom, err => {
+                // property is gone: server must answer with BadName
+                should.exist(err);
+                err.error.should.equal(15);
+                cb();
+                return true; // error handled, don't emit on client
+            })
+        ], done);
+    });
+
+    it('CreateMode/AddOutputMode/DeleteOutputMode/DestroyMode lifecycle', function(done) {
+        const self = this;
+        const randr = this.randr;
+        const output = this.output;
+        const modeInfo = {
+            width: 320, height: 240, dot_clock: 5000000,
+            h_sync_start: 328, h_sync_end: 360, h_total: 400, h_skew: 0,
+            v_sync_start: 245, v_sync_end: 248, v_total: 260,
+            modeflags: 0, name: 'nodex11_test_320x240'
+        };
+        randr.CreateMode(this.root, modeInfo, (err, mode) => {
+            if (err) {
+                // some servers refuse user modes; a controlled RANDR error
+                // still proves the request was well-formed
+                err.minorOpcode.should.equal(16);
+                err.majorOpcode.should.equal(randr.majorOpcode);
+                done();
+                return true;
+            }
+            mode.should.be.above(0);
+            async.series([
+                cb => {
+                    randr.AddOutputMode(output, mode);
+                    syncError(self, cb);
+                },
+                cb => randr.GetOutputInfo(output, 0, (err, info) => {
+                    should.not.exist(err);
+                    info.modes.should.containEql(mode);
+                    cb();
+                }),
+                cb => {
+                    randr.DeleteOutputMode(output, mode);
+                    syncError(self, cb);
+                },
+                cb => {
+                    randr.DestroyMode(mode);
+                    syncError(self, cb);
+                },
+                cb => randr.GetOutputInfo(output, 0, (err, info) => {
+                    should.not.exist(err);
+                    info.modes.should.not.containEql(mode);
+                    cb();
+                })
+            ], done);
+        });
+    });
+
+    it('SetCrtcConfig re-applying the current config should return Success', function(done) {
+        const self = this;
+        this.randr.GetCrtcInfo(this.crtc, this.resources.config_timestamp, (err, info) => {
+            should.not.exist(err);
+            info.status.should.equal(0);
+            // re-apply exactly what is already configured so nothing changes
+            self.randr.SetCrtcConfig(self.crtc, info.timestamp, self.resources.config_timestamp,
+                info.x, info.y, info.mode, info.rotation, info.output, (err, res) => {
+                    should.not.exist(err);
+                    res.status.should.equal(0);
+                    done();
+                });
+        });
+    });
+
+    it('GetCrtcGamma/SetCrtcGamma should round-trip and restore', function(done) {
+        const self = this;
+        const randr = this.randr;
+        const crtc = this.crtc;
+        randr.GetCrtcGammaSize(crtc, (err, size) => {
+            if (err) {
+                // no gamma support on this crtc: a controlled RANDR error is
+                // still proof the request reached the server
+                err.minorOpcode.should.equal(22);
+                done();
+                return true;
+            }
+            if (size === 0) return done(); // gamma not supported, nothing to set
+            randr.GetCrtcGamma(crtc, (err, orig) => {
+                should.not.exist(err);
+                orig.size.should.equal(size);
+                orig.red.length.should.equal(size);
+                orig.green.length.should.equal(size);
+                orig.blue.length.should.equal(size);
+                const ramp = [];
+                for (let i = 0; i < size; ++i)
+                    ramp.push(Math.floor(i * 65535 / (size - 1)));
+                randr.SetCrtcGamma(crtc, ramp, ramp, ramp);
+                syncError(self, e => {
+                    should.not.exist(e);
+                    randr.GetCrtcGamma(crtc, (err, readBack) => {
+                        should.not.exist(err);
+                        readBack.red.should.eql(ramp);
+                        readBack.green.should.eql(ramp);
+                        readBack.blue.should.eql(ramp);
+                        // restore what was there before (shared server!)
+                        randr.SetCrtcGamma(crtc, orig.red, orig.green, orig.blue);
+                        syncError(self, e => {
+                            should.not.exist(e);
+                            randr.GetCrtcGamma(crtc, (err, restored) => {
+                                should.not.exist(err);
+                                restored.red.should.eql(orig.red);
+                                restored.green.should.eql(orig.green);
+                                restored.blue.should.eql(orig.blue);
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    it('GetCrtcTransform should report identity transforms by default', function(done) {
+        this.randr.GetCrtcTransform(this.crtc, (err, info) => {
+            should.not.exist(err);
+            info.pendingTransform.should.eql(IDENTITY);
+            info.currentTransform.should.eql(IDENTITY);
+            info.hasTransforms.should.be.a.Boolean();
+            info.pendingFilter.should.be.a.String();
+            info.currentFilter.should.be.a.String();
+            info.pendingParams.should.be.an.Array();
+            info.currentParams.should.be.an.Array();
+            done();
+        });
+    });
+
+    it('SetCrtcTransform succeeds or yields BadValue when transforms are unsupported', function(done) {
+        const self = this;
+        this.randr.GetCrtcTransform(this.crtc, (err, info) => {
+            should.not.exist(err);
+            // identity transform: a no-op even where transforms are supported
+            self.randr.SetCrtcTransform(self.crtc, IDENTITY, '', []);
+            syncError(self, e => {
+                if (info.hasTransforms) {
+                    should.not.exist(e);
+                } else {
+                    // Xvfb: crtc has no transform support -> controlled BadValue
+                    should.exist(e);
+                    e.error.should.equal(2);
+                    e.minorOpcode.should.equal(26);
+                    e.majorOpcode.should.equal(self.randr.majorOpcode);
+                }
+                done();
+            });
+        });
+    });
+
+    it('GetPanning should return the panning state', function(done) {
+        this.randr.GetPanning(this.crtc, (err, panning) => {
+            should.not.exist(err);
+            panning.status.should.equal(0);
+            ['left', 'top', 'width', 'height',
+                'trackLeft', 'trackTop', 'trackWidth', 'trackHeight',
+                'borderLeft', 'borderTop', 'borderRight', 'borderBottom'].forEach(f => {
+                panning[f].should.be.a.Number();
+            });
+            done();
+        });
+    });
+
+    it('SetPanning re-applying current state succeeds or yields a controlled RANDR error', function(done) {
+        const self = this;
+        this.randr.GetPanning(this.crtc, (err, panning) => {
+            should.not.exist(err);
+            // re-apply the state just read so nothing actually changes
+            self.randr.SetPanning(self.crtc, panning.timestamp, panning, (err, res) => {
+                if (err) {
+                    // Xvfb has no panning hook and answers with a RANDR error
+                    err.error.should.be.aboveOrEqual(self.randr.firstError);
+                    err.minorOpcode.should.equal(29);
+                    err.majorOpcode.should.equal(self.randr.majorOpcode);
+                    done();
+                    return true;
+                }
+                res.status.should.equal(0);
+                done();
+            });
+        });
+    });
+
+    it('SetOutputPrimary/GetOutputPrimary should round-trip and restore', function(done) {
+        const self = this;
+        const randr = this.randr;
+        randr.GetOutputPrimary(this.root, (err, original) => {
+            should.not.exist(err);
+            randr.SetOutputPrimary(self.root, self.output);
+            syncError(self, e => {
+                should.not.exist(e);
+                randr.GetOutputPrimary(self.root, (err, primary) => {
+                    should.not.exist(err);
+                    primary.should.equal(self.output);
+                    // restore previous primary output (shared server!)
+                    randr.SetOutputPrimary(self.root, original);
+                    syncError(self, e => {
+                        should.not.exist(e);
+                        randr.GetOutputPrimary(self.root, (err, restored) => {
+                            should.not.exist(err);
+                            restored.should.equal(original);
+                            done();
+                        });
+                    });
+                });
+            });
         });
     });
 

--- a/test/record.js
+++ b/test/record.js
@@ -1,0 +1,116 @@
+const x11 = require('../lib');
+const should = require('should');
+
+// RECORD extension. Recording requires a dedicated connection for EnableContext:
+// the control connection creates/registers/disables/frees the context, while a
+// second, dedicated connection issues EnableContext and receives the intercepted
+// protocol data.
+describe('RECORD extension', () => {
+    before(function(done) {
+        const self = this;
+        // control connection: owns the context, issues the recorded requests
+        const c1 = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.X.require('record', (err, ext) => {
+                should.not.exist(err);
+                self.record = ext;
+                // dedicated enable connection
+                const c2 = x11.createClient((err2, dpy2) => {
+                    should.not.exist(err2);
+                    self.Xenable = dpy2.client;
+                    self.Xenable.require('record', (err3, ext2) => {
+                        should.not.exist(err3);
+                        self.recordEnable = ext2;
+                        done();
+                    });
+                });
+                c2.on('error', done);
+            });
+        });
+        c1.on('error', done);
+    });
+
+    it('QueryVersion should report at least 1.13', function() {
+        this.record.major.should.equal(1);
+        this.record.minor.should.be.aboveOrEqual(0);
+    });
+
+    it('CreateContext + GetContext round-trip', function(done) {
+        const self = this;
+        const context = this.X.AllocID();
+        this.record.CreateContext(context, 0, [this.record.CS.AllClients], [
+            { coreRequests: { first: 0, last: 127 } }
+        ]);
+        this.record.GetContext(context, (err, info) => {
+            should.not.exist(err);
+            info.enabled.should.equal(false);
+            info.interceptedClients.should.be.an.Array();
+            // one range registered for the AllClients pseudo-client
+            info.interceptedClients.length.should.be.aboveOrEqual(1);
+            const ranges = info.interceptedClients[0].ranges;
+            ranges.length.should.be.aboveOrEqual(1);
+            ranges[0].coreRequests.first.should.equal(0);
+            ranges[0].coreRequests.last.should.equal(127);
+            self.record.FreeContext(context);
+            done();
+        });
+    });
+
+    it('EnableContext should intercept a recorded client request', function(done) {
+        const self = this;
+        const context = this.X.AllocID();
+        let finished = false;
+
+        // record ALL core requests issued by the control connection
+        const controlSpec = this.X.display.resource_base;
+        this.record.CreateContext(context, 0, [controlSpec], [
+            { coreRequests: { first: 0, last: 127 } }
+        ]);
+
+        const finish = err => {
+            if (finished)
+                return;
+            finished = true;
+            // always clean up so we never leave a context enabled on the server
+            self.record.FreeContext(context);
+            done(err);
+        };
+
+        let started = false;
+        let sawInternAtom = false;
+
+        this.recordEnable.EnableContext(context, reply => {
+            if (reply.category === self.record.Category.StartOfData) {
+                started = true;
+                // recording is now live: issue a known request on the control connection
+                self.X.InternAtom(false, 'X11_RECORD_TEST_ATOM', () => {});
+                return;
+            }
+            if (reply.category === self.record.Category.FromClient && reply.data.length > 0) {
+                // first byte of a recorded request is its opcode; InternAtom == 16
+                if (reply.data.readUInt8(0) === 16) {
+                    sawInternAtom = true;
+                    // stop recording from the control connection
+                    self.record.DisableContext(context);
+                }
+            }
+        }, (err) => {
+            // fires when EndOfData terminates the multi-reply series
+            if (err)
+                return finish(err);
+            started.should.equal(true);
+            sawInternAtom.should.equal(true);
+            finish();
+        });
+    });
+
+    after(function(done) {
+        const self = this;
+        this.Xenable.terminate();
+        this.Xenable.on('end', () => {
+            self.X.terminate();
+            self.X.on('end', done);
+        });
+    });
+});

--- a/test/render.js
+++ b/test/render.js
@@ -1,0 +1,339 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('RENDER extension', () => {
+
+    const W = 16;
+    const H = 16;
+
+    let display;
+    let X;
+    let root;
+    let depth;
+    let render;
+    let bytesPP;
+
+    before(done => {
+        const client = x11.createClient((err, dpy) => {
+            if (err)
+                return done(err);
+            display = dpy;
+            X = display.client;
+            root = display.screen[0].root;
+            depth = display.screen[0].root_depth;
+            bytesPP = depth <= 8 ? 1 : (depth <= 16 ? 2 : 4);
+            X.require('render', (err, ext) => {
+                if (err)
+                    return done(err);
+                render = ext;
+                done();
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(done => {
+        X.terminate();
+        X.on('end', done);
+        X = null;
+        display = null;
+    });
+
+    function getPixel(imageData, x, y) {
+        const off = (y * W + x) * bytesPP;
+        let value = 0;
+        for (let i = 0; i < bytesPP; ++i)
+            value += imageData[off + i] << (8 * i);
+        // depth-24 pixels travel as 4 bytes; the padding byte is undefined
+        const mask = depth >= 32 ? 0xffffffff : (1 << depth) - 1;
+        return (value & mask) >>> 0;
+    }
+
+    // channel helpers assume the standard 24/32-bit TrueColor layout Xvfb uses
+    const red = v => (v >> 16) & 0xff;
+    const blue = v => v & 0xff;
+
+    // depth-24 pixmap wrapped into a picture, filled solid black
+    function mkCanvas() {
+        const pixmap = X.AllocID();
+        X.CreatePixmap(pixmap, root, depth, W, H);
+        const pic = X.AllocID();
+        render.CreatePicture(pic, pixmap, render.rgb24);
+        render.FillRectangles(render.PictOp.Src, pic, [0, 0, 0, 1], [0, 0, W, H]);
+        return {
+            pixmap,
+            pic,
+            free: () => {
+                render.FreePicture(pic);
+                X.FreePixmap(pixmap);
+            }
+        };
+    }
+
+    function readBack(pixmap, cb) {
+        X.GetImage(2, pixmap, 0, 0, W, H, 0xffffffff, (err, img) => {
+            should.not.exist(err);
+            cb(img.data);
+        });
+    }
+
+    it('QueryPictFormats should list picture formats and init discovers standard ones', done => {
+        should.exist(render.rgb24);
+        should.exist(render.rgba32);
+        should.exist(render.a8);
+        render.QueryPictFormats((err, res) => {
+            should.not.exist(err);
+            res.formats.should.be.an.Array();
+            res.formats.length.should.be.above(0);
+            res.formats.map(f => f[0]).should.containEql(render.rgb24);
+            done();
+        });
+    });
+
+    it('QueryPictIndexValues should return Match error for a direct (non-indexed) format', done => {
+        // Xvfb only has TrueColor/direct formats, so the server must answer
+        // with a Match error - proves the request is correctly formed
+        render.QueryPictIndexValues(render.rgb24, err => {
+            should.exist(err);
+            err.error.should.equal(8); // Match
+            done();
+            return true; // error handled, don't emit on client
+        });
+    });
+
+    it('CreateLinearGradient should composite a left-to-right color ramp', done => {
+        const c = mkCanvas();
+        const grad = X.AllocID();
+        render.CreateLinearGradient(grad, [0, 0], [W, 0],
+            [[0, [1, 0, 0, 1]], [1, [0, 0, 1, 1]]]); // red -> blue
+        render.Composite(render.PictOp.Src, grad, 0, c.pic, 0, 0, 0, 0, 0, 0, W, H);
+        readBack(c.pixmap, data => {
+            const left = getPixel(data, 1, 8);
+            const right = getPixel(data, 14, 8);
+            red(left).should.be.above(180);
+            blue(left).should.be.below(80);
+            blue(right).should.be.above(180);
+            red(right).should.be.below(80);
+            render.FreePicture(grad);
+            c.free();
+            done();
+        });
+    });
+
+    it('CreateRadialGradient should be white at center, dark at corners', done => {
+        const c = mkCanvas();
+        const grad = X.AllocID();
+        render.CreateRadialGradient(grad, [W / 2, H / 2], [W / 2, H / 2], 0, W / 2,
+            [[0, [1, 1, 1, 1]], [1, [0, 0, 0, 1]]]); // white -> black
+        render.Composite(render.PictOp.Src, grad, 0, c.pic, 0, 0, 0, 0, 0, 0, W, H);
+        readBack(c.pixmap, data => {
+            const center = getPixel(data, W / 2, H / 2);
+            const corner = getPixel(data, 0, 0);
+            red(center).should.be.above(200);
+            red(corner).should.be.below(60);
+            render.FreePicture(grad);
+            c.free();
+            done();
+        });
+    });
+
+    it('CreateConicalGradient with equal stops should fill uniformly', done => {
+        const c = mkCanvas();
+        const grad = X.AllocID();
+        // both stops red - result is red everywhere, independent of angle math
+        render.CreateConicalGradient(grad, [W / 2, H / 2], 45,
+            [[0, [1, 0, 0, 1]], [1, [1, 0, 0, 1]]]);
+        render.Composite(render.PictOp.Src, grad, 0, c.pic, 0, 0, 0, 0, 0, 0, W, H);
+        readBack(c.pixmap, data => {
+            red(getPixel(data, 4, 4)).should.be.above(200);
+            red(getPixel(data, 12, 12)).should.be.above(200);
+            blue(getPixel(data, 4, 4)).should.be.below(60);
+            render.FreePicture(grad);
+            c.free();
+            done();
+        });
+    });
+
+    it('ChangePicture should update the repeat attribute of a picture', done => {
+        const c = mkCanvas();
+        const spx = X.AllocID();
+        X.CreatePixmap(spx, root, depth, 1, 1);
+        const spic = X.AllocID();
+        render.CreatePicture(spic, spx, render.rgb24);
+        render.FillRectangles(render.PictOp.Src, spic, [1, 1, 1, 1], [0, 0, 1, 1]);
+        // repeat defaults to None: only (0,0) gets painted
+        render.Composite(render.PictOp.Over, spic, 0, c.pic, 0, 0, 0, 0, 0, 0, W, H);
+        readBack(c.pixmap, data => {
+            getPixel(data, 0, 0).should.equal(0xffffff);
+            getPixel(data, 8, 8).should.equal(0);
+            render.ChangePicture(spic, { repeat: render.Repeat.Normal });
+            render.Composite(render.PictOp.Over, spic, 0, c.pic, 0, 0, 0, 0, 0, 0, W, H);
+            readBack(c.pixmap, data2 => {
+                getPixel(data2, 8, 8).should.equal(0xffffff);
+                getPixel(data2, 15, 15).should.equal(0xffffff);
+                render.FreePicture(spic);
+                X.FreePixmap(spx);
+                c.free();
+                done();
+            });
+        });
+    });
+
+    it('SetPictureClipRectangles should restrict rendering to the clip list', done => {
+        const c = mkCanvas();
+        render.SetPictureClipRectangles(c.pic, 0, 0, [4, 4, 8, 8]);
+        render.FillRectangles(render.PictOp.Src, c.pic, [1, 1, 1, 1], [0, 0, W, H]);
+        readBack(c.pixmap, data => {
+            getPixel(data, 1, 1).should.equal(0); // outside clip
+            getPixel(data, 8, 8).should.equal(0xffffff); // inside clip
+            getPixel(data, 14, 14).should.equal(0); // outside clip
+            // ChangePicture with clipMask None resets the clip
+            render.ChangePicture(c.pic, { clipMask: 0 });
+            render.FillRectangles(render.PictOp.Src, c.pic, [1, 1, 1, 1], [0, 0, W, H]);
+            readBack(c.pixmap, data2 => {
+                getPixel(data2, 1, 1).should.equal(0xffffff);
+                c.free();
+                done();
+            });
+        });
+    });
+
+    it('FillRectangles should fill every rectangle in the list', done => {
+        const c = mkCanvas();
+        render.FillRectangles(render.PictOp.Src, c.pic, [1, 1, 1, 1],
+            [0, 0, 4, 4, 12, 12, 4, 4]); // two separate rects
+        readBack(c.pixmap, data => {
+            getPixel(data, 2, 2).should.equal(0xffffff);
+            getPixel(data, 13, 13).should.equal(0xffffff);
+            getPixel(data, 8, 8).should.equal(0);
+            c.free();
+            done();
+        });
+    });
+
+    it('Trapezoids should render a trapezoid (regression: buffer overflow)', done => {
+        const c = mkCanvas();
+        const solid = X.AllocID();
+        render.CreateSolidFill(solid, 1, 1, 1, 1);
+        // axis-aligned trapezoid covering x 4..12, y 4..12:
+        // top, bottom, left x1,y1,x2,y2, right x1,y1,x2,y2
+        render.Trapezoids(render.PictOp.Over, solid, 0, 0, c.pic, 0,
+            [4, 12, 4, 4, 4, 12, 12, 4, 12, 12]);
+        readBack(c.pixmap, data => {
+            getPixel(data, 8, 8).should.equal(0xffffff); // inside
+            getPixel(data, 2, 8).should.equal(0); // outside
+            render.FreePicture(solid);
+            c.free();
+            done();
+        });
+    });
+
+    it('TriFan should render a triangle fan', done => {
+        const c = mkCanvas();
+        const solid = X.AllocID();
+        render.CreateSolidFill(solid, 1, 1, 1, 1);
+        // single triangle covering the upper-right half
+        render.TriFan(render.PictOp.Over, solid, 0, 0, c.pic, 0, [0, 0, W, 0, W, H]);
+        readBack(c.pixmap, data => {
+            getPixel(data, 12, 4).should.equal(0xffffff); // inside
+            getPixel(data, 3, 12).should.equal(0); // outside
+            render.FreePicture(solid);
+            c.free();
+            done();
+        });
+    });
+
+    it('TriStrip should render a triangle strip', done => {
+        const c = mkCanvas();
+        const solid = X.AllocID();
+        render.CreateSolidFill(solid, 1, 1, 1, 1);
+        // single triangle covering the upper-left half
+        render.TriStrip(render.PictOp.Over, solid, 0, 0, c.pic, 0, [0, 0, W, 0, 0, H]);
+        readBack(c.pixmap, data => {
+            getPixel(data, 4, 4).should.equal(0xffffff); // inside
+            getPixel(data, 13, 13).should.equal(0); // outside
+            // two more points extend the strip over the whole square
+            render.TriStrip(render.PictOp.Over, solid, 0, 0, c.pic, 0,
+                [0, 0, W, 0, 0, H, W, H]);
+            readBack(c.pixmap, data2 => {
+                getPixel(data2, 13, 13).should.equal(0xffffff);
+                render.FreePicture(solid);
+                c.free();
+                done();
+            });
+        });
+    });
+
+    function mkArgbCursor(hotX, hotY) {
+        const cpx = X.AllocID();
+        X.CreatePixmap(cpx, root, 32, 8, 8);
+        const cpic = X.AllocID();
+        render.CreatePicture(cpic, cpx, render.rgba32);
+        render.FillRectangles(render.PictOp.Src, cpic, [1, 0, 0, 1], [0, 0, 8, 8]);
+        const cid = X.AllocID();
+        render.CreateCursor(cid, cpic, hotX, hotY);
+        render.FreePicture(cpic);
+        X.FreePixmap(cpx);
+        return cid;
+    }
+
+    it('CreateCursor should create a usable cursor from an ARGB32 picture', done => {
+        const cid = mkArgbCursor(4, 4);
+        const wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, 10, 10, 0, 0, 0, 0, { cursor: cid });
+        // any of the above failing would error before this reply arrives
+        X.GetWindowAttributes(wid, (err, attrs) => {
+            should.not.exist(err);
+            X.DestroyWindow(wid);
+            X.FreeCursor(cid);
+            done();
+        });
+    });
+
+    it('CreateAnimCursor should create a usable animated cursor', done => {
+        const cid1 = mkArgbCursor(0, 0);
+        const cid2 = mkArgbCursor(4, 4);
+        const anim = X.AllocID();
+        render.CreateAnimCursor(anim, [[cid1, 50], [cid2, 50]]);
+        const wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, 10, 10, 0, 0, 0, 0, { cursor: anim });
+        X.GetWindowAttributes(wid, (err, attrs) => {
+            should.not.exist(err);
+            X.DestroyWindow(wid);
+            X.FreeCursor(anim);
+            X.FreeCursor(cid1);
+            X.FreeCursor(cid2);
+            done();
+        });
+    });
+
+    it('FreeGlyphs should remove glyphs from a glyph set', done => {
+        const c = mkCanvas();
+        const solid = X.AllocID();
+        render.CreateSolidFill(solid, 1, 1, 1, 1);
+        const gsid = X.AllocID();
+        render.CreateGlyphSet(gsid, render.a8);
+        // 4x4 fully-opaque glyph for char code 65 ('A'), origin at its lower-left
+        render.AddGlyphs(gsid, [{
+            id: 65, width: 4, height: 4, x: 0, y: 4,
+            offX: 4 * 64, offY: 0, image: Buffer.alloc(16, 255)
+        }]);
+        render.CompositeGlyphs8(render.PictOp.Over, solid, c.pic, 0, gsid, 0, 0,
+            [[2, 6, 'A']]);
+        readBack(c.pixmap, data => {
+            getPixel(data, 3, 4).should.equal(0xffffff); // glyph drawn
+            // repaint black, free the glyph, draw again: nothing may appear
+            render.FillRectangles(render.PictOp.Src, c.pic, [0, 0, 0, 1], [0, 0, W, H]);
+            render.FreeGlyphs(gsid, [65]);
+            render.CompositeGlyphs8(render.PictOp.Over, solid, c.pic, 0, gsid, 0, 0,
+                [[2, 6, 'A']]);
+            readBack(c.pixmap, data2 => {
+                getPixel(data2, 3, 4).should.equal(0); // freed glyph is skipped
+                render.FreeGlyphSet(gsid);
+                render.FreePicture(solid);
+                c.free();
+                done();
+            });
+        });
+    });
+});

--- a/test/res.js
+++ b/test/res.js
@@ -1,0 +1,119 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('X-Resource extension', () => {
+
+    const W = 50;
+    const H = 40;
+
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.display = dpy;
+            self.X = dpy.client;
+            self.root = dpy.screen[0].root;
+            self.depth = dpy.screen[0].root_depth;
+            self.bytesPP = self.depth <= 8 ? 1 : (self.depth <= 16 ? 2 : 4);
+            self.X.require('res', (err, ext) => {
+                should.not.exist(err);
+                self.res = ext;
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    it('QueryVersion should report at least 1.0', function() {
+        this.res.major.should.be.aboveOrEqual(1);
+        this.res.minor.should.be.aboveOrEqual(0);
+    });
+
+    it('QueryClients should include our own client XID range', function(done) {
+        const self = this;
+        this.res.QueryClients((err, clients) => {
+            should.not.exist(err);
+            clients.length.should.be.above(0);
+            const mine = clients.filter(c => c.resourceBase === self.display.resource_base);
+            mine.length.should.equal(1);
+            mine[0].resourceMask.should.equal(self.display.resource_mask);
+            done();
+        });
+    });
+
+    it('QueryClientResources should report a PIXMAP count increase after CreatePixmap', function(done) {
+        const self = this;
+        const PIXMAP = 20; // predefined PIXMAP atom
+        const countPixmaps = types => {
+            const entry = types.filter(t => t.resourceType === PIXMAP)[0];
+            return entry ? entry.count : 0;
+        };
+        this.res.QueryClientResources(this.display.resource_base, (err, typesBefore) => {
+            should.not.exist(err);
+            const before = countPixmaps(typesBefore);
+            self.pixmap = self.X.AllocID();
+            self.X.CreatePixmap(self.pixmap, self.root, self.depth, W, H);
+            self.res.QueryClientResources(self.display.resource_base, (err, typesAfter) => {
+                should.not.exist(err);
+                countPixmaps(typesAfter).should.equal(before + 1);
+                done();
+            });
+        });
+    });
+
+    it('QueryClientPixmapBytes should grow by at least the size of a new pixmap', function(done) {
+        const self = this;
+        this.res.QueryClientPixmapBytes(this.display.resource_base, (err, bytesBefore) => {
+            should.not.exist(err);
+            const pixmap = self.X.AllocID();
+            self.X.CreatePixmap(pixmap, self.root, self.depth, W, H);
+            self.res.QueryClientPixmapBytes(self.display.resource_base, (err, bytesAfter) => {
+                should.not.exist(err);
+                // scanlines may be padded, so at least the unpadded size
+                (bytesAfter - bytesBefore).should.be.aboveOrEqual(W * H * self.bytesPP);
+                self.X.FreePixmap(pixmap);
+                done();
+            });
+        });
+    });
+
+    it('QueryClientIds should return our own process id (1.2)', function(done) {
+        if (this.res.major === 1 && this.res.minor < 2)
+            return this.skip(); // server doesn't speak X-Resource 1.2
+        this.res.QueryClientIds([{
+            client: this.display.resource_base,
+            mask: this.res.ClientIdMask.LocalClientPID
+        }], (err, ids) => {
+            should.not.exist(err);
+            ids.length.should.equal(1);
+            ids[0].mask.should.equal(2);
+            ids[0].value.should.eql([process.pid]);
+            done();
+        });
+    });
+
+    it('QueryResourceBytes should report the size of a known pixmap (1.2)', function(done) {
+        if (this.res.major === 1 && this.res.minor < 2)
+            return this.skip(); // server doesn't speak X-Resource 1.2
+        const self = this;
+        this.res.QueryResourceBytes(0, [{ resource: this.pixmap, type: 0 }], (err, sizes) => {
+            should.not.exist(err);
+            sizes.length.should.be.aboveOrEqual(1);
+            const mine = sizes.filter(s => s.resource === self.pixmap)[0];
+            should.exist(mine);
+            mine.type.should.equal(20); // PIXMAP atom
+            mine.bytes.should.be.aboveOrEqual(W * H * self.bytesPP);
+            mine.refCount.should.be.aboveOrEqual(1);
+            mine.crossReferences.should.be.an.Array();
+            done();
+        });
+    });
+
+    after(function(done) {
+        if (this.pixmap)
+            this.X.FreePixmap(this.pixmap);
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/screen-saver.js
+++ b/test/screen-saver.js
@@ -1,0 +1,79 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('MIT-SCREEN-SAVER extension', () => {
+    let display;
+    let X;
+    let saver;
+    let root;
+
+    before(done => {
+        const client = x11.createClient((err, dpy) => {
+            if (err)
+                return done(err);
+            display = dpy;
+            X = display.client;
+            root = display.screen[0].root;
+            X.require('screen-saver', (err, ext) => {
+                should.not.exist(err);
+                saver = ext;
+                done();
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(done => {
+        // safety: never leave the shared server suspended or with saver attributes set
+        saver.Suspend(false);
+        saver.UnsetAttributes(root);
+        X.GetInputFocus(() => {
+            X.terminate();
+            X.on('end', done);
+        });
+    });
+
+    it('QueryVersion (auto) should report version 1.x', () => {
+        saver.major.should.equal(1);
+        saver.minor.should.be.aboveOrEqual(1);
+    });
+
+    it('QueryInfo should return saver info for the root window', done => {
+        saver.QueryInfo(root, (err, info) => {
+            should.not.exist(err);
+            info.state.should.be.within(0, 3);
+            info.idle.should.be.a.Number();
+            info.until.should.be.a.Number();
+            info.kind.should.be.within(0, 2);
+            done();
+        });
+    });
+
+    it('SetAttributes then UnsetAttributes should be accepted', done => {
+        // class/depth/visual 0 = CopyFromParent
+        saver.SetAttributes(root, 0, 0, 100, 100, 0, 0, 0, 0,
+            { backgroundPixel: display.screen[0].black_pixel });
+        saver.UnsetAttributes(root);
+        // sync: any error in the two requests above would arrive before this reply
+        saver.QueryInfo(root, (err, info) => {
+            should.not.exist(err);
+            should.exist(info);
+            done();
+        });
+    });
+
+    it('Suspend on/off should be accepted and leave the saver queryable', done => {
+        saver.Suspend(true);
+        saver.QueryInfo(root, (err, info) => {
+            // always release the suspension, even if the assertion below throws
+            saver.Suspend(false);
+            should.not.exist(err);
+            should.exist(info);
+            saver.QueryInfo(root, (err2, info2) => {
+                should.not.exist(err2);
+                info2.state.should.be.within(0, 3);
+                done();
+            });
+        });
+    });
+});

--- a/test/shape.js
+++ b/test/shape.js
@@ -1,0 +1,90 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('SHAPE extension', () => {
+    let display;
+    let X;
+    let shape;
+    let root;
+    let wid1;
+    let wid2;
+
+    before(done => {
+        const client = x11.createClient((err, dpy) => {
+            if (err)
+                return done(err);
+            display = dpy;
+            X = display.client;
+            root = display.screen[0].root;
+            X.require('shape', (err, ext) => {
+                should.not.exist(err);
+                shape = ext;
+                wid1 = X.AllocID();
+                X.CreateWindow(wid1, root, 0, 0, 100, 100);
+                wid2 = X.AllocID();
+                X.CreateWindow(wid2, root, 0, 0, 100, 100);
+                done();
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(done => {
+        X.DestroyWindow(wid1);
+        X.DestroyWindow(wid2);
+        X.terminate();
+        X.on('end', done);
+    });
+
+    // sort by y then x so we can compare regardless of server-side ordering
+    const sortRects = rects =>
+        rects.slice().sort((a, b) => (a[1] - b[1]) || (a[0] - b[0]));
+
+    const shapeRects = [[0, 0, 10, 10], [20, 20, 10, 10]];
+
+    it('Rectangles + GetRectangles should round-trip a bounding shape', done => {
+        shape.Rectangles(shape.Op.Set, shape.Kind.Bounding, wid1, 0, 0, shapeRects);
+        shape.GetRectangles(wid1, shape.Kind.Bounding, (err, res) => {
+            should.not.exist(err);
+            res.ordering.should.be.within(0, 3);
+            sortRects(res.rectangles).should.eql(sortRects(shapeRects));
+            done();
+        });
+    });
+
+    it('QueryExtents should report the bounding shape extents', done => {
+        shape.QueryExtents(wid1, (err, extents) => {
+            should.not.exist(err);
+            extents.boundingShaped.should.equal(true);
+            extents.clipShaped.should.equal(false);
+            extents.bounding.should.eql({ x: 0, y: 0, width: 30, height: 30 });
+            // clip shape not set: extents cover the whole 100x100 window
+            extents.clip.should.eql({ x: 0, y: 0, width: 100, height: 100 });
+            done();
+        });
+    });
+
+    it('Combine should copy the shape from one window to another', done => {
+        shape.Combine(shape.Op.Set, shape.Kind.Bounding, shape.Kind.Bounding,
+            wid2, 0, 0, wid1);
+        shape.GetRectangles(wid2, shape.Kind.Bounding, (err, res) => {
+            should.not.exist(err);
+            sortRects(res.rectangles).should.eql(sortRects(shapeRects));
+            done();
+        });
+    });
+
+    it('Offset should translate the shape', done => {
+        shape.Offset(shape.Kind.Bounding, wid1, 5, 7);
+        shape.QueryExtents(wid1, (err, extents) => {
+            should.not.exist(err);
+            extents.bounding.should.eql({ x: 5, y: 7, width: 30, height: 30 });
+            shape.GetRectangles(wid1, shape.Kind.Bounding, (err, res) => {
+                should.not.exist(err);
+                sortRects(res.rectangles).should.eql(
+                    sortRects(shapeRects.map(r => [r[0] + 5, r[1] + 7, r[2], r[3]])));
+                done();
+            });
+        });
+    });
+});

--- a/test/shm.js
+++ b/test/shm.js
@@ -1,0 +1,165 @@
+const x11 = require('../lib');
+const should = require('should');
+
+// Node has no built-in way to create SysV shared memory segments (and the
+// zero-dependency rule forbids native addons), so a real Attach/PutImage
+// round-trip through an actual segment cannot be tested here. Instead the
+// wire format is validated with controlled X errors: a request that reaches
+// the server, is parsed correctly and rejected with the exact expected error
+// code/badParam proves the encoding, the opcode wiring and the registration
+// of the extension's BadSeg error parser.
+
+describe('MIT-SHM extension', () => {
+    before(function(done) {
+        const self = this;
+        x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.root = dpy.screen[0].root;
+            self.depth = dpy.screen[0].root_depth;
+            self.X.require('shm', (err, ext) => {
+                should.not.exist(err);
+                self.shm = ext;
+                done();
+            });
+        });
+    });
+
+    it('QueryVersion (auto-called) should report at least 1.1 and a sane pixmap format', function() {
+        this.shm.major.should.equal(1);
+        this.shm.minor.should.be.aboveOrEqual(1);
+        this.shm.sharedPixmaps.should.be.a.Boolean();
+        // pixmapFormat is one of the core image formats; only meaningful
+        // when shared pixmaps are supported
+        if (this.shm.sharedPixmaps)
+            this.shm.pixmapFormat.should.equal(this.shm.ImageFormat.ZPixmap);
+        this.shm.uid.should.be.a.Number();
+        this.shm.gid.should.be.a.Number();
+    });
+
+    it('QueryVersion round-trip should match the cached values', function(done) {
+        const self = this;
+        this.shm.QueryVersion((err, vers) => {
+            should.not.exist(err);
+            vers.majorVersion.should.equal(self.shm.major);
+            vers.minorVersion.should.equal(self.shm.minor);
+            vers.sharedPixmaps.should.equal(self.shm.sharedPixmaps);
+            vers.pixmapFormat.should.equal(self.shm.pixmapFormat);
+            done();
+        });
+    });
+
+    it('Attach with a bogus shmid should raise BadAccess from the SHM opcode', function(done) {
+        const self = this;
+        const seg = this.X.AllocID();
+        // the SEG XID is fresh and valid, so the server gets past the XID
+        // check and fails in shmat() on the bogus shmid -> core BadAccess
+        // (the extension BadSeg error is only raised for unattached SEG XIDs,
+        // covered by the tests below)
+        this.shm.Attach(seg, 0x7fffffff, false);
+        const seq = this.X.seq_num;
+        this.X.once('error', err => {
+            err.error.should.equal(10); // BadAccess
+            err.seq.should.equal(seq);
+            err.majorOpcode.should.equal(self.shm.majorOpcode);
+            err.minorOpcode.should.equal(1);
+            done();
+        });
+    });
+
+    it('Detach of an unattached segment should raise the extension BadSeg error', function(done) {
+        const self = this;
+        const seg = this.X.AllocID();
+        this.shm.Detach(seg);
+        const seq = this.X.seq_num;
+        this.X.once('error', err => {
+            err.error.should.equal(self.shm.firstError + self.shm.errors.BadSeg);
+            err.seq.should.equal(seq);
+            err.badParam.should.equal(seg);
+            err.majorOpcode.should.equal(self.shm.majorOpcode);
+            err.minorOpcode.should.equal(2);
+            err.message.should.match(/MIT-SHM/);
+            done();
+        });
+    });
+
+    it('PutImage with an unattached segment should raise BadSeg', function(done) {
+        const self = this;
+        const gc = this.X.AllocID();
+        this.X.CreateGC(gc, this.root);
+        const seg = this.X.AllocID();
+        this.shm.PutImage(this.root, gc, {
+            totalWidth: 4, totalHeight: 4,
+            srcX: 0, srcY: 0, srcWidth: 4, srcHeight: 4,
+            dstX: 0, dstY: 0,
+            depth: this.depth, format: this.shm.ImageFormat.ZPixmap,
+            sendEvent: false, shmseg: seg, offset: 0
+        });
+        const seq = this.X.seq_num;
+        this.X.once('error', err => {
+            err.error.should.equal(self.shm.firstError + self.shm.errors.BadSeg);
+            err.seq.should.equal(seq);
+            err.badParam.should.equal(seg);
+            err.minorOpcode.should.equal(3);
+            self.X.FreeGC(gc);
+            done();
+        });
+    });
+
+    it('GetImage with an unattached segment should raise BadSeg via the reply callback', function(done) {
+        const self = this;
+        const seg = this.X.AllocID();
+        this.shm.GetImage(this.root, 0, 0, 4, 4, 0xffffffff,
+            this.shm.ImageFormat.ZPixmap, seg, 0, err => {
+                should.exist(err);
+                err.error.should.equal(self.shm.firstError + self.shm.errors.BadSeg);
+                err.badParam.should.equal(seg);
+                err.minorOpcode.should.equal(4);
+                done();
+                return true; // handled - don't re-emit on the client
+            });
+    });
+
+    it('CreatePixmap with an unattached segment should raise BadSeg', function(done) {
+        if (!this.shm.sharedPixmaps)
+            return this.skip(); // server would answer BadImplementation
+        const self = this;
+        const pid = this.X.AllocID();
+        const seg = this.X.AllocID();
+        this.shm.CreatePixmap(pid, this.root, 4, 4, this.depth, seg, 0);
+        const seq = this.X.seq_num;
+        this.X.once('error', err => {
+            err.error.should.equal(self.shm.firstError + self.shm.errors.BadSeg);
+            err.seq.should.equal(seq);
+            err.badParam.should.equal(seg);
+            err.minorOpcode.should.equal(5);
+            done();
+        });
+    });
+
+    it('ShmCompletion event parser should decode the wire layout', function() {
+        // cannot trigger a real completion event without a live segment, so
+        // feed the registered parser a hand-built event body (bytes 8..31 of
+        // the 32-byte event) and check the field mapping
+        const parser = this.X.eventParsers[this.shm.firstEvent + this.shm.events.ShmCompletion];
+        should.exist(parser);
+        const raw = Buffer.alloc(24);
+        raw.writeUInt16LE(3, 0);          // minor_event
+        raw.writeUInt8(130, 2);           // major_event
+        raw.writeUInt32LE(0x00a00001, 4); // shmseg
+        raw.writeUInt32LE(4096, 8);       // offset
+        const ev = parser(this.shm.firstEvent, 42, 0x00500001, 0, raw);
+        ev.name.should.equal('ShmCompletion');
+        ev.seq.should.equal(42);
+        ev.drawable.should.equal(0x00500001);
+        ev.minorEvent.should.equal(3);
+        ev.majorEvent.should.equal(130);
+        ev.shmseg.should.equal(0x00a00001);
+        ev.offset.should.equal(4096);
+    });
+
+    after(function(done) {
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/sync.js
+++ b/test/sync.js
@@ -1,0 +1,250 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('SYNC extension', () => {
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.root = dpy.screen[0].root;
+            self.X.require('sync', (err, ext) => {
+                should.not.exist(err);
+                self.sync = ext;
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    after(function(done) {
+        if (this.alarm)
+            this.sync.DestroyAlarm(this.alarm);
+        if (this.counter)
+            this.sync.DestroyCounter(this.counter);
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+
+    it('Initialize should report version 3.x', function() {
+        this.sync.major.should.equal(3);
+        this.sync.minor.should.be.aboveOrEqual(0);
+    });
+
+    it('ListSystemCounters should include SERVERTIME', function(done) {
+        this.sync.ListSystemCounters((err, counters) => {
+            should.not.exist(err);
+            counters.should.be.an.Array();
+            const names = counters.map(c => c.name);
+            names.should.containEql('SERVERTIME');
+            counters.forEach(c => {
+                c.counter.should.be.above(0);
+                c.resolution.should.be.a.Number();
+            });
+            done();
+        });
+    });
+
+    it('CreateCounter with initial value 100 should QueryCounter back 100', function(done) {
+        this.counter = this.X.AllocID();
+        this.sync.CreateCounter(this.counter, 100);
+        this.sync.QueryCounter(this.counter, (err, value) => {
+            should.not.exist(err);
+            value.should.equal(100);
+            done();
+        });
+    });
+
+    it('SetCounter and ChangeCounter should round-trip (incl. 64-bit and negative values)', function(done) {
+        const self = this;
+        const big = Math.pow(2, 40) + 7; // needs the hi 32-bit half
+        self.sync.SetCounter(self.counter, big);
+        self.sync.QueryCounter(self.counter, (err, value) => {
+            should.not.exist(err);
+            value.should.equal(big);
+            self.sync.SetCounter(self.counter, 10);
+            self.sync.ChangeCounter(self.counter, -25);
+            self.sync.QueryCounter(self.counter, (err, value2) => {
+                should.not.exist(err);
+                value2.should.equal(-15);
+                done();
+            });
+        });
+    });
+
+    it('CreateAlarm and QueryAlarm should round-trip alarm attributes', function(done) {
+        const self = this;
+        self.sync.SetCounter(self.counter, 0);
+        self.alarm = self.X.AllocID();
+        self.sync.CreateAlarm(self.alarm, {
+            counter: self.counter,
+            valueType: self.sync.ValueType.Absolute,
+            value: 1000,
+            testType: self.sync.TestType.PositiveComparison,
+            delta: 1,
+            events: 1
+        });
+        self.sync.QueryAlarm(self.alarm, (err, alarm) => {
+            should.not.exist(err);
+            alarm.trigger.counter.should.equal(self.counter);
+            alarm.trigger.waitType.should.equal(self.sync.ValueType.Absolute);
+            alarm.trigger.waitValue.should.equal(1000);
+            alarm.trigger.testType.should.equal(self.sync.TestType.PositiveComparison);
+            alarm.delta.should.equal(1);
+            alarm.events.should.equal(true);
+            alarm.state.should.equal(self.sync.AlarmState.Active);
+            done();
+        });
+    });
+
+    it('ChangeAlarm should update the trigger value', function(done) {
+        const self = this;
+        self.sync.ChangeAlarm(self.alarm, { value: 50 });
+        self.sync.QueryAlarm(self.alarm, (err, alarm) => {
+            should.not.exist(err);
+            alarm.trigger.waitValue.should.equal(50);
+            alarm.trigger.counter.should.equal(self.counter);
+            done();
+        });
+    });
+
+    it('crossing the alarm threshold should deliver an AlarmNotify event', function(done) {
+        const self = this;
+        self.X.once('event', ev => {
+            ev.name.should.equal('AlarmNotify');
+            ev.alarm.should.equal(self.alarm);
+            ev.counterValue.should.equal(60);
+            ev.state.should.equal(self.sync.AlarmState.Active);
+            done();
+        });
+        self.sync.SetCounter(self.counter, 60); // alarm threshold is 50
+    });
+
+    it('Await should block the client until a second connection satisfies the condition', function(done) {
+        const self = this;
+        const awaited = self.X.AllocID();
+        self.sync.CreateCounter(awaited, 0);
+        self.sync.QueryCounter(awaited, (err, value) => {
+            should.not.exist(err);
+            value.should.equal(0);
+
+            let unblocked = false;
+            let gotCounterNotify = false;
+
+            self.X.once('event', ev => {
+                ev.name.should.equal('CounterNotify');
+                ev.counter.should.equal(awaited);
+                ev.counterValue.should.equal(5);
+                ev.destroyed.should.equal(false);
+                gotCounterNotify = true;
+            });
+
+            self.sync.Await([{
+                counter: awaited,
+                valueType: self.sync.ValueType.Absolute,
+                value: 5,
+                testType: self.sync.TestType.PositiveComparison,
+                eventThreshold: 0
+            }]);
+
+            // this reply can only arrive once the Await condition is met
+            self.sync.QueryCounter(awaited, (err, value2) => {
+                should.not.exist(err);
+                unblocked = true;
+                value2.should.equal(5);
+                gotCounterNotify.should.equal(true);
+                self.sync.DestroyCounter(awaited);
+                done();
+            });
+
+            setTimeout(() => {
+                // still blocked: the QueryCounter reply must not have arrived yet
+                unblocked.should.equal(false);
+                x11.createClient((err, dpy2) => {
+                    should.not.exist(err);
+                    const X2 = dpy2.client;
+                    X2.require('sync', (err, sync2) => {
+                        should.not.exist(err);
+                        sync2.SetCounter(awaited, 5); // unblocks the first client
+                        X2.on('event', () => {}); // ignore
+                        setTimeout(() => X2.terminate(), 100);
+                    });
+                });
+            }, 200);
+        });
+    });
+
+    it('SetPriority and GetPriority should round-trip on own client', function(done) {
+        const self = this;
+        self.sync.SetPriority(0, 5); // 0 = the requesting client
+        self.sync.GetPriority(0, (err, priority) => {
+            should.not.exist(err);
+            priority.should.equal(5);
+            self.sync.SetPriority(0, 0);
+            self.sync.GetPriority(0, (err, priority2) => {
+                should.not.exist(err);
+                priority2.should.equal(0);
+                done();
+            });
+        });
+    });
+
+    it('fences should create, trigger, reset and query', function(done) {
+        const self = this;
+        if (self.sync.minor < 1) {
+            // fences were added in SYNC 3.1
+            return this.skip();
+        }
+        const fence = self.X.AllocID();
+        self.sync.CreateFence(self.root, fence, false);
+        self.sync.QueryFence(fence, (err, triggered) => {
+            should.not.exist(err);
+            triggered.should.equal(false);
+            self.sync.TriggerFence(fence);
+            self.sync.QueryFence(fence, (err, triggered2) => {
+                should.not.exist(err);
+                triggered2.should.equal(true);
+                self.sync.ResetFence(fence);
+                self.sync.QueryFence(fence, (err, triggered3) => {
+                    should.not.exist(err);
+                    triggered3.should.equal(false);
+                    self.sync.DestroyFence(fence);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('AwaitFence should block until a second connection triggers the fence', function(done) {
+        const self = this;
+        if (self.sync.minor < 1) {
+            return this.skip();
+        }
+        const fence = self.X.AllocID();
+        self.sync.CreateFence(self.root, fence, false);
+
+        let unblocked = false;
+        self.sync.AwaitFence([fence]);
+        self.sync.QueryFence(fence, (err, triggered) => {
+            should.not.exist(err);
+            unblocked = true;
+            triggered.should.equal(true);
+            self.sync.DestroyFence(fence);
+            done();
+        });
+
+        setTimeout(() => {
+            unblocked.should.equal(false);
+            x11.createClient((err, dpy2) => {
+                should.not.exist(err);
+                const X2 = dpy2.client;
+                X2.require('sync', (err, sync2) => {
+                    should.not.exist(err);
+                    sync2.TriggerFence(fence);
+                    setTimeout(() => X2.terminate(), 100);
+                });
+            });
+        }, 200);
+    });
+});

--- a/test/xc-misc.js
+++ b/test/xc-misc.js
@@ -1,0 +1,64 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('XC-MISC extension', () => {
+    let display;
+    let X;
+    let xcmisc;
+
+    before(done => {
+        const client = x11.createClient((err, dpy) => {
+            if (err)
+                return done(err);
+            display = dpy;
+            X = display.client;
+            X.require('xc-misc', (err, ext) => {
+                should.not.exist(err);
+                xcmisc = ext;
+                done();
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(done => {
+        X.terminate();
+        X.on('end', done);
+    });
+
+    it('GetVersion should return major 1, minor >= 1', done => {
+        xcmisc.GetVersion(1, 1, (err, version) => {
+            should.not.exist(err);
+            version[0].should.equal(1);
+            version[1].should.be.aboveOrEqual(1);
+            done();
+        });
+    });
+
+    it('auto GetVersion should have set ext.major/ext.minor', () => {
+        xcmisc.major.should.equal(1);
+        xcmisc.minor.should.be.aboveOrEqual(1);
+    });
+
+    it('GetXIDRange should return a non-empty id range', done => {
+        xcmisc.GetXIDRange((err, range) => {
+            should.not.exist(err);
+            range.startId.should.be.above(0);
+            range.count.should.be.above(0);
+            done();
+        });
+    });
+
+    it('GetXIDList should return the requested number of ids', done => {
+        xcmisc.GetXIDList(5, (err, ids) => {
+            should.not.exist(err);
+            ids.should.be.an.Array();
+            ids.should.have.length(5);
+            ids.forEach(id => {
+                id.should.be.a.Number();
+                id.should.be.above(0);
+            });
+            done();
+        });
+    });
+});

--- a/test/xinerama.js
+++ b/test/xinerama.js
@@ -1,0 +1,66 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('XINERAMA extension', () => {
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.root = dpy.screen[0].root;
+            self.X.require('xinerama', (err, ext) => {
+                should.not.exist(err);
+                self.xinerama = ext;
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    it('QueryVersion should report at least 1.1', function() {
+        this.xinerama.major.should.be.aboveOrEqual(1);
+        this.xinerama.minor.should.be.aboveOrEqual(1);
+    });
+
+    it('GetState should return a 0/1 flag for the root window', function(done) {
+        this.xinerama.GetState(this.root, (err, state) => {
+            should.not.exist(err);
+            state.should.be.within(0, 1);
+            done();
+        });
+    });
+
+    it('GetScreenCount should return a number for the root window', function(done) {
+        this.xinerama.GetScreenCount(this.root, (err, count) => {
+            should.not.exist(err);
+            count.should.be.a.Number();
+            count.should.be.aboveOrEqual(0);
+            done();
+        });
+    });
+
+    it('IsActive and QueryScreens should agree with each other', function(done) {
+        const self = this;
+        this.xinerama.IsActive((err, state) => {
+            should.not.exist(err);
+            self.xinerama.QueryScreens((err, screens) => {
+                should.not.exist(err);
+                screens.should.be.an.Array();
+                if (state === 0) {
+                    screens.length.should.equal(0);
+                } else {
+                    screens.length.should.be.above(0);
+                    screens[0].width.should.be.above(0);
+                    screens[0].height.should.be.above(0);
+                }
+                done();
+            });
+        });
+    });
+
+    after(function(done) {
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/xinput.js
+++ b/test/xinput.js
@@ -1,0 +1,117 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('XInputExtension', () => {
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.X.require('xinput', (err, ext) => {
+                should.not.exist(err);
+                self.xi = ext;
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    it('GetExtensionVersion should report the extension present', function(done) {
+        this.xi.GetExtensionVersion((err, vers) => {
+            should.not.exist(err);
+            vers.present.should.equal(1);
+            vers.serverMajor.should.be.aboveOrEqual(1);
+            done();
+        });
+    });
+
+    it('ListInputDevices should list the virtual core pointer and keyboard', function(done) {
+        const xi = this.xi;
+        xi.ListInputDevices((err, devices) => {
+            should.not.exist(err);
+            devices.length.should.be.aboveOrEqual(2);
+
+            const pointer = devices.find(dev => dev.use === xi.DeviceUse.IsXPointer);
+            const keyboard = devices.find(dev => dev.use === xi.DeviceUse.IsXKeyboard);
+            should.exist(pointer);
+            should.exist(keyboard);
+            pointer.name.should.equal('Virtual core pointer');
+            keyboard.name.should.equal('Virtual core keyboard');
+
+            const buttonClass = pointer.classes.find(cls => cls.classId === xi.InputClass.Button);
+            should.exist(buttonClass);
+            buttonClass.numButtons.should.be.above(0);
+            const valuatorClass = pointer.classes.find(cls => cls.classId === xi.InputClass.Valuator);
+            should.exist(valuatorClass);
+            valuatorClass.axes.length.should.be.aboveOrEqual(2);
+
+            const keyClass = keyboard.classes.find(cls => cls.classId === xi.InputClass.Key);
+            should.exist(keyClass);
+            keyClass.minKeycode.should.be.above(0);
+            keyClass.maxKeycode.should.be.above(keyClass.minKeycode);
+            keyClass.numKeys.should.equal(keyClass.maxKeycode - keyClass.minKeycode + 1);
+            done();
+        });
+    });
+
+    it('XIQueryVersion should have negotiated XI 2.x', function() {
+        should.exist(this.xi.xi2);
+        this.xi.xi2.majorVersion.should.equal(2);
+        this.xi.xi2.minorVersion.should.be.aboveOrEqual(0);
+    });
+
+    it('XIQueryDevice(AllDevices) should list master pointer/keyboard with classes', function(done) {
+        const xi = this.xi;
+        xi.XIQueryDevice(xi.AllDevices, (err, devices) => {
+            should.not.exist(err);
+            devices.length.should.be.aboveOrEqual(2);
+
+            const master = devices.find(dev => dev.use === xi.DeviceType.MasterPointer);
+            const masterKbd = devices.find(dev => dev.use === xi.DeviceType.MasterKeyboard);
+            should.exist(master);
+            should.exist(masterKbd);
+            master.name.should.equal('Virtual core pointer');
+            masterKbd.name.should.equal('Virtual core keyboard');
+            // master devices are paired with each other
+            master.attachment.should.equal(masterKbd.deviceId);
+            masterKbd.attachment.should.equal(master.deviceId);
+            master.enabled.should.equal(1);
+
+            const buttonClass = master.classes.find(cls => cls.type === xi.ClassType.Button);
+            should.exist(buttonClass);
+            buttonClass.numButtons.should.be.above(0);
+            buttonClass.labels.length.should.equal(buttonClass.numButtons);
+
+            const valuators = master.classes.filter(cls => cls.type === xi.ClassType.Valuator);
+            valuators.length.should.be.aboveOrEqual(2);
+            valuators[0].number.should.equal(0);
+            valuators[0].mode.should.be.within(0, 1);
+
+            const keyClass = masterKbd.classes.find(cls => cls.type === xi.ClassType.Key);
+            should.exist(keyClass);
+            keyClass.keycodes.length.should.be.above(0);
+            done();
+        });
+    });
+
+    it('XIQueryDevice by id should return just that device', function(done) {
+        const xi = this.xi;
+        xi.XIQueryDevice(xi.AllMasterDevices, (err, masters) => {
+            should.not.exist(err);
+            const pointerId = masters.find(dev => dev.use === xi.DeviceType.MasterPointer).deviceId;
+            xi.XIQueryDevice(pointerId, (err, devices) => {
+                should.not.exist(err);
+                devices.length.should.equal(1);
+                devices[0].deviceId.should.equal(pointerId);
+                devices[0].name.should.equal('Virtual core pointer');
+                done();
+            });
+        });
+    });
+
+    after(function(done) {
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/xkb.js
+++ b/test/xkb.js
@@ -1,0 +1,137 @@
+const x11 = require('../lib');
+const should = require('should');
+
+describe('XKEYBOARD extension', () => {
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            self.X = dpy.client;
+            self.X.require('xkb', (err, ext) => {
+                should.not.exist(err);
+                self.xkb = ext;
+                done();
+            });
+        });
+
+        client.on('error', done);
+    });
+
+    it('UseExtension should report a supported 1.x server version', function() {
+        this.xkb.supported.should.equal(1);
+        this.xkb.serverMajor.should.equal(1);
+        this.xkb.serverMinor.should.be.aboveOrEqual(0);
+    });
+
+    it('GetState should return group and modifier state of the core keyboard', function(done) {
+        this.xkb.GetState(this.xkb.UseCoreKbd, (err, state) => {
+            should.not.exist(err);
+            state.deviceID.should.be.above(0);
+            state.group.should.be.within(0, 3);
+            state.lockedGroup.should.be.within(0, 3);
+            state.mods.should.be.within(0, 255);
+            state.baseMods.should.be.within(0, 255);
+            state.latchedMods.should.be.within(0, 255);
+            state.lockedMods.should.be.within(0, 255);
+            state.ptrBtnState.should.be.a.Number();
+            done();
+        });
+    });
+
+    it('Bell should ring without error', function(done) {
+        const self = this;
+        const onError = err => done(err);
+        this.X.on('error', onError);
+        // eventOnly bell: reaches the server, but keeps CI quiet
+        this.xkb.Bell(this.xkb.UseCoreKbd, this.xkb.DfltXIClass, this.xkb.DfltXIId,
+            0, 0, 1, -1, -1, 0, 0);
+        // round trip to make sure any error for the bell has arrived
+        this.xkb.GetState(this.xkb.UseCoreKbd, err => {
+            self.X.removeListener('error', onError);
+            should.not.exist(err);
+            done();
+        });
+    });
+
+    it('LatchLockState should lock a modifier, visible via GetState, then restore', function(done) {
+        const self = this;
+        const xkb = this.xkb;
+        const lockMask = xkb.ModMask.Lock; // caps lock
+        xkb.LatchLockState(xkb.UseCoreKbd, lockMask, lockMask, false, 0, 0, 0, false, 0);
+        xkb.GetState(xkb.UseCoreKbd, (err, state) => {
+            should.not.exist(err);
+            (state.lockedMods & lockMask).should.equal(lockMask);
+            // restore: other tests share the server's keyboard state
+            xkb.LatchLockState(xkb.UseCoreKbd, lockMask, 0, false, 0, 0, 0, false, 0);
+            xkb.GetState(xkb.UseCoreKbd, (err, state) => {
+                should.not.exist(err);
+                (state.lockedMods & lockMask).should.equal(0);
+                done();
+            });
+        });
+    });
+
+    it('SelectEvents + eventOnly Bell should deliver an XkbBellNotify event', function(done) {
+        const self = this;
+        const xkb = this.xkb;
+        xkb.SelectEvents(xkb.UseCoreKbd, xkb.EventType.BellNotify, 0,
+            xkb.EventType.BellNotify, 0, 0);
+        const onEvent = ev => {
+            if (ev.name !== 'XkbBellNotify')
+                return;
+            self.X.removeListener('event', onEvent);
+            // deselect again to not disturb later tests
+            xkb.SelectEvents(xkb.UseCoreKbd, xkb.EventType.BellNotify,
+                xkb.EventType.BellNotify, 0, 0, 0);
+            ev.pitch.should.equal(440);
+            ev.duration.should.equal(10);
+            ev.eventOnly.should.equal(1);
+            done();
+        };
+        this.X.on('event', onEvent);
+        xkb.Bell(xkb.UseCoreKbd, xkb.DfltXIClass, xkb.DfltXIId, 50, 0, 1, 440, 10, 0, 0);
+    });
+
+    it('GetControls should return the default repeat timings', function(done) {
+        this.xkb.GetControls(this.xkb.UseCoreKbd, (err, ctrls) => {
+            should.not.exist(err);
+            ctrls.numGroups.should.be.aboveOrEqual(1);
+            ctrls.repeatDelay.should.be.above(0);
+            ctrls.repeatInterval.should.be.above(0);
+            ctrls.mouseKeysDfltBtn.should.be.above(0);
+            ctrls.perKeyRepeat.length.should.equal(32);
+            done();
+        });
+    });
+
+    it('GetNames should return keycodes/symbols atoms and per-key names', function(done) {
+        const self = this;
+        const xkb = this.xkb;
+        const which = xkb.NameDetail.Keycodes | xkb.NameDetail.Symbols |
+            xkb.NameDetail.KeyNames | xkb.NameDetail.GroupNames |
+            xkb.NameDetail.VirtualModNames | xkb.NameDetail.IndicatorNames;
+        xkb.GetNames(xkb.UseCoreKbd, which, (err, names) => {
+            should.not.exist(err);
+            names.which.should.equal(which);
+            names.minKeyCode.should.be.above(0);
+            names.maxKeyCode.should.be.above(names.minKeyCode);
+            names.keyNames.length.should.equal(names.nKeys);
+            names.keyNames.should.containEql('AE01');
+            names.virtualModNames.length.should.be.above(0);
+            names.keycodesName.should.be.above(0);
+            names.symbolsName.should.be.above(0);
+            self.X.GetAtomName(names.keycodesName, (err, keycodesName) => {
+                should.not.exist(err);
+                keycodesName.length.should.be.above(0);
+                done();
+            });
+        });
+    });
+
+    after(function(done) {
+        // defensive: make sure no modifier lock leaks to other test files
+        this.xkb.LatchLockState(this.xkb.UseCoreKbd, 0xff, 0, false, 0, 0xff, 0, false, 0);
+        this.X.terminate();
+        this.X.on('end', done);
+    });
+});

--- a/test/xtest.js
+++ b/test/xtest.js
@@ -34,6 +34,83 @@ describe('XTEST extension', () => {
         });
     });
 
+    describe('CompareCursor', () => {
+        it('should return true comparing None with a window without cursor', done => {
+            const root = display.screen[0].root;
+            const wid = X.AllocID();
+            X.CreateWindow(wid, root, 0, 0, 10, 10);
+            xtest.CompareCursor(wid, xtest.Cursor.None, (err, same) => {
+                X.DestroyWindow(wid);
+                should.not.exist(err);
+                same.should.equal(true);
+                done();
+            });
+        });
+
+        it('should match the cursor set on a window and mismatch None', done => {
+            const root = display.screen[0].root;
+            const fid = X.AllocID();
+            X.OpenFont(fid, 'cursor');
+            const cid = X.AllocID();
+            // 68/69 - XC_left_ptr glyph and its mask in the standard cursor font
+            X.CreateGlyphCursor(cid, fid, fid, 68, 69,
+                { R: 0, G: 0, B: 0 }, { R: 0xffff, G: 0xffff, B: 0xffff });
+            X.CloseFont(fid);
+            const wid = X.AllocID();
+            X.CreateWindow(wid, root, 0, 0, 10, 10, 0, 0, 0, 0, { cursor: cid });
+            xtest.CompareCursor(wid, cid, (err, same) => {
+                should.not.exist(err);
+                same.should.equal(true);
+                xtest.CompareCursor(wid, xtest.Cursor.None, (err, same) => {
+                    X.DestroyWindow(wid);
+                    X.FreeCursor(cid);
+                    should.not.exist(err);
+                    same.should.equal(false);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('FakeInput', () => {
+        it('MotionNotify should move the pointer to the requested position', done => {
+            const root = display.screen[0].root;
+            X.QueryPointer(root, (err, before) => {
+                should.not.exist(err);
+                // detail 0 = absolute, root 0 = current screen
+                xtest.FakeInput(xtest.MotionNotify, 0, 0, 0, 33, 44);
+                X.QueryPointer(root, (err, pointer) => {
+                    // always restore the shared pointer position
+                    X.WarpPointer(0, root, 0, 0, 0, 0, before.rootX, before.rootY);
+                    should.not.exist(err);
+                    pointer.rootX.should.equal(33);
+                    pointer.rootY.should.equal(44);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('GrabControl', () => {
+        afterEach(() => {
+            // never leave this client impervious to grabs on the shared server
+            xtest.GrabControl(false);
+        });
+
+        it('should turn grab imperviousness on and off without error', done => {
+            xtest.GrabControl(true);
+            // sync round-trip: an error for GrabControl would arrive first
+            X.GetInputFocus(err => {
+                should.not.exist(err);
+                xtest.GrabControl(false);
+                X.GetInputFocus(err => {
+                    should.not.exist(err);
+                    done();
+                });
+            });
+        });
+    });
+
     after(done => {
         X.terminate();
         X.on('end', done);

--- a/test/xv.js
+++ b/test/xv.js
@@ -1,0 +1,187 @@
+const x11 = require('../lib');
+const should = require('should');
+
+// Xvfb exposes the XVideo extension but (typically) zero adaptors, so there
+// is no real port to drive. Port-based requests are then validated with a
+// bogus port: a controlled XvBadPort error proves the request reached the
+// server with correct framing. When a real adaptor exists (real hardware),
+// the same tests exercise the success path instead.
+
+const BOGUS_PORT = 0;
+
+describe('XVideo extension', () => {
+
+    let X;
+    let root;
+    let xv;
+    let adaptors;
+    let port = null;
+    let errorHandler = null;
+
+    before(done => {
+        const client = x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            X = dpy.client;
+            root = dpy.screen[0].root;
+            X.require('xv', (err, ext) => {
+                should.not.exist(err);
+                xv = ext;
+                xv.QueryAdaptors(root, (err, list) => {
+                    should.not.exist(err);
+                    adaptors = list;
+                    if (adaptors.length > 0)
+                        port = adaptors[0].baseId;
+                    done();
+                });
+            });
+        });
+        client.on('error', err => {
+            if (errorHandler)
+                errorHandler(err);
+            else
+                done(err);
+        });
+    });
+
+    after(done => {
+        X.terminate();
+        X.on('end', done);
+    });
+
+    it('QueryExtension should report version 2.2 or later', () => {
+        xv.major.should.be.aboveOrEqual(2);
+        if (xv.major === 2)
+            xv.minor.should.be.aboveOrEqual(2);
+    });
+
+    it('QueryAdaptors should return a well-formed (possibly empty) list', () => {
+        adaptors.should.be.an.Array();
+        adaptors.forEach(a => {
+            a.baseId.should.be.above(0);
+            a.name.should.be.a.String();
+            a.numPorts.should.be.aboveOrEqual(1);
+            a.type.should.be.within(0, 31);
+            a.formats.should.be.an.Array();
+            a.formats.forEach(f => {
+                f.visual.should.be.above(0);
+                f.depth.should.be.above(0);
+            });
+        });
+    });
+
+    it('QueryEncodings should list encodings or raise XvBadPort', done => {
+        if (port !== null) {
+            xv.QueryEncodings(port, (err, encodings) => {
+                should.not.exist(err);
+                encodings.should.be.an.Array();
+                encodings.length.should.be.aboveOrEqual(1);
+                encodings[0].name.should.be.a.String();
+                encodings[0].width.should.be.above(0);
+                encodings[0].height.should.be.above(0);
+                done();
+            });
+        } else {
+            xv.QueryEncodings(BOGUS_PORT, err => {
+                err.error.should.equal(xv.errors.BadPort);
+                done();
+                return true; // error handled, don't emit on the client
+            });
+        }
+    });
+
+    it('GrabPort/UngrabPort should succeed or raise XvBadPort', done => {
+        if (port !== null) {
+            xv.GrabPort(port, 0, (err, status) => {
+                should.not.exist(err);
+                status.should.equal(xv.GrabPortStatus.Success);
+                xv.UngrabPort(port, 0);
+                done();
+            });
+        } else {
+            xv.GrabPort(BOGUS_PORT, 0, err => {
+                err.error.should.equal(xv.errors.BadPort);
+                done();
+                return true;
+            });
+        }
+    });
+
+    it('QueryBestSize should return a size or raise XvBadPort', done => {
+        if (port !== null) {
+            xv.QueryBestSize(port, 320, 240, 640, 480, false, (err, size) => {
+                should.not.exist(err);
+                size.width.should.be.above(0);
+                size.height.should.be.above(0);
+                done();
+            });
+        } else {
+            xv.QueryBestSize(BOGUS_PORT, 320, 240, 640, 480, false, err => {
+                err.error.should.equal(xv.errors.BadPort);
+                done();
+                return true;
+            });
+        }
+    });
+
+    it('QueryPortAttributes should list attributes or raise XvBadPort', done => {
+        if (port !== null) {
+            xv.QueryPortAttributes(port, (err, attributes) => {
+                should.not.exist(err);
+                attributes.should.be.an.Array();
+                attributes.forEach(a => {
+                    a.name.should.be.a.String();
+                    a.flags.should.be.a.Number();
+                });
+                done();
+            });
+        } else {
+            xv.QueryPortAttributes(BOGUS_PORT, err => {
+                err.error.should.equal(xv.errors.BadPort);
+                done();
+                return true;
+            });
+        }
+    });
+
+    it('GetPortAttribute should raise XvBadPort for a bogus port', done => {
+        // even with a real port an attribute atom would be needed, so always
+        // exercise the error path here
+        xv.GetPortAttribute(BOGUS_PORT, 1 /* any atom */, err => {
+            err.error.should.equal(xv.errors.BadPort);
+            done();
+            return true;
+        });
+    });
+
+    it('SetPortAttribute (no reply) should raise XvBadPort via the error event', done => {
+        xv.SetPortAttribute(BOGUS_PORT, 1 /* any atom */, 0);
+        const seq = X.seq_num;
+        errorHandler = err => {
+            errorHandler = null;
+            err.error.should.equal(xv.errors.BadPort);
+            err.seq.should.equal(seq);
+            done();
+        };
+    });
+
+    it('ListImageFormats should list formats or raise XvBadPort', done => {
+        if (port !== null) {
+            xv.ListImageFormats(port, (err, formats) => {
+                should.not.exist(err);
+                formats.should.be.an.Array();
+                formats.forEach(f => {
+                    f.id.should.be.above(0);
+                    f.bpp.should.be.above(0);
+                    f.guid.length.should.equal(16);
+                });
+                done();
+            });
+        } else {
+            xv.ListImageFormats(BOGUS_PORT, err => {
+                err.error.should.equal(xv.errors.BadPort);
+                done();
+                return true;
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Implements every extension advertised by the X server and fills all request gaps in the existing extension modules, each request validated against a live Xvfb. Adds a `docs/` API reference and fixes a series of long-standing wire-format bugs.

### New extensions
XINERAMA, SYNC (3.1 incl. fences), RECORD (multi-reply EnableContext), MIT-SHM, DOUBLE-BUFFER, X-Resource (1.2), Generic Event Extension, Present, XVideo, XKEYBOARD (partial: UseExtension/SelectEvents/Bell/GetState/LatchLockState/GetControls/GetNames), XInputExtension (XI1 + XI2 XIQueryVersion/XIQueryDevice)

### Completed extensions
XFIXES (now full v5 incl. pointer barriers), RANDR (full 1.3), RENDER, SHAPE, MIT-SCREEN-SAVER, XTEST, XC-MISC, Apple-WM (window menu / update requests, validated against live XQuartz)

### Core
- GenericEvent (type 35) framing by length field + dispatch via `X.geEventParsers` keyed by extension major opcode — Present events work end to end (previously any GE event corrupted the stream)
- `test-runner.js` gates every extension test file on `QueryExtension`, so the suite passes on servers missing any extension

### Bug fixes (pre-existing)
- `Damage.Destroy` sent a malformed 12-byte packet — every call failed with BadLength
- `Render.Trapezoids` buffer overflow on any non-empty input; `FillRectangles` only filled the first rect; `CreatePicture` silently dropped zero-valued attributes
- `XTEST.FakeInput` wrote coordinates at wrong offsets — fake motion always went to (0,0)
- RANDR `GetOutputInfo` name, `GetScreenResources` mode list (~12/13 of modes dropped), `GetCrtcInfo` possible-outputs parsing
- MIT-SCREEN-SAVER version parsing (minor always 0), State enum, Notify event fields
- XFIXES `ChangeSaveSet` never sent the window; damage's event parser was registered under XFIXES by mistake
- apple-wm invoked the callback twice when the extension is missing

### Breaking changes (targeting 3.0.0, see Changelog.md)
- `AllocColor` reply: green/blue no longer swapped, `pixel` is the real 32-bit value (was `>> 8`)
- `GetWindowAttributes` reply: `doNotPropogateMask` → `doNotPropagateMask`
- `Randr.ConfigStatus.Sucess` → `Success`
- `PolyText8/16` throw `Error` objects instead of strings
- `XCMisc.GetXIDList` returns plain ids (was one-element arrays)

### Docs
New `docs/` folder: README (getting started), `core-requests.md` (all 120 requests), `core-events.md` (all 34 events), and one page per extension in `docs/ext/` (24 pages). Signatures derived from the implementation and verified against tests/live servers. AGENTS.md now requires docs to be updated alongside code changes.

Deliberately excluded: GLX fixes (Ortho/Normal3fv opcodes, BindTexImage attribs, ProgramString) — separate upcoming work; known issues are listed in `docs/ext/glx.md`.

## Test plan
- `npm run test:local` — 234 passing, 1 pending (pre-existing), 0 failing against Xvfb (XQuartz) on macOS
- `npm run lint` clean
- Apple-WM requests validated against a live XQuartz server (1.3.0)
- All docs relative links verified