### PR TITLE
GLX: ChooseFBConfig helper implementing the GLX 1.4 selection rules

### DIFF
--- a/docs/ext/glx.md
+++ b/docs/ext/glx.md
@@ -232,6 +232,36 @@ Opcode 21. `cb(err, configs)` — array of objects keyed by attribute name
 (`FBCONFIG_ID`, `VISUAL_ID`, `DRAWABLE_TYPE`, `RENDER_TYPE`,
 `DOUBLEBUFFER`, ...).
 
+### ChooseFBConfig(screen, spec, cb)
+Convenience helper, not a protocol request: fetches the screen's fbconfigs
+with `GetFBConfigs` and applies the `glXChooseFBConfig` selection rules
+(GLX 1.4 spec §3.3.3) client-side. `spec` is an object keyed by attribute
+name; values are numbers, booleans, or `null` for "don't care".
+`cb(err, configs)` receives **all** matching configs sorted best-first —
+take `configs[0]` as the best match (empty array = nothing matched).
+
+```js
+GLX.ChooseFBConfig(0, {
+    DOUBLEBUFFER: true,
+    RED_SIZE: 8, GREEN_SIZE: 8, BLUE_SIZE: 8,
+    DEPTH_SIZE: 16,
+    DRAWABLE_TYPE: GLX.glxConst.WINDOW_BIT
+}, (err, configs) => {
+    const fbconfig = configs[0];
+    // GLX.CreateNewContext(ctx, fbconfig.FBCONFIG_ID, ...)
+});
+```
+
+Unspecified attributes take the spec's defaults (`RENDER_TYPE`
+`GLX_RGBA_BIT`, `DRAWABLE_TYPE` `GLX_WINDOW_BIT`, `STEREO` false, sizes 0,
+most others don't-care); sized attributes are minimums, `RENDER_TYPE`/
+`DRAWABLE_TYPE` are masks, the rest match exactly. Ties are broken by the
+spec's sort rules: no-caveat configs first, then deeper color (for the
+components you requested), smaller `BUFFER_SIZE`, single-buffer before
+double, fewer aux buffers, depth (none when unrequested, else deepest),
+smaller stencil, larger requested accum, `TrueColor` visuals first.
+Specifying `FBCONFIG_ID` ignores all other attributes, per the spec.
+
 ### CreatePixmap(screen, fbconfig, pixmap, glxpixmap, attribs)
 Opcode 22 (GLX 1.3 fbconfig flavour of CreateGLXPixmap). No reply.
 

--- a/examples/opengl/pbuffer-interop.js
+++ b/examples/opengl/pbuffer-interop.js
@@ -22,12 +22,13 @@ x11.createClient((err, display) => {
 
     X.require('glx', (err, GLX) => {
         if (err) throw err;
-        GLX.GetFBConfigs(0, (err, configs) => {
+        GLX.ChooseFBConfig(0, {
+            DRAWABLE_TYPE: GLX.glxConst.PBUFFER_BIT,
+            RENDER_TYPE: GLX.glxConst.RGBA_BIT,
+            DEPTH_SIZE: 1
+        }, (err, configs) => {
             if (err) throw err;
-            const cfg = configs.find(c =>
-                (c.DRAWABLE_TYPE & GLX.glxConst.PBUFFER_BIT) &&
-                (c.RENDER_TYPE & GLX.glxConst.RGBA_BIT) &&
-                c.DEPTH_SIZE > 0);
+            const cfg = configs[0]; // best match per the GLX selection rules
             if (!cfg)
                 throw new Error('no pbuffer-capable RGBA fbconfig on this server');
 

--- a/lib/ext/glx.js
+++ b/lib/ext/glx.js
@@ -202,6 +202,188 @@ function paddedLength(len) {
     return (len + 3) & ~3;
 }
 
+// ---------------------------------------------------------------------------
+// glXChooseFBConfig-style selection (GLX 1.4 spec §3.3.3), done client-side
+// over decoded GetFBConfigs results.
+
+const DONT_CARE = glxConst.DONT_CARE;
+
+// match kinds: how a requested value is compared to a config's value
+const EXACT = 0, MINIMUM = 1, MASK = 2;
+
+// attribute -> [default when unspecified, match kind] per the spec's table
+const fbMatchRules = {
+    FBCONFIG_ID: [DONT_CARE, EXACT],
+    BUFFER_SIZE: [0, MINIMUM],
+    LEVEL: [0, EXACT],
+    DOUBLEBUFFER: [DONT_CARE, EXACT],
+    STEREO: [0, EXACT],
+    AUX_BUFFERS: [0, MINIMUM],
+    RED_SIZE: [0, MINIMUM],
+    GREEN_SIZE: [0, MINIMUM],
+    BLUE_SIZE: [0, MINIMUM],
+    ALPHA_SIZE: [0, MINIMUM],
+    DEPTH_SIZE: [0, MINIMUM],
+    STENCIL_SIZE: [0, MINIMUM],
+    ACCUM_RED_SIZE: [0, MINIMUM],
+    ACCUM_GREEN_SIZE: [0, MINIMUM],
+    ACCUM_BLUE_SIZE: [0, MINIMUM],
+    ACCUM_ALPHA_SIZE: [0, MINIMUM],
+    RENDER_TYPE: [glxConst.RGBA_BIT, MASK],
+    DRAWABLE_TYPE: [glxConst.WINDOW_BIT, MASK],
+    X_RENDERABLE: [DONT_CARE, EXACT],
+    X_VISUAL_TYPE: [DONT_CARE, EXACT],
+    CONFIG_CAVEAT: [DONT_CARE, EXACT],
+    TRANSPARENT_TYPE: [glxConst.NONE, EXACT],
+    TRANSPARENT_INDEX_VALUE: [DONT_CARE, EXACT],
+    TRANSPARENT_RED_VALUE: [DONT_CARE, EXACT],
+    TRANSPARENT_GREEN_VALUE: [DONT_CARE, EXACT],
+    TRANSPARENT_BLUE_VALUE: [DONT_CARE, EXACT],
+    TRANSPARENT_ALPHA_VALUE: [DONT_CARE, EXACT],
+    // GLX 1.4 / ARB_multisample
+    SAMPLE_BUFFERS: [0, MINIMUM],
+    SAMPLES: [0, MINIMUM]
+};
+
+const caveatOrder = {
+    [glxConst.SLOW_CONFIG]: 1,
+    [glxConst.NON_CONFORMANT_CONFIG]: 2
+};
+
+const visualTypeOrder = {
+    [glxConst.TRUE_COLOR]: 0,
+    [glxConst.DIRECT_COLOR]: 1,
+    [glxConst.PSEUDO_COLOR]: 2,
+    [glxConst.STATIC_COLOR]: 3,
+    [glxConst.GRAY_SCALE]: 4,
+    [glxConst.STATIC_GRAY]: 5
+};
+
+const COLOR_SIZES = ['RED_SIZE', 'GREEN_SIZE', 'BLUE_SIZE', 'ALPHA_SIZE'];
+const ACCUM_SIZES = ['ACCUM_RED_SIZE', 'ACCUM_GREEN_SIZE', 'ACCUM_BLUE_SIZE',
+    'ACCUM_ALPHA_SIZE'];
+
+// Filter + sort `configs` (as decoded by GetFBConfigs) against `spec`, an
+// object keyed by attribute name; values may be numbers, booleans, or
+// null/DONT_CARE for "any". Returns matching configs best-first; ties keep
+// server order (Array#sort is stable). Exported for glx.js unit tests.
+function chooseFBConfigs(configs, spec) {
+    const want = {};
+    for (const key in spec) {
+        if (!(key in glxAttrib))
+            throw new TypeError(`unknown GLX attribute: ${key}`);
+        let v = spec[key];
+        if (v === null || v === undefined)
+            v = DONT_CARE;
+        else if (typeof v === 'boolean')
+            v = v ? 1 : 0;
+        else if (typeof v !== 'number' || !Number.isFinite(v))
+            throw new TypeError(`GLX attribute ${key} wants a number, boolean or null`);
+        want[key] = v >>> 0; // uint32 domain, same as the decoded configs
+    }
+
+    // "When a GLX_FBCONFIG_ID is specified, all attributes are ignored"
+    if (want.FBCONFIG_ID !== undefined && want.FBCONFIG_ID !== DONT_CARE)
+        return configs.filter(cfg => cfg.FBCONFIG_ID === want.FBCONFIG_ID);
+
+    // per-spec ignore clauses
+    if (want.DRAWABLE_TYPE !== undefined && want.DRAWABLE_TYPE !== DONT_CARE &&
+        !(want.DRAWABLE_TYPE & glxConst.WINDOW_BIT))
+        delete want.X_VISUAL_TYPE;
+    if (want.X_RENDERABLE === 0)
+        delete want.X_VISUAL_TYPE;
+    if (want.TRANSPARENT_TYPE !== glxConst.TRANSPARENT_INDEX)
+        delete want.TRANSPARENT_INDEX_VALUE;
+    if (want.TRANSPARENT_TYPE !== glxConst.TRANSPARENT_RGB) {
+        delete want.TRANSPARENT_RED_VALUE;
+        delete want.TRANSPARENT_GREEN_VALUE;
+        delete want.TRANSPARENT_BLUE_VALUE;
+    }
+
+    const matches = (cfg, key, wanted, kind, specified) => {
+        if (wanted === DONT_CARE)
+            return true;
+        const have = cfg[key];
+        if (have === undefined)
+            // config doesn't report the attribute: never hold a *default*
+            // against it, an explicit request is compared against 0
+            return !specified || wanted === 0;
+        switch (kind) {
+            case MINIMUM: return have >= wanted;
+            case MASK: return (have & wanted) === wanted;
+            default: return have === wanted;
+        }
+    };
+
+    const matched = configs.filter(cfg => {
+        for (const key in fbMatchRules) {
+            const [dflt, kind] = fbMatchRules[key];
+            const specified = want[key] !== undefined;
+            if (!matches(cfg, key, specified ? want[key] : dflt, kind, specified))
+                return false;
+        }
+        for (const key in want) {
+            // extension attributes outside the spec table: exact match
+            if (!(key in fbMatchRules) &&
+                !matches(cfg, key, want[key], EXACT, true))
+                return false;
+        }
+        return true;
+    });
+
+    // sort rules 1-9, applied in order; "requested" below means the caller
+    // gave a value that is neither 0 nor DONT_CARE
+    const requested = key => want[key] !== undefined &&
+        want[key] !== DONT_CARE && want[key] > 0;
+    const num = v => (v === undefined ? 0 : v);
+    const requestedColor = COLOR_SIZES.filter(requested);
+    const requestedAccum = ACCUM_SIZES.filter(requested);
+    const bitSum = (cfg, keys) => keys.reduce((sum, k) => sum + num(cfg[k]), 0);
+    const depthRequested = requested('DEPTH_SIZE');
+
+    return matched.sort((a, b) => {
+        // 1. no caveat, then slow, then non-conformant
+        let d = (caveatOrder[a.CONFIG_CAVEAT] || 0) -
+                (caveatOrder[b.CONFIG_CAVEAT] || 0);
+        if (d) return d;
+        // 2. larger total color bits over the requested components only
+        d = bitSum(b, requestedColor) - bitSum(a, requestedColor);
+        if (d) return d;
+        // 3. smaller BUFFER_SIZE
+        d = num(a.BUFFER_SIZE) - num(b.BUFFER_SIZE);
+        if (d) return d;
+        // 4. single buffered before double buffered
+        d = num(a.DOUBLEBUFFER) - num(b.DOUBLEBUFFER);
+        if (d) return d;
+        // 5. smaller AUX_BUFFERS
+        d = num(a.AUX_BUFFERS) - num(b.AUX_BUFFERS);
+        if (d) return d;
+        // 6. larger DEPTH_SIZE when requested; otherwise prefer no depth
+        //    buffer at all, then larger (matches Mesa and the spec's
+        //    "if this value is zero, configurations with no depth buffer
+        //    are preferred")
+        const da = num(a.DEPTH_SIZE), db = num(b.DEPTH_SIZE);
+        if (da !== db) {
+            if (!depthRequested) {
+                if (da === 0) return -1;
+                if (db === 0) return 1;
+            }
+            return db - da;
+        }
+        // 7. smaller STENCIL_SIZE
+        d = num(a.STENCIL_SIZE) - num(b.STENCIL_SIZE);
+        if (d) return d;
+        // 8. larger total accum bits over the requested components only
+        d = bitSum(b, requestedAccum) - bitSum(a, requestedAccum);
+        if (d) return d;
+        // 9. visual type: TrueColor, DirectColor, PseudoColor, StaticColor,
+        //    GrayScale, StaticGray; configs with no visual last
+        const va = visualTypeOrder[a.X_VISUAL_TYPE];
+        const vb = visualTypeOrder[b.X_VISUAL_TYPE];
+        return (va === undefined ? 6 : va) - (vb === undefined ? 6 : vb);
+    });
+}
+
 exports.requireExt = (display, callback) => {
     const X = display.client;
     X.QueryExtension('GLX', (err, ext) => {
@@ -497,6 +679,26 @@ exports.requireExt = (display, callback) => {
                     configs[i] = decodeAttribPairs(buf, 24 + i * numAttribs * 8, numAttribs);
                 return configs;
             }, callback);
+        };
+
+        // glXChooseFBConfig equivalent: fetches the screen's fbconfigs and
+        // returns the ones matching `spec`, sorted best-first per the GLX 1.4
+        // selection rules. `spec` is keyed by attribute name, e.g.
+        //   GLX.ChooseFBConfig(0, { DOUBLEBUFFER: true, RED_SIZE: 8,
+        //                           DEPTH_SIZE: 16 }, (err, configs) => ...)
+        // Values may be numbers, booleans, or null for "don't care";
+        // callback(err, configs) — take configs[0] as the best match.
+        ext.ChooseFBConfig = (screen, spec, callback) => {
+            ext.GetFBConfigs(screen, (err, configs) => {
+                if (err) return callback(err);
+                let chosen;
+                try {
+                    chosen = chooseFBConfigs(configs, spec);
+                } catch (specErr) {
+                    return callback(specErr);
+                }
+                callback(null, chosen);
+            });
         };
 
         // opcode 22; attribs: flat [attribute, value, ...] array
@@ -1033,3 +1235,8 @@ exports.requireExt = (display, callback) => {
         callback(null, ext);
     });
 };
+
+// exported for unit tests (test/glx-choose.js): pure filter+sort over
+// already-decoded fbconfig objects, and the value constants it consumes
+exports.chooseFBConfigs = chooseFBConfigs;
+exports.glxConst = glxConst;

--- a/test/glx-choose.js
+++ b/test/glx-choose.js
@@ -1,0 +1,170 @@
+// Unit tests for the glXChooseFBConfig-style selection rules (GLX 1.4 spec
+// §3.3.3) — pure filter+sort over decoded fbconfig objects, no server needed.
+const assert = require('assert');
+const { chooseFBConfigs, glxConst: C } = require('../lib/ext/glx');
+
+// a plausible fbconfig; override per test
+let nextId = 1;
+function cfg(over) {
+    return Object.assign({
+        FBCONFIG_ID: nextId++,
+        VISUAL_ID: 0x21,
+        BUFFER_SIZE: 24,
+        LEVEL: 0,
+        DOUBLEBUFFER: 0,
+        STEREO: 0,
+        AUX_BUFFERS: 0,
+        RED_SIZE: 8, GREEN_SIZE: 8, BLUE_SIZE: 8, ALPHA_SIZE: 0,
+        DEPTH_SIZE: 0,
+        STENCIL_SIZE: 0,
+        ACCUM_RED_SIZE: 0, ACCUM_GREEN_SIZE: 0,
+        ACCUM_BLUE_SIZE: 0, ACCUM_ALPHA_SIZE: 0,
+        RENDER_TYPE: C.RGBA_BIT,
+        DRAWABLE_TYPE: C.WINDOW_BIT | C.PIXMAP_BIT,
+        X_RENDERABLE: 1,
+        X_VISUAL_TYPE: C.TRUE_COLOR,
+        CONFIG_CAVEAT: C.NONE,
+        TRANSPARENT_TYPE: C.NONE
+    }, over);
+}
+
+const ids = configs => configs.map(c => c.FBCONFIG_ID);
+
+describe('GLX ChooseFBConfig selection rules', () => {
+
+  describe('matching', () => {
+
+    it('defaults require RGBA rendering to a window', () => {
+        const rgbaWindow = cfg({});
+        const indexOnly = cfg({ RENDER_TYPE: C.COLOR_INDEX_BIT });
+        const pbufferOnly = cfg({ DRAWABLE_TYPE: C.PBUFFER_BIT });
+        const out = chooseFBConfigs([indexOnly, rgbaWindow, pbufferOnly], {});
+        assert.deepStrictEqual(ids(out), [rgbaWindow.FBCONFIG_ID]);
+    });
+
+    it('sized attributes match as minimums', () => {
+        const small = cfg({ RED_SIZE: 5, GREEN_SIZE: 6, BLUE_SIZE: 5 });
+        const big = cfg({});
+        const out = chooseFBConfigs([small, big], { RED_SIZE: 8 });
+        assert.deepStrictEqual(ids(out), [big.FBCONFIG_ID]);
+    });
+
+    it('mask attributes require all requested bits', () => {
+        const winOnly = cfg({ DRAWABLE_TYPE: C.WINDOW_BIT });
+        const winPbuffer = cfg({ DRAWABLE_TYPE: C.WINDOW_BIT | C.PBUFFER_BIT });
+        const out = chooseFBConfigs([winOnly, winPbuffer],
+            { DRAWABLE_TYPE: C.WINDOW_BIT | C.PBUFFER_BIT });
+        assert.deepStrictEqual(ids(out), [winPbuffer.FBCONFIG_ID]);
+    });
+
+    it('DOUBLEBUFFER is exact when specified, any when not', () => {
+        const single = cfg({ DOUBLEBUFFER: 0 });
+        const dbl = cfg({ DOUBLEBUFFER: 1 });
+        assert.deepStrictEqual(ids(chooseFBConfigs([single, dbl], { DOUBLEBUFFER: true })),
+            [dbl.FBCONFIG_ID]);
+        assert.deepStrictEqual(ids(chooseFBConfigs([single, dbl], { DOUBLEBUFFER: false })),
+            [single.FBCONFIG_ID]);
+        assert.strictEqual(chooseFBConfigs([single, dbl], {}).length, 2);
+    });
+
+    it('null means don\'t care', () => {
+        const stereo = cfg({ STEREO: 1 });
+        const mono = cfg({});
+        // STEREO defaults to false; null lifts the restriction
+        assert.strictEqual(chooseFBConfigs([stereo, mono], {}).length, 1);
+        assert.strictEqual(chooseFBConfigs([stereo, mono], { STEREO: null }).length, 2);
+    });
+
+    it('FBCONFIG_ID short-circuits every other attribute', () => {
+        const indexOnly = cfg({ RENDER_TYPE: C.COLOR_INDEX_BIT, DOUBLEBUFFER: 1 });
+        const other = cfg({});
+        const out = chooseFBConfigs([other, indexOnly],
+            { FBCONFIG_ID: indexOnly.FBCONFIG_ID, DOUBLEBUFFER: false });
+        assert.deepStrictEqual(ids(out), [indexOnly.FBCONFIG_ID]);
+    });
+
+    it('unknown attribute names throw', () => {
+        assert.throws(() => chooseFBConfigs([cfg({})], { RED_SIZ: 8 }),
+            /unknown GLX attribute/);
+    });
+
+    it('an attribute the config does not report only matches undemanding requests', () => {
+        const noSamples = cfg({}); // SAMPLE_BUFFERS/SAMPLES absent
+        assert.strictEqual(chooseFBConfigs([noSamples], { SAMPLES: 4 }).length, 0);
+        assert.strictEqual(chooseFBConfigs([noSamples], { SAMPLES: 0 }).length, 1);
+    });
+  });
+
+  describe('sorting', () => {
+
+    it('rule 1: no caveat, then slow, then non-conformant', () => {
+        const slow = cfg({ CONFIG_CAVEAT: C.SLOW_CONFIG });
+        const nonConf = cfg({ CONFIG_CAVEAT: C.NON_CONFORMANT_CONFIG });
+        const clean = cfg({});
+        const out = chooseFBConfigs([slow, nonConf, clean], {});
+        assert.deepStrictEqual(ids(out),
+            [clean.FBCONFIG_ID, slow.FBCONFIG_ID, nonConf.FBCONFIG_ID]);
+    });
+
+    it('rule 2: deeper color wins only for requested components', () => {
+        const deep = cfg({ RED_SIZE: 10, GREEN_SIZE: 10, BLUE_SIZE: 10,
+            ALPHA_SIZE: 2, BUFFER_SIZE: 32 });
+        const shallow = cfg({});
+        // color depth requested: deeper first despite larger BUFFER_SIZE
+        assert.deepStrictEqual(ids(chooseFBConfigs([shallow, deep], { RED_SIZE: 1 })),
+            [deep.FBCONFIG_ID, shallow.FBCONFIG_ID]);
+        // not requested: rule 3 (smaller BUFFER_SIZE) decides instead
+        assert.deepStrictEqual(ids(chooseFBConfigs([deep, shallow], {})),
+            [shallow.FBCONFIG_ID, deep.FBCONFIG_ID]);
+    });
+
+    it('rule 4: single buffered precedes double buffered', () => {
+        const dbl = cfg({ DOUBLEBUFFER: 1 });
+        const single = cfg({});
+        assert.deepStrictEqual(ids(chooseFBConfigs([dbl, single], {})),
+            [single.FBCONFIG_ID, dbl.FBCONFIG_ID]);
+    });
+
+    it('rule 6: no depth buffer preferred when unrequested, largest when requested', () => {
+        const none = cfg({});
+        const d16 = cfg({ DEPTH_SIZE: 16 });
+        const d24 = cfg({ DEPTH_SIZE: 24 });
+        assert.deepStrictEqual(ids(chooseFBConfigs([d16, d24, none], {})),
+            [none.FBCONFIG_ID, d24.FBCONFIG_ID, d16.FBCONFIG_ID]);
+        assert.deepStrictEqual(ids(chooseFBConfigs([d16, d24, none], { DEPTH_SIZE: 1 })),
+            [d24.FBCONFIG_ID, d16.FBCONFIG_ID]);
+    });
+
+    it('rule 7: smaller stencil preferred', () => {
+        const s8 = cfg({ STENCIL_SIZE: 8 });
+        const s0 = cfg({});
+        assert.deepStrictEqual(ids(chooseFBConfigs([s8, s0], {})),
+            [s0.FBCONFIG_ID, s8.FBCONFIG_ID]);
+    });
+
+    it('rule 8: larger accum total wins for requested components', () => {
+        const accum16 = cfg({ ACCUM_RED_SIZE: 16, ACCUM_GREEN_SIZE: 16,
+            ACCUM_BLUE_SIZE: 16 });
+        const accum8 = cfg({ ACCUM_RED_SIZE: 8, ACCUM_GREEN_SIZE: 8,
+            ACCUM_BLUE_SIZE: 8 });
+        const out = chooseFBConfigs([accum8, accum16], { ACCUM_RED_SIZE: 1 });
+        assert.deepStrictEqual(ids(out),
+            [accum16.FBCONFIG_ID, accum8.FBCONFIG_ID]);
+    });
+
+    it('rule 9: TrueColor visuals precede DirectColor', () => {
+        const direct = cfg({ X_VISUAL_TYPE: C.DIRECT_COLOR });
+        const truec = cfg({});
+        assert.deepStrictEqual(ids(chooseFBConfigs([direct, truec], {})),
+            [truec.FBCONFIG_ID, direct.FBCONFIG_ID]);
+    });
+
+    it('equal configs keep server order', () => {
+        const a = cfg({});
+        const b = cfg({});
+        const c = cfg({});
+        assert.deepStrictEqual(ids(chooseFBConfigs([a, b, c], {})),
+            [a.FBCONFIG_ID, b.FBCONFIG_ID, c.FBCONFIG_ID]);
+    });
+  });
+});

--- a/test/glx.js
+++ b/test/glx.js
@@ -139,6 +139,50 @@ describe('GLX extension', function() {
         }));
     });
 
+    it('ChooseFBConfig should return matching configs sorted best-first', function(done) {
+        const self = this;
+        const C = this.GLX.glxConst;
+        const spec = { RENDER_TYPE: C.RGBA_BIT, DRAWABLE_TYPE: C.WINDOW_BIT,
+            RED_SIZE: 1, GREEN_SIZE: 1, BLUE_SIZE: 1, DOUBLEBUFFER: true };
+        this.GLX.ChooseFBConfig(0, spec, guard(done, (err, chosen) => {
+            should.not.exist(err);
+            chosen.should.be.an.Array();
+            chosen.length.should.be.above(0);
+            // every returned config satisfies the request
+            for (const c of chosen) {
+                (c.RENDER_TYPE & C.RGBA_BIT).should.be.above(0);
+                (c.DRAWABLE_TYPE & C.WINDOW_BIT).should.be.above(0);
+                c.RED_SIZE.should.be.above(0);
+                c.DOUBLEBUFFER.should.equal(1);
+            }
+            // the best config has no caveat and the deepest color available
+            // among the matches (sort rules 1 and 2)
+            const best = chosen[0];
+            (best.CONFIG_CAVEAT === undefined ||
+                best.CONFIG_CAVEAT === C.NONE).should.be.true();
+            const colorBits = c => c.RED_SIZE + c.GREEN_SIZE + c.BLUE_SIZE;
+            for (const c of chosen)
+                colorBits(best).should.be.aboveOrEqual(colorBits(c));
+            // results come from the server's fbconfig list
+            self.GLX.GetFBConfigs(0, guard(done, (err2, all) => {
+                should.not.exist(err2);
+                const allIds = new Set(all.map(c => c.FBCONFIG_ID));
+                for (const c of chosen)
+                    allIds.has(c.FBCONFIG_ID).should.be.true();
+                done();
+            }));
+        }));
+    });
+
+    it('ChooseFBConfig with an impossible spec should return an empty list', function(done) {
+        this.GLX.ChooseFBConfig(0, { RED_SIZE: 1024 }, guard(done, (err, chosen) => {
+            should.not.exist(err);
+            chosen.should.be.an.Array();
+            chosen.length.should.equal(0);
+            done();
+        }));
+    });
+
     it('GetFBConfigsSGIX should agree with GetFBConfigs', function(done) {
         const self = this;
         this.GLX.GetFBConfigsSGIX(0, guard(done, (err, configs) => {


### PR DESCRIPTION
Closes #183.

The attribute constants and decoded `GetFBConfigs` replies landed with #218; this adds the remaining piece — a `glXChooseFBConfig` equivalent so callers stop filtering the config list by hand (which silently picks server order and regularly lands on caveated/stereo/accum-heavy configs).

## API

```js
GLX.ChooseFBConfig(0, {
    DOUBLEBUFFER: true,
    RED_SIZE: 8, GREEN_SIZE: 8, BLUE_SIZE: 8,
    DEPTH_SIZE: 16
}, (err, configs) => {
    const fbconfig = configs[0];   // best match; [] if nothing matched
});
```

`spec` is keyed by the same attribute names as the decoded configs; values are numbers, booleans, or `null` for don't-care. The callback receives **all** matching configs sorted best-first, mirroring `glXChooseFBConfig` returning the full sorted list.

## Semantics

Implements GLX 1.4 spec §3.3.3 client-side over `GetFBConfigs`:

- per-attribute defaults (`RENDER_TYPE` → `GLX_RGBA_BIT`, `DRAWABLE_TYPE` → `GLX_WINDOW_BIT`, `STEREO` → false, sizes → 0, most others → don't-care) and match kinds (exact / minimum / mask);
- the spec's ignore clauses: `FBCONFIG_ID` short-circuits everything, `X_VISUAL_TYPE` is dropped when the requested drawable type has no `WINDOW_BIT` or `X_RENDERABLE` is false, `TRANSPARENT_*_VALUE` only apply under the matching `TRANSPARENT_TYPE`;
- the nine sort precedence rules: caveat (none → slow → non-conformant), larger color depth counting only the components the caller requested, smaller `BUFFER_SIZE`, single-buffer first, fewer aux buffers, depth, smaller stencil, larger requested accum total, visual-type order (`TrueColor` first). Ties keep server order (stable sort).

One documented judgment call: for the depth rule the spec's numbered list says "larger `GLX_DEPTH_SIZE`" while its attribute text says a zero request prefers configs with *no* depth buffer. We follow Mesa's reconciliation: no-depth first when depth wasn't requested, deepest first otherwise.

Extension attributes outside the spec table (e.g. `BIND_TO_TEXTURE_RGBA_EXT`) can be specified and match exactly; unknown attribute names throw. Configs that don't report a requested attribute only match undemanding (0/don't-care) requests, so e.g. `SAMPLES: 4` correctly excludes servers without multisample.

## Tests / consumers

- `test/glx-choose.js` — 16 unit cases over the pure filter+sort core (exported from `lib/ext/glx.js`), no X server needed: every match kind, don't-care handling, the `FBCONFIG_ID` short-circuit, each sort rule, and stability.
- `test/glx.js` — two integration tests against a live server: returned configs satisfy the request, best-first ordering holds (no caveat + deepest requested color), results are a subset of `GetFBConfigs`, and an impossible spec yields `[]`.
- `examples/opengl/pbuffer-interop.js` now uses the helper; `docs/ext/glx.md` documents it.

Full suite: 300 passing against Xvfb `+iglx` (was 282), lint clean.