### PR TITLE
Flow control and checked void requests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,8 +50,12 @@ The `display` passed to the callback describes the connection setup block:
 ## Making requests
 
 All requests live on `X = display.client` and follow the callback style —
-no promises. Requests with no reply take plain arguments; requests with a
-reply take a trailing `callback(err, result)`:
+no promises. Requests with a reply take a trailing `callback(err, result)`.
+Requests with no reply ("void" requests) can be fired and forgotten, or given
+a trailing `callback(err)` that fires exactly once: with `null` once the
+server has processed the request without error, or with the X error it
+caused (the client issues a cheap sync round trip when needed, the way
+`xcb_request_check` does):
 
 ```js
 const wid = X.AllocID();                       // allocate a resource id
@@ -62,6 +66,13 @@ X.MapWindow(wid);
 X.InternAtom(false, 'WM_NAME', (err, atom) => { // with reply
     // ...
 });
+
+X.ChangeWindowAttributes(root, {                // void request, checked:
+    eventMask: x11.eventMask.SubstructureRedirect
+}, err => {
+    // err === null   → the request succeeded (e.g. we are the WM now)
+    // err instanceof Error → e.g. BadAccess: another WM is running
+});
 ```
 
 Resource ids (windows, pixmaps, GCs, …) are allocated client-side with
@@ -70,6 +81,48 @@ destroyed. When you are done with the connection, call `X.terminate()`; the
 client emits `'end'` when the stream closes.
 
 See [core-requests.md](core-requests.md) for the complete reference.
+
+## Flow control
+
+Requests are buffered and written to the socket immediately, but the socket
+may not keep up (mouse-driven redraws, full-speed rendering). Three tools
+keep memory bounded:
+
+- **Return value + `'drain'`.** Every request method returns `false` when
+  the socket applied backpressure — same contract as `stream.Writable`'s
+  `write()`. Stop producing and resume on the client's `'drain'` event:
+
+  ```js
+  function render() {
+      let ok = true;
+      while (ok && hasWork())
+          ok = X.PolyFillRectangle(wid, gc, nextBatch());
+      if (!ok)
+          X.once('drain', render);   // resume when the socket caught up
+  }
+  ```
+
+- **`X.flush([cb])`** — the callback fires once everything buffered so far
+  has been handed to the OS. Returns a Promise when called without a
+  callback.
+
+- **`X.sync([cb])`** — a full round trip: the callback fires once the
+  *server has processed* every request issued so far (the equivalent of
+  `XSync`). Any errors those requests caused have been delivered by then.
+  Returns a Promise when called without a callback. Pacing a render loop
+  with `sync` throttles to what the server actually consumes:
+
+  ```js
+  function frame() {
+      drawFrame(X, wid, gc);
+      X.sync(() => frame());     // next frame only when this one is done
+  }
+  ```
+
+Sequence numbers are 16-bit on the wire but full-width on the client
+(`err.seq` keeps growing past 65535); the client transparently inserts a
+cheap round-trip request once per 60000 reply-less requests to keep the
+mapping unambiguous, the same way libxcb does.
 
 ## Listening for events
 
@@ -98,10 +151,12 @@ See [core-events.md](core-events.md) for every core event and its fields.
 
 ## Error handling
 
-X errors arrive asynchronously. Errors caused by a request with a reply are
-routed to that request's callback as `err` (an `Error` with `error` code,
-`seq`, `badParam`, `majorOpcode`/`minorOpcode`). Errors from reply-less
-requests — and errors nobody claims — are emitted as `'error'` on the client:
+X errors arrive asynchronously. Errors caused by a request issued with a
+callback — whether it has a reply or not — are routed to that callback as
+`err` (an `Error` with `error` code, `seq`, `badParam`,
+`majorOpcode`/`minorOpcode`). Errors from requests issued without a
+callback — and errors nobody claims — are emitted as `'error'` on the
+client:
 
 ```js
 X.on('error', err => console.error(err.message, err.badParam));

--- a/docs/core-requests.md
+++ b/docs/core-requests.md
@@ -3,9 +3,11 @@
 Reference for all 120 requests of the X11 core protocol as implemented on the
 client object (`X = display.client`, see [README.md](README.md) for connecting
 and the general calling convention). Requests with a reply take a trailing
-`cb(err, result)`; requests without one state "No reply." — they are fire and
-forget, and any X error they cause is emitted as `'error'` on the client with
-`err.seq` identifying the failing request. Source:
+`cb(err, result)`; requests without one state "No reply." — they can be fired
+and forgotten, or given a trailing `cb(err)` invoked exactly once: `null` on
+success (confirmed via a sync round trip when necessary) or the X error the
+request caused. Without a callback, errors are emitted as `'error'` on the
+client with `err.seq` identifying the failing request. Source:
 [`lib/corereqs.js`](../lib/corereqs.js); reply unpackers partly in
 [`lib/generated/core-replies.js`](../lib/generated/core-replies.js). Tests:
 [`test/core-*.js`](../test).

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -2,10 +2,15 @@
 
 const { EventEmitter } = require('events');
 
+const EMPTY = Buffer.alloc(0);
+
 /**
  * Bidirectional X11 framing buffer.
  * - Inbound: accumulate socket chunks; satisfy exact-length get(n, cb) reads.
  * - Outbound: put(Buffer) queues packets; flush() writes with drain/backpressure.
+ *   flush(cb) additionally invokes cb once everything queued before the call
+ *   has been handed to the OS. 'drain' is emitted when a backpressured socket
+ *   catches up and the queue is empty again.
  */
 function FrameBuffer() {
     EventEmitter.call(this);
@@ -13,7 +18,7 @@ function FrameBuffer() {
     this._length = 0;
     this._offset = 0;
     this._readQueue = [];
-    this.write_queue = [];
+    this.write_queue = []; // Buffers, and flush-callback sentinels between them
     this._socket = null;
     this._draining = false;
 }
@@ -37,6 +42,8 @@ FrameBuffer.prototype.attach = function(socket) {
     socket.on('drain', () => {
         self._draining = false;
         self.flush();
+        if (!self._draining)
+            self.emit('drain');
     });
 };
 
@@ -89,24 +96,50 @@ FrameBuffer.prototype.put = function(buf) {
     return this;
 };
 
-FrameBuffer.prototype.flush = function() {
+/**
+ * Write the queue out. Returns false when the socket applied backpressure
+ * (remaining data is sent on 'drain'). An optional callback fires once all
+ * data queued up to this call has been handed to the OS.
+ */
+FrameBuffer.prototype.flush = function(doneCb) {
+    if (doneCb) {
+        if (typeof doneCb !== 'function')
+            throw new TypeError('FrameBuffer.flush expects a callback function');
+        this.write_queue.push(doneCb);
+    }
+
     if (this._draining)
-        return;
+        return false;
 
     if (this._socket) {
         while (this.write_queue.length > 0) {
-            const buf = this.write_queue.shift();
-            const ok = this._socket.write(buf);
+            const item = this.write_queue.shift();
+            if (typeof item === 'function') {
+                // everything before this sentinel is inside the socket;
+                // fire once it reaches the OS
+                if (this._socket.writableLength === 0)
+                    queueMicrotask(item);
+                else
+                    this._socket.write(EMPTY, item);
+                continue;
+            }
+            const ok = this._socket.write(item);
             if (!ok) {
                 this._draining = true;
-                return;
+                return false;
             }
         }
-        return;
+        return true;
     }
 
-    while (this.write_queue.length > 0)
-        this.emit('data', this.write_queue.shift());
+    while (this.write_queue.length > 0) {
+        const item = this.write_queue.shift();
+        if (typeof item === 'function')
+            queueMicrotask(item);
+        else
+            this.emit('data', item);
+    }
+    return true;
 };
 
 module.exports = FrameBuffer;

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -105,6 +105,9 @@ XClient.prototype.init = function(stream)
     const client = this;
     // Outbound: FrameBuffer.attach handles write + drain/backpressure
     pack_stream.attach(stream);
+    pack_stream.on('drain', () => {
+        client.emit('drain');
+    });
     stream.on('data', data => {
         pack_stream.write(data);
     });
@@ -115,6 +118,15 @@ XClient.prototype.init = function(stream)
     this.pack_stream = pack_stream;
 
     this.rsrc_id = 0; // generated for each new resource
+
+    // seq_num is full-width and never wraps: requests don't carry it on the
+    // wire, and incoming 16-bit sequence numbers are widened in _widenSeq.
+    this._recv_seq = 0;        // full seq of the last packet received
+    this._last_seq_anchor = 0; // seq of the last reply-generating request sent
+    this._last_void_seq = 0;   // seq of the last void request with a callback
+    this._void_sync_scheduled = false;
+    this._injecting_anchor = false;
+
     const cli = this;
     if (cli.options.debug) {
       this.seq_num_ = 0;
@@ -170,14 +182,40 @@ XClient.prototype.terminate = function()
     this.stream.end();
 }
 
-// GetAtomName used as cheapest non-modifying request with reply
-// 3 - id for shortest standard atom, "ARC"
 XClient.prototype.ping = function(cb) {
    const start = Date.now();
-   this.GetAtomName(3, (err, str) => {
+   this.sync(err => {
       if (err) return cb(err);
       return cb(null, Date.now() - start);
    });
+}
+
+// Round trip to the server: the callback fires once every request issued so
+// far has been processed. Any errors those requests caused have been
+// delivered by then, so this is the barrier XSync/xcb_request_check provide.
+// Without a callback a Promise is returned.
+XClient.prototype.sync = function(cb) {
+    if (!cb) {
+        return new Promise((resolve, reject) => {
+            this.sync(err => (err ? reject(err) : resolve()));
+        });
+    }
+    // GetInputFocus is the traditional cheapest request with a reply
+    this.GetInputFocus(err => {
+        cb(err || null);
+        return true;
+    });
+}
+
+// The callback fires once all request bytes buffered so far have been handed
+// to the OS (issue #195). Without a callback a Promise is returned.
+XClient.prototype.flush = function(cb) {
+    if (!cb) {
+        return new Promise(resolve => {
+            this.flush(resolve);
+        });
+    }
+    this.pack_stream.flush(cb);
 }
 
 XClient.prototype.close = function(cb) {
@@ -204,12 +242,17 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
             if (client._closing)
                throw new Error('client is in closing state');
 
-            // simple overflow handling (this means that currently there is no way to have more than 65535 requests in the queue
-            // TODO: edge cases testing
-            if (client.seq_num == 65535)
-               client.seq_num = 0;
-            else
-               client.seq_num++;
+            // Wire sequence numbers are 16 bits. Keep at least one
+            // reply-generating request in every 60000-request window so
+            // incoming numbers widen unambiguously (libxcb does the same).
+            if (!client._injecting_anchor &&
+                client.seq_num - client._last_seq_anchor >= 60000) {
+               client._injecting_anchor = true;
+               client.GetInputFocus(() => true);
+               client._injecting_anchor = false;
+            }
+
+            client.seq_num++;
 
             let callback = args.length > 0 ? args[args.length - 1] : null;
             if (callback && callback.constructor.name != 'Function')
@@ -229,9 +272,10 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                      const value = args[1];
                      if (client.atoms[value]) {
                          -- client.seq_num;
-                         return setImmediate(() => {
+                         setImmediate(() => {
                              callback(undefined, client.atoms[value]);
                          });
+                         return true;
                      } else {
                          client.pending_atoms[client.seq_num] = value;
                      }
@@ -241,9 +285,10 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                      const atom = args[0];
                      if (client.atom_names[atom]) {
                          -- client.seq_num;
-                         return setImmediate(() => {
+                         setImmediate(() => {
                              callback(undefined, client.atom_names[atom]);
                          });
+                         return true;
                      } else {
                          client.pending_atoms[client.seq_num] = atom;
                      }
@@ -254,11 +299,21 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                  if (!Buffer.isBuffer(packet))
                      throw new TypeError(`${reqName}: pack template must return a Buffer`);
 
-                 if (callback)
+                 const expectsReply = !!reqReplTemplate[1];
+                 if (expectsReply)
+                     client._last_seq_anchor = client.seq_num;
+
+                 if (callback) {
                      this.replies[this.seq_num] = [reqReplTemplate[1], callback, reqReplTemplate[2]];
+                     // a void request only hears back on failure; make sure a
+                     // later reply confirms its success (issue #85)
+                     if (!expectsReply)
+                         client._scheduleVoidSync(this.seq_num);
+                 }
 
                  client.pack_stream.put(packet);
-                 client.pack_stream.flush();
+                 // false = socket backpressure: pause and wait for 'drain'
+                 return client.pack_stream.flush();
 
             } else if (templateType == 'Array'){
                  // legacy: should not happen once all templates are functions returning Buffer
@@ -305,6 +360,64 @@ XClient.prototype.unpackEvent = function(type, seq, extra, code, raw, headerBuf)
     return coreEvents.unpackEvent(type, seq, extra, code, raw, headerBuf);
 }
 
+// Server packets carry only the low 16 bits of the request sequence number;
+// reconstruct the full value. Packets arrive in non-decreasing sequence
+// order, and request issuing guarantees an anchor (a reply) at least every
+// 60000 requests, so the gap between consecutive received numbers is < 2^16.
+XClient.prototype._widenSeq = function(wire16)
+{
+    let full = this._recv_seq - (this._recv_seq % 0x10000) + wire16;
+    if (full < this._recv_seq)
+        full += 0x10000;
+    this._recv_seq = full;
+    return full;
+}
+
+// The server processes requests in order and sends errors immediately, so
+// once a packet with sequence number `uptoSeq` arrives, every void request
+// up to it that did not error has succeeded: fire its callback (issue #85).
+XClient.prototype._sweepVoid = function(uptoSeq)
+{
+    let done = null;
+    for (const key in this.replies) {
+        const seq = +key;
+        if (seq > uptoSeq)
+            break; // integer keys enumerate in ascending order
+        const handler = this.replies[seq];
+        if (handler[0])
+            continue; // expects a reply; resolved by its own reply packet
+        delete this.replies[seq];
+        if (this.options.debug)
+            delete this.seq2stack[seq];
+        (done = done || []).push(handler[1]);
+    }
+    if (done)
+        for (const callback of done)
+            callback(null);
+}
+
+// A void request's success is only observable once the server gets past it.
+// If nothing after it will generate a reply, force a cheap round trip so the
+// callback always fires. Coalesced: one round trip covers any number of void
+// requests issued in the same tick.
+XClient.prototype._scheduleVoidSync = function(seq)
+{
+    this._last_void_seq = seq;
+    if (this._void_sync_scheduled)
+        return;
+    this._void_sync_scheduled = true;
+    setImmediate(() => {
+        this._void_sync_scheduled = false;
+        if (this._closing || (this.stream && this.stream.writableEnded))
+            return;
+        // skip if a reply-generating request was sent after the void request
+        // (its reply confirms it) or the server already got past it
+        if (this._last_seq_anchor < this._last_void_seq &&
+            this._recv_seq < this._last_void_seq)
+            this.GetInputFocus(() => true);
+    });
+}
+
 XClient.prototype.expectReplyHeader = function()
 {
     const client = this;
@@ -312,7 +425,9 @@ XClient.prototype.expectReplyHeader = function()
             // CCSL: type, detail/error_code/opt, seq, length_or_extra
             const type = headerBuf.readUInt8(0);
             const detail = headerBuf.readUInt8(1);
-            const seq_num = headerBuf.readUInt16LE(2);
+            // KeymapNotify (11) is the only packet without a sequence number
+            const seq_num = (type & 0x7f) === 11 ?
+                client._recv_seq : client._widenSeq(headerBuf.readUInt16LE(2));
             const bad_value = headerBuf.readUInt32LE(4);
 
             if (type == 0)
@@ -339,6 +454,7 @@ XClient.prototype.expectReplyHeader = function()
                       extUnpacker(error, error_code, seq_num, bad_value, buf);
                     }
 
+                    client._sweepVoid(seq_num - 1);
                     const handler = client.replies[seq_num];
                     if (handler) {
                         const callback = handler[1];
@@ -360,6 +476,7 @@ XClient.prototype.expectReplyHeader = function()
                 // where other events keep 32-bit event data
                 const event_body_length = (type & 0x7f) === 35 ? 24 + bad_value * 4 : 24;
                 client.pack_stream.get(event_body_length, buf => {
+                    client._sweepVoid(seq_num);
                     const extra = bad_value;
                     const code = detail;
                     const ev = client.unpackEvent(type, seq_num, extra, code, buf, headerBuf);
@@ -392,6 +509,7 @@ XClient.prototype.expectReplyHeader = function()
 
             client.pack_stream.get( bodylength, data => {
 
+                client._sweepVoid(seq_num);
                 const handler = client.replies[seq_num];
                 if (handler) {
                     const unpack = handler[0];

--- a/test/flow-control.js
+++ b/test/flow-control.js
@@ -1,0 +1,153 @@
+const x11 = require('../lib');
+const assert = require('assert');
+
+describe('flow control', () => {
+
+  let display;
+  let X;
+  let root;
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err) return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          client.removeListener('error', done);
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.on('end', done);
+      X.terminate();
+  });
+
+  describe('void request callbacks (#85)', () => {
+
+    it('invokes the callback with null once the request succeeded', done => {
+        X.ChangeWindowAttributes(root, { eventMask: 0 }, err => {
+            assert.strictEqual(err, null);
+            done();
+        });
+    });
+
+    it('routes the error to the callback of the failing request', done => {
+        X.ChangeWindowAttributes(0, { eventMask: 0 }, err => {
+            assert.ok(err instanceof Error);
+            assert.strictEqual(err.error, 3); // BadWindow
+            done();
+            return true; // handled: don't re-emit on the client
+        });
+    });
+
+    it('invokes the callback exactly once', done => {
+        let calls = 0;
+        X.ChangeWindowAttributes(root, { eventMask: 0 }, err => {
+            assert.strictEqual(err, null);
+            calls++;
+        });
+        X.sync(err => {
+            assert.ifError(err);
+            setTimeout(() => {
+                assert.strictEqual(calls, 1);
+                done();
+            }, 30);
+        });
+    });
+
+    it('reports BadAccess when another client owns SubstructureRedirect', done => {
+        // the issue #85 scenario: register as window manager, then find out
+        const wmMask = x11.eventMask.SubstructureRedirect;
+        X.ChangeWindowAttributes(root, { eventMask: wmMask }, err => {
+            assert.strictEqual(err, null); // we are the window manager now
+            const second = x11.createClient((err2, dpy2) => {
+                assert.ifError(err2);
+                dpy2.client.ChangeWindowAttributes(root, { eventMask: wmMask }, err3 => {
+                    assert.ok(err3 instanceof Error);
+                    assert.strictEqual(err3.error, 10); // BadAccess
+                    dpy2.client.terminate();
+                    done();
+                    return true;
+                });
+            });
+            second.on('error', done);
+        });
+    });
+  });
+
+  describe('sync()', () => {
+
+    it('completes after all previous requests were processed', done => {
+        let sweeps = 0;
+        X.ChangeWindowAttributes(root, { eventMask: 0 }, () => { sweeps++; });
+        X.ChangeWindowAttributes(root, { eventMask: 0 }, () => { sweeps++; });
+        X.sync(err => {
+            assert.ifError(err);
+            assert.strictEqual(sweeps, 2);
+            done();
+        });
+    });
+
+    it('returns a promise when called without a callback', () => X.sync());
+  });
+
+  describe('flush()', () => {
+
+    it('fires once buffered requests were handed to the OS', done => {
+        X.ChangeWindowAttributes(root, { eventMask: 0 });
+        X.flush(done);
+    });
+
+    it('fires with an empty write queue too', done => {
+        X.flush(done);
+    });
+
+    it('returns a promise when called without a callback', () => X.flush());
+  });
+
+  describe('backpressure (#195)', () => {
+
+    it('requests return false when the socket backs up, then drain fires', function(done) {
+        this.timeout(30000);
+        const wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, 1, 1);
+        const chunk = Buffer.alloc(0xfff0, 0xab);
+        let ok = true;
+        let writes = 0;
+        while (ok && writes < 4096) {
+            ok = X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, chunk);
+            writes++;
+        }
+        assert.strictEqual(ok, false, `no backpressure after ${writes} writes`);
+        X.once('drain', () => {
+            X.sync(err => {
+                X.DestroyWindow(wid);
+                X.ReleaseID(wid);
+                done(err);
+            });
+        });
+    });
+  });
+
+  describe('sequence number widening', () => {
+
+    it('matches an error to its callback past the 16-bit wire wrap', function(done) {
+        this.timeout(60000);
+        for (let i = 0; i < 66000; i++)
+            X.ChangeWindowAttributes(root, { eventMask: 0 });
+        let voidErr = null;
+        X.ChangeWindowAttributes(0, { eventMask: 0 }, err => {
+            voidErr = err;
+            return true;
+        });
+        X.sync(err => {
+            assert.ifError(err);
+            assert.ok(voidErr instanceof Error, 'error reached its own callback');
+            assert.strictEqual(voidErr.error, 3); // BadWindow
+            assert.ok(voidErr.seq > 65535, 'sequence numbers are full-width');
+            done();
+        });
+    });
+  });
+});

--- a/test/sequence-overflow.js
+++ b/test/sequence-overflow.js
@@ -35,7 +35,9 @@ describe('Client', () => {
             return done();
          }
          left--;
-         display.client.GetAtomName(1, test);
+         // GetInputFocus really round-trips (GetAtomName of a standard atom
+         // is answered from the local cache and never hits the wire)
+         display.client.GetInputFocus(test);
       }
 
       left++;


### PR DESCRIPTION
Closes #195, closes #85.

The two issues share one missing primitive — honest sequence-number bookkeeping — so this PR fixes them together in three layers.

## 1. Full-width sequence tracking

`seq_num` no longer wraps at 65535. Requests don't carry the sequence number on the wire, so the client-side counter can be full-width; incoming 16-bit numbers are widened against the last received packet (packets arrive in non-decreasing order). To keep the widening unambiguous the client guarantees an anchor — a reply-generating request — in every 60000-request window, injecting a `GetInputFocus` when the application only issues void requests (same trick as libxcb).

This fixes the problems called out in the #85 discussion: `err.seq` collisions / callback misdelivery after 65535 requests, and `this.replies` leaking an entry for every void request whose callback never fired.

## 2. Checked void requests (#85)

A reply-less request called with a trailing callback now follows node CPS: the callback fires **exactly once** —

- `callback(null)` once the server has provably processed the request without error (any packet with a later sequence number confirms it, since errors are delivered in order), or
- `callback(err)` with the X error it caused.

If nothing after the void request would generate a reply, the client issues one coalesced `GetInputFocus` round trip on the next tick — the `xcb_request_check` behaviour, with no timeouts involved. The window-manager scenario from the issue now works directly:

```js
X.ChangeWindowAttributes(root, { eventMask: SubstructureRedirect }, err => {
    // err === null → we are the WM; BadAccess → another WM is running
});
```

There is also an explicit barrier, `X.sync([cb])` (`XSync` equivalent; returns a promise when called without a callback). `ping()`/`close()` were quietly broken by the atom cache — `GetAtomName(3)` is answered locally and never round-tripped — they now use `sync()`.

Behavioural note: previously a void-request callback was only invoked on error; it is now also invoked (with `null`) on success. The error-filter contract (return `true` to suppress the client-level `'error'` emit) is unchanged.

## 3. Application-visible backpressure (#195)

- Every request method returns `false` when the socket applied backpressure — the `stream.Writable#write` contract — and the client emits `'drain'` when it caught up.
- `X.flush([cb])` fires once all buffered request bytes have been handed to the OS.
- `await X.sync()` gives protocol-level pacing: throttle to what the *server* has consumed, not just what the kernel accepted — the generalized form of the Expose-loopback idea from the issue.

Docs: new *Flow control* section in `docs/README.md`, updated calling convention in `docs/core-requests.md`.

Tests: `test/flow-control.js` covers void success/error/exactly-once, the two-WM BadAccess scenario, `sync`/`flush` (callback + promise), backpressure + `drain`, and error-to-callback matching past the 16-bit wrap. `test/sequence-overflow.js` now really round-trips (it was hitting the atom cache). Full suite + xserver + glx-emu pass against Xvfb.