### PR TITLE
feat(xserver): RENDER extension for the JS X server

### DIFF
--- a/lib/xserver/drawing.js
+++ b/lib/xserver/drawing.js
@@ -73,7 +73,7 @@ function install(server) {
         server.getDrawable(body.readUInt32LE(4));
         const width = body.readUInt16LE(8);
         const height = body.readUInt16LE(10);
-        if (depth !== 1 && depth !== 24 && depth !== 32)
+        if (depth !== 1 && depth !== 8 && depth !== 24 && depth !== 32)
             throw new XError(codes.Value, depth);
         if (width === 0 || height === 0)
             throw new XError(codes.Value, 0);
@@ -242,16 +242,31 @@ function install(server) {
                 if (data.length < rowBytes * height)
                     throw new XError(codes.Length, data.length);
                 t.raster.putBitmap(rgc, dstX, dstY, width, height, rowBytes, data, true);
+            } else if (depth === 8) {
+                if (leftPad !== 0)
+                    throw new XError(codes.Match, leftPad);
+                const rowBytes = padded32(width * 8);
+                if (data.length < rowBytes * height)
+                    throw new XError(codes.Length, data.length);
+                const pixels = new Uint32Array(width * height);
+                for (let y = 0; y < height; y++)
+                    for (let x = 0; x < width; x++)
+                        pixels[y * width + x] = data[y * rowBytes + x];
+                t.raster.putPixels(rgc, dstX, dstY, width, height, pixels);
             } else {
                 if (leftPad !== 0)
                     throw new XError(codes.Match, leftPad);
                 const rowBytes = width * 4;
                 if (data.length < rowBytes * height)
                     throw new XError(codes.Length, data.length);
+                // depth-32 data into a depth-32 drawable keeps the alpha
+                // byte (RENDER rgba32 uploads); a depth-24 target stores
+                // only the low 24 bits
+                const mask = t.depth === 32 ? 0xffffffff : 0xffffff;
                 const pixels = new Uint32Array(width * height);
                 for (let y = 0; y < height; y++)
                     for (let x = 0; x < width; x++)
-                        pixels[y * width + x] = data.readUInt32LE(y * rowBytes + x * 4) & 0xffffff;
+                        pixels[y * width + x] = (data.readUInt32LE(y * rowBytes + x * 4) & mask) >>> 0;
                 t.raster.putPixels(rgc, dstX, dstY, width, height, pixels);
             }
         } else if (format === 0 || (format === 1 && depth === 1)) {
@@ -297,6 +312,12 @@ function install(server) {
                 for (let xx = 0; xx < width; xx++)
                     if (pixels[yy * width + xx] & planeMask & 1)
                         data[yy * rowBytes + (xx >> 3)] |= 1 << (xx & 7);
+        } else if (t.depth === 8) {
+            const rowBytes = padded32(width * 8);
+            data = Buffer.alloc(rowBytes * height);
+            for (let yy = 0; yy < height; yy++)
+                for (let xx = 0; xx < width; xx++)
+                    data[yy * rowBytes + xx] = pixels[yy * width + xx] & planeMask & 0xff;
         } else {
             data = Buffer.alloc(width * height * 4);
             for (let i = 0; i < pixels.length; i++)

--- a/lib/xserver/extensions/render.js
+++ b/lib/xserver/extensions/render.js
@@ -1,0 +1,1203 @@
+'use strict';
+
+// RENDER extension for the pure-JS X server.
+//
+// The wire decoder mirrors this repo's client encoder (lib/ext/render.js).
+// Two deviations from stock renderproto follow from that:
+//  - AddGlyphs images arrive with rows already padded to a 4-byte stride and
+//    offX/offY already divided down to whole pixels by the client.
+//  - AddTraps carries SPANFIX trapezoids (top l/r/y, bottom l/r/y), the same
+//    layout Xorg uses for AddTraps.
+//
+// Pixel model: pictures composite in premultiplied ARGB over the server's
+// Uint32 rasters. How the 32-bit cell maps to channels depends on the
+// picture format depth:
+//  - 32 (rgba32): full 0xAARRGGBB, premultiplied.
+//  - 24 (rgb24):  0x00RRGGBB; alpha reads as 255, writes drop alpha and keep
+//    the top byte 0 - the core server (compose(), GetImage, PutImage) only
+//    understands the low 24 bits, so we must not invent data up there.
+//  -  8 (a8):     alpha in the low byte, color reads as premultiplied black.
+//  -  1 (mono1):  alpha in bit 0.
+
+const { XError, codes } = require('../errors');
+
+// RENDER errors, as offsets from the extension's firstError
+const ERR_PICTFORMAT = 0;
+const ERR_PICTURE = 1;
+const ERR_PICTOP = 2;
+const ERR_GLYPHSET = 3;
+const ERR_GLYPH = 4;
+
+const FIXED = 65536; // 16.16 fixed point
+const pad4 = n => (n + 3) & ~3;
+
+// picture format ids: arbitrary XIDs outside any client's resource range.
+// The descriptors are exactly what the client's require('render') handshake
+// looks for to derive Render.rgba32 / rgb24 / a8 / mono1.
+const FORMAT_LIST = [
+    { id: 0x101, depth: 32, r: [16, 255], g: [8, 255], b: [0, 255], a: [24, 255] }, // rgba32
+    { id: 0x102, depth: 24, r: [16, 255], g: [8, 255], b: [0, 255], a: [0, 0] },    // rgb24
+    { id: 0x103, depth: 8, r: [0, 0], g: [0, 0], b: [0, 0], a: [0, 255] },          // a8
+    { id: 0x104, depth: 1, r: [0, 0], g: [0, 0], b: [0, 0], a: [0, 1] }             // mono1
+];
+const RGB24_ID = 0x102;
+const formats = new Map();
+for (const f of FORMAT_LIST)
+    formats.set(f.id, f);
+
+// per-server firstError (error codes are allocated at registration time)
+const firstErrors = new WeakMap();
+const renderError = (server, offset, badValue) =>
+    new XError(firstErrors.get(server) + offset, badValue);
+
+// wire COLOR (4 x CARD16 in r/g/b/a order, premultiplied) -> [a, r, g, b]
+// floats 0..255. 65535 / 255 === 257 exactly.
+function readColor(body, off) {
+    return [
+        body.readUInt16LE(off + 6) / 257,
+        body.readUInt16LE(off) / 257,
+        body.readUInt16LE(off + 2) / 257,
+        body.readUInt16LE(off + 4) / 257
+    ];
+}
+
+// ---------------------------------------------------------------------
+// raster channel access (see the pixel-model note above)
+
+function readPx(raster, depth, x, y, out) {
+    const p = raster.data[y * raster.width + x];
+    switch (depth) {
+        case 32:
+            out[0] = (p >>> 24) & 0xff;
+            out[1] = (p >>> 16) & 0xff;
+            out[2] = (p >>> 8) & 0xff;
+            out[3] = p & 0xff;
+            return out;
+        case 24:
+            out[0] = 255;
+            out[1] = (p >>> 16) & 0xff;
+            out[2] = (p >>> 8) & 0xff;
+            out[3] = p & 0xff;
+            return out;
+        case 8:
+            out[0] = p & 0xff;
+            out[1] = 0;
+            out[2] = 0;
+            out[3] = 0;
+            return out;
+        default: // 1
+            out[0] = (p & 1) * 255;
+            out[1] = 0;
+            out[2] = 0;
+            out[3] = 0;
+            return out;
+    }
+}
+
+const clamp255 = v => (v < 0 ? 0 : v > 255 ? 255 : Math.round(v));
+
+function writePx(raster, depth, x, y, a, r, g, b) {
+    const i = y * raster.width + x;
+    switch (depth) {
+        case 32:
+            raster.data[i] =
+                ((clamp255(a) << 24) | (clamp255(r) << 16) | (clamp255(g) << 8) | clamp255(b)) >>> 0;
+            return;
+        case 24:
+            raster.data[i] = ((clamp255(r) << 16) | (clamp255(g) << 8) | clamp255(b)) >>> 0;
+            return;
+        case 8:
+            raster.data[i] = clamp255(a);
+            return;
+        default: // 1
+            raster.data[i] = a >= 128 ? 1 : 0;
+    }
+}
+
+// ---------------------------------------------------------------------
+// Porter-Duff (premultiplied). Returns [Fa, Fb] for src/dst contribution;
+// result channel = src*Fa + dst*Fb, alphas included.
+
+function blendFactors(op, as, ad) {
+    switch (op) {
+        case 0: return [0, 0];                 // Clear
+        case 1: return [1, 0];                 // Src
+        case 2: return [0, 1];                 // Dst
+        case 3: return [1, 1 - as];            // Over
+        case 4: return [1 - ad, 1];            // OverReverse
+        case 5: return [ad, 0];                // In
+        case 6: return [0, as];                // InReverse
+        case 7: return [1 - ad, 0];            // Out
+        case 8: return [0, 1 - as];            // OutReverse
+        case 9: return [ad, 1 - as];           // Atop
+        case 10: return [1 - ad, as];          // AtopReverse
+        case 11: return [1 - ad, 1 - as];      // Xor
+        case 12: return [1, 1];                // Add
+        case 13: return [as > 0 ? Math.min(1, (1 - ad) / as) : 1, 1]; // Saturate
+        default: return null;                  // caller raises BadPictOp
+    }
+}
+
+// ---------------------------------------------------------------------
+// antialiased coverage accumulation, shared by AddTraps, Trapezoids and the
+// triangle requests.
+//
+// One trapezoid = linear left edge (tlx,ty)-(blx,by) and right edge
+// (trx,ty)-(brx,by). Horizontal coverage per column is analytic (exact);
+// vertically each pixel row is split into SUB sub-bands sampled at their
+// midpoints - combined that comfortably exceeds the 4x4-supersampling
+// quality bar while staying O(covered pixels).
+
+const SUB = 4;
+
+function accumulateTrap(cov, W, H, tlx, trx, ty, blx, brx, by) {
+    if (!(by > ty))
+        return;
+    const yStart = Math.max(0, Math.floor(ty));
+    const yEnd = Math.min(H, Math.ceil(by));
+    const invH = 1 / (by - ty);
+    for (let Y = yStart; Y < yEnd; Y++) {
+        const bandTop = Math.max(ty, Y);
+        const bandBot = Math.min(by, Y + 1);
+        if (!(bandBot > bandTop))
+            continue;
+        const step = (bandBot - bandTop) / SUB;
+        const rowBase = Y * W;
+        for (let s = 0; s < SUB; s++) {
+            const t = (bandTop + (s + 0.5) * step - ty) * invH;
+            let lx = tlx + (blx - tlx) * t;
+            let rx = trx + (brx - trx) * t;
+            if (rx < lx) {
+                const tmp = lx;
+                lx = rx;
+                rx = tmp;
+            }
+            if (rx <= 0 || lx >= W)
+                continue;
+            if (lx < 0)
+                lx = 0;
+            if (rx > W)
+                rx = W;
+            const x0 = Math.floor(lx);
+            const x1 = Math.ceil(rx);
+            for (let X = x0; X < x1; X++) {
+                const covered = Math.min(X + 1, rx) - Math.max(X, lx);
+                if (covered > 0)
+                    cov[rowBase + X] += covered * step;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// gradient color lookup. Stops are [{offset, color: [a,r,g,b]}] sorted by
+// offset; t outside the stop range clamps to the edge stops (pad).
+
+function gradientAt(stops, t) {
+    if (stops.length === 0)
+        return [0, 0, 0, 0];
+    if (!(t > stops[0].offset))
+        return stops[0].color;
+    const last = stops[stops.length - 1];
+    if (!(t < last.offset))
+        return last.color;
+    for (let i = 1; i < stops.length; i++) {
+        if (t <= stops[i].offset) {
+            const a = stops[i - 1];
+            const b = stops[i];
+            const span = b.offset - a.offset;
+            const f = span > 0 ? (t - a.offset) / span : 0;
+            return [
+                a.color[0] + (b.color[0] - a.color[0]) * f,
+                a.color[1] + (b.color[1] - a.color[1]) * f,
+                a.color[2] + (b.color[2] - a.color[2]) * f,
+                a.color[3] + (b.color[3] - a.color[3]) * f
+            ];
+        }
+    }
+    return last.color;
+}
+
+function getPicture(server, xid) {
+    const res = server.resources.get(xid);
+    if (!res || res.type !== 'picture')
+        throw renderError(server, ERR_PICTURE, xid);
+    return res;
+}
+
+function getGlyphset(server, xid) {
+    const res = server.resources.get(xid);
+    if (!res || res.type !== 'glyphset')
+        throw renderError(server, ERR_GLYPHSET, xid);
+    return res;
+}
+
+// pictures with backing storage (as opposed to solid/gradient sources)
+function targetRaster(pict) {
+    if (!pict.drawable)
+        throw new XError(codes.Match, pict.id);
+    return pict.drawable.raster; // read per-op: window rasters are replaced on resize
+}
+
+function damage(server, pict) {
+    if (pict.drawable && pict.drawable.type === 'window')
+        server.damageWindow(pict.drawable);
+}
+
+// clip set by SetPictureClipRectangles: null (no clip) or rects in drawable
+// coordinates. All write loops test destination pixels against it.
+function inClip(pict, x, y) {
+    const clip = pict.clip;
+    if (!clip)
+        return true;
+    for (let i = 0; i < clip.length; i++) {
+        const r = clip[i];
+        if (x >= r.x && y >= r.y && x < r.x + r.width && y < r.y + r.height)
+            return true;
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------
+// sampling: (x, y) are source-space coordinates at pixel centers
+// (caller passes srcX + i + 0.5). The picture transform maps them into
+// texture space, then the filter fetches texels honoring `repeat`.
+
+function fetchTexel(pict, ix, iy, out) {
+    const raster = pict.drawable.raster;
+    const W = raster.width;
+    const H = raster.height;
+    switch (pict.repeat) {
+        case 1: // Normal: tile
+            ix = ((ix % W) + W) % W;
+            iy = ((iy % H) + H) % H;
+            break;
+        case 2: // Pad: clamp to edge
+            ix = ix < 0 ? 0 : ix >= W ? W - 1 : ix;
+            iy = iy < 0 ? 0 : iy >= H ? H - 1 : iy;
+            break;
+        case 3: { // Reflect
+            ix = ((ix % (2 * W)) + 2 * W) % (2 * W);
+            if (ix >= W)
+                ix = 2 * W - 1 - ix;
+            iy = ((iy % (2 * H)) + 2 * H) % (2 * H);
+            if (iy >= H)
+                iy = 2 * H - 1 - iy;
+            break;
+        }
+        default: // None: outside is transparent black
+            if (ix < 0 || iy < 0 || ix >= W || iy >= H) {
+                out[0] = out[1] = out[2] = out[3] = 0;
+                return out;
+            }
+    }
+    return readPx(raster, pict.format.depth, ix, iy, out);
+}
+
+function applyTransform(pict, x, y, out2) {
+    const m = pict.transform;
+    if (!m) {
+        out2[0] = x;
+        out2[1] = y;
+        return out2;
+    }
+    const w = m[6] * x + m[7] * y + m[8];
+    const inv = w !== 0 ? 1 / w : 0;
+    out2[0] = (m[0] * x + m[1] * y + m[2]) * inv;
+    out2[1] = (m[3] * x + m[4] * y + m[5]) * inv;
+    return out2;
+}
+
+function gradientParam(pict, x, y) {
+    switch (pict.kind) {
+        case 'linear': {
+            const dx = pict.p2[0] - pict.p1[0];
+            const dy = pict.p2[1] - pict.p1[1];
+            const lenSq = dx * dx + dy * dy;
+            if (lenSq === 0)
+                return 0;
+            return ((x - pict.p1[0]) * dx + (y - pict.p1[1]) * dy) / lenSq;
+        }
+        case 'radial': {
+            // two-circle gradient (canvas createRadialGradient semantics):
+            // largest s with |P - lerp(c1,c2,s)| = lerp(r1,r2,s)
+            const cdx = pict.p2[0] - pict.p1[0];
+            const cdy = pict.p2[1] - pict.p1[1];
+            const dr = pict.r2 - pict.r1;
+            const pdx = x - pict.p1[0];
+            const pdy = y - pict.p1[1];
+            const a = cdx * cdx + cdy * cdy - dr * dr;
+            const b = pdx * cdx + pdy * cdy + pict.r1 * dr;
+            const c = pdx * pdx + pdy * pdy - pict.r1 * pict.r1;
+            if (Math.abs(a) < 1e-9)
+                return b !== 0 ? c / (2 * b) : 0;
+            const disc = b * b - a * c;
+            if (disc < 0)
+                return 0;
+            // largest root of a*s^2 - 2b*s + c = 0; for a < 0 (always the
+            // case for concentric canvas-style gradients, where
+            // a = -dr^2) that is the (b - sqrt)/a branch
+            const sq = Math.sqrt(disc);
+            return a > 0 ? (b + sq) / a : (b - sq) / a;
+        }
+        default: { // conical; angle is in degrees per renderproto
+            const ang = Math.atan2(y - pict.p1[1], x - pict.p1[0]);
+            let t = (ang - (pict.angle * Math.PI) / 180) / (2 * Math.PI);
+            t -= Math.floor(t);
+            return t;
+        }
+    }
+}
+
+// returns sample(x, y, out) -> out = [a, r, g, b] floats 0..255
+function makeSampler(pict) {
+    if (pict.kind === 'solid') {
+        const c = pict.color;
+        return (x, y, out) => {
+            out[0] = c[0];
+            out[1] = c[1];
+            out[2] = c[2];
+            out[3] = c[3];
+            return out;
+        };
+    }
+    if (pict.kind === 'linear' || pict.kind === 'radial' || pict.kind === 'conical') {
+        const pos = [0, 0];
+        return (x, y, out) => {
+            applyTransform(pict, x, y, pos);
+            const c = gradientAt(pict.stops, gradientParam(pict, pos[0], pos[1]));
+            out[0] = c[0];
+            out[1] = c[1];
+            out[2] = c[2];
+            out[3] = c[3];
+            return out;
+        };
+    }
+
+    // drawable-backed picture
+    const pos = [0, 0];
+    const filter = pict.filter;
+    if (filter === 'bilinear') {
+        const t00 = [0, 0, 0, 0];
+        const t10 = [0, 0, 0, 0];
+        const t01 = [0, 0, 0, 0];
+        const t11 = [0, 0, 0, 0];
+        return (x, y, out) => {
+            applyTransform(pict, x, y, pos);
+            const u = pos[0] - 0.5;
+            const v = pos[1] - 0.5;
+            const x0 = Math.floor(u);
+            const y0 = Math.floor(v);
+            const fx = u - x0;
+            const fy = v - y0;
+            fetchTexel(pict, x0, y0, t00);
+            fetchTexel(pict, x0 + 1, y0, t10);
+            fetchTexel(pict, x0, y0 + 1, t01);
+            fetchTexel(pict, x0 + 1, y0 + 1, t11);
+            for (let c = 0; c < 4; c++) {
+                const top = t00[c] + (t10[c] - t00[c]) * fx;
+                const bot = t01[c] + (t11[c] - t01[c]) * fx;
+                out[c] = top + (bot - top) * fy;
+            }
+            return out;
+        };
+    }
+    if (filter === 'convolution' && pict.filterParams && pict.filterParams.length > 2) {
+        const kw = Math.max(1, Math.round(pict.filterParams[0]));
+        const kh = Math.max(1, Math.round(pict.filterParams[1]));
+        const kernel = pict.filterParams.slice(2);
+        const tex = [0, 0, 0, 0];
+        return (x, y, out) => {
+            applyTransform(pict, x, y, pos);
+            const x0 = Math.floor(pos[0] - kw / 2 + 0.5);
+            const y0 = Math.floor(pos[1] - kh / 2 + 0.5);
+            out[0] = out[1] = out[2] = out[3] = 0;
+            for (let j = 0; j < kh; j++) {
+                for (let i = 0; i < kw; i++) {
+                    const k = kernel[j * kw + i];
+                    if (k === 0)
+                        continue;
+                    fetchTexel(pict, x0 + i, y0 + j, tex);
+                    out[0] += tex[0] * k;
+                    out[1] += tex[1] * k;
+                    out[2] += tex[2] * k;
+                    out[3] += tex[3] * k;
+                }
+            }
+            return out;
+        };
+    }
+    // nearest (also the stand-in for fast/good/best/binomial/gaussian)
+    return (x, y, out) => {
+        applyTransform(pict, x, y, pos);
+        return fetchTexel(pict, Math.floor(pos[0]), Math.floor(pos[1]), out);
+    };
+}
+
+// -------------------------------------------------------------------
+// the core composite loop, shared by Composite / the coverage requests /
+// glyphs. `coverage(i, j)` (0..1) modulates the source like a
+// non-component-alpha mask; op is applied across the whole region, per
+// RENDER's dst = op(src IN mask, dst) - including where coverage is 0.
+
+function compositeSpan(server, op, sample, srcX, srcY, mask, dst, dstX, dstY, w, h, coverage) {
+    const raster = targetRaster(dst);
+    const depth = dst.format.depth;
+    const W = raster.width;
+    const H = raster.height;
+    const s = [0, 0, 0, 0];
+    const m = [0, 0, 0, 0];
+    const d = [0, 0, 0, 0];
+    for (let j = 0; j < h; j++) {
+        const Y = dstY + j;
+        if (Y < 0 || Y >= H)
+            continue;
+        for (let i = 0; i < w; i++) {
+            const X = dstX + i;
+            if (X < 0 || X >= W || !inClip(dst, X, Y))
+                continue;
+            sample(srcX + i + 0.5, srcY + j + 0.5, s);
+            let f = 1;
+            if (mask) {
+                mask.sample(mask.x + i + 0.5, mask.y + j + 0.5, m);
+                f = m[0] / 255;
+            }
+            if (coverage)
+                f *= coverage(i, j);
+            const sa = s[0] * f;
+            const sr = s[1] * f;
+            const sg = s[2] * f;
+            const sb = s[3] * f;
+            readPx(raster, depth, X, Y, d);
+            const factors = blendFactors(op, sa / 255, d[0] / 255);
+            if (!factors)
+                throw renderError(server, ERR_PICTOP, op);
+            const [fa, fb] = factors;
+            writePx(
+                raster, depth, X, Y,
+                sa * fa + d[0] * fb,
+                sr * fa + d[1] * fb,
+                sg * fa + d[2] * fb,
+                sb * fa + d[3] * fb
+            );
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// request handlers
+
+function createPicture(server, client, body) {
+    const pid = body.readUInt32LE(0);
+    const drawable = server.getDrawable(body.readUInt32LE(4));
+    const format = formats.get(body.readUInt32LE(8));
+    if (!format)
+        throw renderError(server, ERR_PICTFORMAT, body.readUInt32LE(8));
+    if (format.depth !== drawable.depth)
+        throw new XError(codes.Match, drawable.id);
+    server.checkIdFree(client, pid);
+    const pict = {
+        type: 'picture',
+        id: pid,
+        owner: client,
+        kind: 'drawable',
+        drawable,
+        format,
+        repeat: 0,
+        componentAlpha: 0,
+        transform: null,
+        filter: 'nearest',
+        filterParams: null,
+        clip: null
+    };
+    applyPictureValues(pict, body, 12);
+    server.resources.set(pid, pict);
+}
+
+// CreatePicture/ChangePicture LISTofVALUE, in the protocol's bit order.
+// Only repeat, clipMask=None (clears the clip list) and componentAlpha
+// affect rendering here; polyEdge/polyMode (always-antialiased
+// rasterization), alpha-map and pixmap clip-mask values are accepted and
+// ignored.
+function applyPictureValues(pict, body, maskOff) {
+    const mask = body.readUInt32LE(maskOff);
+    let off = maskOff + 4;
+    for (let bit = 0; bit < 13; bit++) {
+        if (!(mask & (1 << bit)))
+            continue;
+        if (bit === 0)
+            pict.repeat = body.readUInt8(off);
+        else if (bit === 6 && body.readUInt32LE(off) === 0)
+            pict.clip = null; // clipMask None
+        else if (bit === 12)
+            pict.componentAlpha = body.readUInt8(off);
+        off += 4;
+    }
+}
+
+function setPictureClipRectangles(server, body) {
+    const pict = getPicture(server, body.readUInt32LE(0));
+    const ox = body.readInt16LE(4);
+    const oy = body.readInt16LE(6);
+    const rects = [];
+    for (let off = 8; off + 8 <= body.length; off += 8)
+        rects.push({
+            x: ox + body.readInt16LE(off),
+            y: oy + body.readInt16LE(off + 2),
+            width: body.readUInt16LE(off + 4),
+            height: body.readUInt16LE(off + 6)
+        });
+    pict.clip = rects;
+}
+
+function queryPictFormats(server, client) {
+    // 4 formats + one screen section binding the root visual to rgb24 +
+    // one subpixel entry. The client handshake only walks the format list,
+    // but the sections are emitted per spec for other consumers.
+    const nFormats = FORMAT_LIST.length;
+    const screenBytes = 8 /* nDepth+fallback */ + 8 /* one PICTDEPTH */ + 8; /* one PICTVISUAL */
+    const payload = nFormats * 28 + screenBytes + 4;
+    const b = client.startReply(payload / 4, 0);
+    b.writeUInt32LE(nFormats, 8);
+    b.writeUInt32LE(1, 12);  // screens
+    b.writeUInt32LE(1, 16);  // depths
+    b.writeUInt32LE(1, 20);  // visuals
+    b.writeUInt32LE(1, 24);  // subpixel entries
+    let o = 32;
+    for (const f of FORMAT_LIST) {
+        b.writeUInt32LE(f.id, o);
+        b.writeUInt8(1, o + 4);        // type: Direct
+        b.writeUInt8(f.depth, o + 5);
+        b.writeUInt16LE(f.r[0], o + 8);
+        b.writeUInt16LE(f.r[1], o + 10);
+        b.writeUInt16LE(f.g[0], o + 12);
+        b.writeUInt16LE(f.g[1], o + 14);
+        b.writeUInt16LE(f.b[0], o + 16);
+        b.writeUInt16LE(f.b[1], o + 18);
+        b.writeUInt16LE(f.a[0], o + 20);
+        b.writeUInt16LE(f.a[1], o + 22);
+        b.writeUInt32LE(0, o + 24);    // colormap: None
+        o += 28;
+    }
+    // PICTSCREEN: one depth (24) with the root visual bound to rgb24
+    b.writeUInt32LE(1, o);                          // nDepth
+    b.writeUInt32LE(RGB24_ID, o + 4);               // fallback format
+    b.writeUInt8(24, o + 8);                        // PICTDEPTH.depth
+    b.writeUInt16LE(1, o + 10);                     // nPictVisuals
+    b.writeUInt32LE(server.rootVisual >>> 0, o + 16);
+    b.writeUInt32LE(RGB24_ID, o + 20);
+    o += 24;
+    b.writeUInt32LE(0, o);                          // subpixel: Unknown
+    client.send(b);
+}
+
+function queryFilters(client) {
+    const names = ['nearest', 'bilinear', 'convolution', 'fast', 'good', 'best'];
+    let strBytes = 0;
+    for (const n of names)
+        strBytes += 1 + n.length;
+    const payload = pad4(names.length * 2 + strBytes);
+    const b = client.startReply(payload / 4, 0);
+    b.writeUInt32LE(names.length, 8);  // aliases (one per filter, none set)
+    b.writeUInt32LE(names.length, 12); // filters
+    let o = 32;
+    for (let i = 0; i < names.length; i++) {
+        b.writeUInt16LE(0xffff, o);
+        o += 2;
+    }
+    for (const n of names) {
+        b.writeUInt8(n.length, o++);
+        b.write(n, o, 'latin1');
+        o += n.length;
+    }
+    client.send(b);
+}
+
+function composite(server, body) {
+    const op = body.readUInt8(0);
+    const src = getPicture(server, body.readUInt32LE(4));
+    const maskId = body.readUInt32LE(8);
+    const dst = getPicture(server, body.readUInt32LE(12));
+    const srcX = body.readInt16LE(16);
+    const srcY = body.readInt16LE(18);
+    const maskX = body.readInt16LE(20);
+    const maskY = body.readInt16LE(22);
+    const dstX = body.readInt16LE(24);
+    const dstY = body.readInt16LE(26);
+    const w = body.readUInt16LE(28);
+    const h = body.readUInt16LE(30);
+    const mask = maskId
+        ? { sample: makeSampler(getPicture(server, maskId)), x: maskX, y: maskY }
+        : null;
+    compositeSpan(server, op, makeSampler(src), srcX, srcY, mask, dst, dstX, dstY, w, h, null);
+    damage(server, dst);
+}
+
+function fillRectangles(server, body) {
+    const op = body.readUInt8(0);
+    const dst = getPicture(server, body.readUInt32LE(4));
+    const color = readColor(body, 8);
+    const raster = targetRaster(dst);
+    const depth = dst.format.depth;
+    const d = [0, 0, 0, 0];
+    for (let off = 16; off + 8 <= body.length; off += 8) {
+        const rx = body.readInt16LE(off);
+        const ry = body.readInt16LE(off + 2);
+        const rw = body.readUInt16LE(off + 4);
+        const rh = body.readUInt16LE(off + 6);
+        const x0 = Math.max(0, rx);
+        const y0 = Math.max(0, ry);
+        const x1 = Math.min(raster.width, rx + rw);
+        const y1 = Math.min(raster.height, ry + rh);
+        for (let Y = y0; Y < y1; Y++) {
+            for (let X = x0; X < x1; X++) {
+                if (!inClip(dst, X, Y))
+                    continue;
+                readPx(raster, depth, X, Y, d);
+                const factors = blendFactors(op, color[0] / 255, d[0] / 255);
+                if (!factors)
+                    throw renderError(server, ERR_PICTOP, op);
+                const [fa, fb] = factors;
+                writePx(
+                    raster, depth, X, Y,
+                    color[0] * fa + d[0] * fb,
+                    color[1] * fa + d[1] * fb,
+                    color[2] * fa + d[2] * fb,
+                    color[3] * fa + d[3] * fb
+                );
+            }
+        }
+    }
+    damage(server, dst);
+}
+
+// shared tail of Trapezoids/Triangles/TriStrip/TriFan: accumulate the
+// spanfix `traps` into one coverage buffer over their extents and composite
+// through it. Per Xorg, the source aligns srcX/srcY with (alignX, alignY),
+// the integer position of the request's first point (a no-op for repeating
+// solid sources with srcX/srcY 0).
+function compositeCoverage(server, op, src, srcX, srcY, dst, traps, alignX, alignY) {
+    if (traps.length === 0)
+        return;
+    const raster = targetRaster(dst);
+    const W = raster.width;
+    const H = raster.height;
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const t of traps) {
+        // left/right edges may cross (accumulateTrap swaps them per
+        // scanline), so both x bounds consider all four fields
+        minX = Math.min(minX, t.tlx, t.trx, t.blx, t.brx);
+        maxX = Math.max(maxX, t.tlx, t.trx, t.blx, t.brx);
+        minY = Math.min(minY, t.ty);
+        maxY = Math.max(maxY, t.by);
+    }
+
+    // extents of the implicit mask, clipped to the destination
+    const ex0 = Math.max(0, Math.floor(minX));
+    const ey0 = Math.max(0, Math.floor(minY));
+    const ex1 = Math.min(W, Math.ceil(maxX));
+    const ey1 = Math.min(H, Math.ceil(maxY));
+    if (ex1 <= ex0 || ey1 <= ey0)
+        return;
+    const ew = ex1 - ex0;
+    const eh = ey1 - ey0;
+
+    const cov = new Float32Array(ew * eh);
+    for (const t of traps)
+        accumulateTrap(cov, ew, eh, t.tlx - ex0, t.trx - ex0, t.ty - ey0,
+            t.blx - ex0, t.brx - ex0, t.by - ey0);
+
+    compositeSpan(
+        server, op, makeSampler(src),
+        srcX + ex0 - Math.floor(alignX), srcY + ey0 - Math.floor(alignY),
+        null, dst, ex0, ey0, ew, eh,
+        (i, j) => Math.min(1, cov[j * ew + i])
+    );
+    damage(server, dst);
+}
+
+// sort the three vertices by y and split at the middle one: each half is a
+// trapezoid with linear left/right edges
+function triangleTraps(traps, x1, y1, x2, y2, x3, y3) {
+    const v = [[x1, y1], [x2, y2], [x3, y3]].sort((p, q) => p[1] - q[1]);
+    const [v0, v1, v2] = v;
+    if (v2[1] <= v0[1])
+        return; // degenerate
+    const xm = v0[0] + ((v2[0] - v0[0]) * (v1[1] - v0[1])) / (v2[1] - v0[1]);
+    traps.push({ tlx: v0[0], trx: v0[0], ty: v0[1], blx: v1[0], brx: xm, by: v1[1] });
+    traps.push({ tlx: v1[0], trx: xm, ty: v1[1], blx: v2[0], brx: v2[0], by: v2[1] });
+}
+
+// Triangles(11) / TriStrip(12) / TriFan(13) share the header; they differ
+// only in how the point list forms triangles
+function triangleRequest(server, body, mode) {
+    const op = body.readUInt8(0);
+    const src = getPicture(server, body.readUInt32LE(4));
+    const dst = getPicture(server, body.readUInt32LE(8));
+    // maskFormat (offset 12) only picks the coverage precision; coverage is
+    // always accumulated at 8 bits here
+    const srcX = body.readInt16LE(16);
+    const srcY = body.readInt16LE(18);
+    const pts = [];
+    for (let off = 20; off + 8 <= body.length; off += 8)
+        pts.push([body.readInt32LE(off) / FIXED, body.readInt32LE(off + 4) / FIXED]);
+
+    const traps = [];
+    if (mode === 'list') {
+        for (let i = 0; i + 3 <= pts.length; i += 3)
+            triangleTraps(traps, pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1],
+                pts[i + 2][0], pts[i + 2][1]);
+    } else if (mode === 'strip') {
+        for (let i = 0; i + 3 <= pts.length; i++)
+            triangleTraps(traps, pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1],
+                pts[i + 2][0], pts[i + 2][1]);
+    } else { // fan
+        for (let i = 1; i + 2 <= pts.length; i++)
+            triangleTraps(traps, pts[0][0], pts[0][1], pts[i][0], pts[i][1],
+                pts[i + 1][0], pts[i + 1][1]);
+    }
+    if (pts.length === 0)
+        return;
+    compositeCoverage(server, op, src, srcX, srcY, dst, traps, pts[0][0], pts[0][1]);
+}
+
+// Trapezoids (10): classic renderproto trapezoid - top/bottom y plus left
+// and right edge lines; converted to spanfix by intersecting the edges with
+// the top and bottom scanlines
+function trapezoids(server, body) {
+    const op = body.readUInt8(0);
+    const src = getPicture(server, body.readUInt32LE(4));
+    const dst = getPicture(server, body.readUInt32LE(8));
+    const srcX = body.readInt16LE(16);
+    const srcY = body.readInt16LE(18);
+    const traps = [];
+    let alignX = 0;
+    let alignY = 0;
+    for (let off = 20; off + 40 <= body.length; off += 40) {
+        const top = body.readInt32LE(off) / FIXED;
+        const bot = body.readInt32LE(off + 4) / FIXED;
+        const l = [
+            body.readInt32LE(off + 8) / FIXED, body.readInt32LE(off + 12) / FIXED,
+            body.readInt32LE(off + 16) / FIXED, body.readInt32LE(off + 20) / FIXED
+        ];
+        const r = [
+            body.readInt32LE(off + 24) / FIXED, body.readInt32LE(off + 28) / FIXED,
+            body.readInt32LE(off + 32) / FIXED, body.readInt32LE(off + 36) / FIXED
+        ];
+        if (!(bot > top) || l[3] === l[1] || r[3] === r[1])
+            continue; // empty or horizontal edge lines
+        const xAt = (e, y) => e[0] + ((e[2] - e[0]) * (y - e[1])) / (e[3] - e[1]);
+        const trap = {
+            tlx: xAt(l, top), trx: xAt(r, top), ty: top,
+            blx: xAt(l, bot), brx: xAt(r, bot), by: bot
+        };
+        if (traps.length === 0) {
+            alignX = trap.tlx;
+            alignY = trap.ty;
+        }
+        traps.push(trap);
+    }
+    compositeCoverage(server, op, src, srcX, srcY, dst, traps, alignX, alignY);
+}
+
+function addTraps(server, body) {
+    const dst = getPicture(server, body.readUInt32LE(0));
+    const offX = body.readInt16LE(4);
+    const offY = body.readInt16LE(6);
+    const raster = targetRaster(dst);
+    const W = raster.width;
+    const H = raster.height;
+    const depth = dst.format.depth;
+
+    // accumulate the whole request into one float coverage buffer before
+    // the saturating add: traps produced by slab decomposition share
+    // fractional edges, and per-trap rounding would leave seams
+    const cov = new Float32Array(W * H);
+    let minY = H;
+    let maxY = 0;
+    for (let off = 8; off + 24 <= body.length; off += 24) {
+        const tlx = body.readInt32LE(off) / FIXED + offX;
+        const trx = body.readInt32LE(off + 4) / FIXED + offX;
+        const ty = body.readInt32LE(off + 8) / FIXED + offY;
+        const blx = body.readInt32LE(off + 12) / FIXED + offX;
+        const brx = body.readInt32LE(off + 16) / FIXED + offX;
+        const by = body.readInt32LE(off + 20) / FIXED + offY;
+        accumulateTrap(cov, W, H, tlx, trx, ty, blx, brx, by);
+        const y0 = Math.max(0, Math.floor(ty));
+        const y1 = Math.min(H, Math.ceil(by));
+        if (y0 < minY)
+            minY = y0;
+        if (y1 > maxY)
+            maxY = y1;
+    }
+
+    const d = [0, 0, 0, 0];
+    for (let Y = minY; Y < maxY; Y++) {
+        for (let X = 0; X < W; X++) {
+            const c = cov[Y * W + X];
+            if (c <= 0 || !inClip(dst, X, Y))
+                continue;
+            readPx(raster, depth, X, Y, d);
+            const add = Math.min(1, c) * 255;
+            writePx(raster, depth, X, Y, Math.min(255, d[0] + add), d[1], d[2], d[3]);
+        }
+    }
+    damage(server, dst);
+}
+
+function setPictureTransform(server, body) {
+    const pict = getPicture(server, body.readUInt32LE(0));
+    const m = new Array(9);
+    let identity = true;
+    for (let i = 0; i < 9; i++) {
+        m[i] = body.readInt32LE(4 + i * 4) / FIXED;
+        const expect = i === 0 || i === 4 || i === 8 ? 1 : 0;
+        if (m[i] !== expect)
+            identity = false;
+    }
+    pict.transform = identity ? null : m;
+}
+
+function setPictureFilter(server, body) {
+    const pict = getPicture(server, body.readUInt32LE(0));
+    const nameLen = body.readUInt16LE(4);
+    const name = body.toString('latin1', 8, 8 + nameLen);
+    const known = ['nearest', 'bilinear', 'convolution', 'fast', 'good', 'best', 'binomial', 'gaussian'];
+    if (!known.includes(name))
+        throw new XError(codes.Value, 0);
+    const params = [];
+    for (let off = 8 + pad4(nameLen); off + 4 <= body.length; off += 4)
+        params.push(body.readInt32LE(off) / FIXED);
+    pict.filter = name;
+    pict.filterParams = params.length ? params : null;
+}
+
+function readStops(body, off) {
+    const n = body.readUInt32LE(off);
+    const stops = [];
+    const colorsOff = off + 4 + n * 4;
+    for (let i = 0; i < n; i++) {
+        stops.push({
+            offset: body.readInt32LE(off + 4 + i * 4) / FIXED,
+            color: readColor(body, colorsOff + i * 8)
+        });
+    }
+    return stops;
+}
+
+function createSourcePicture(server, client, pid, props) {
+    server.checkIdFree(client, pid);
+    server.resources.set(pid, Object.assign({
+        type: 'picture',
+        id: pid,
+        owner: client,
+        drawable: null,
+        format: FORMAT_LIST[0], // sources behave as rgba32
+        repeat: 0,
+        componentAlpha: 0,
+        transform: null,
+        filter: 'nearest',
+        filterParams: null,
+        clip: null
+    }, props));
+}
+
+function addGlyphs(server, body) {
+    const gs = getGlyphset(server, body.readUInt32LE(0));
+    const n = body.readUInt32LE(4);
+    const idsOff = 8;
+    const infoOff = idsOff + n * 4;
+    let imgOff = infoOff + n * 12;
+    for (let i = 0; i < n; i++) {
+        const id = body.readUInt32LE(idsOff + i * 4);
+        const o = infoOff + i * 12;
+        const width = body.readUInt16LE(o);
+        const height = body.readUInt16LE(o + 2);
+        const stride = pad4(width); // a8 scanlines are 4-byte padded on the wire
+        const len = stride * height;
+        if (imgOff + len > body.length)
+            throw new XError(codes.Length, len);
+        const data = new Uint8Array(len);
+        data.set(body.subarray(imgOff, imgOff + len));
+        gs.glyphs.set(id, {
+            width,
+            height,
+            stride,
+            x: body.readInt16LE(o + 4),
+            y: body.readInt16LE(o + 6),
+            offX: body.readInt16LE(o + 8),
+            offY: body.readInt16LE(o + 10),
+            data
+        });
+        imgOff += len;
+    }
+}
+
+function compositeGlyphs(server, body, idBytes) {
+    const op = body.readUInt8(0);
+    const src = getPicture(server, body.readUInt32LE(4));
+    const dst = getPicture(server, body.readUInt32LE(8));
+    // maskFormat (offset 12): each glyph is composited individually, which
+    // is identical for Over/opaque-src draws and avoids a second coverage
+    // pass
+    let gs = getGlyphset(server, body.readUInt32LE(16));
+    const srcX = body.readInt16LE(20);
+    const srcY = body.readInt16LE(22);
+
+    const raster = targetRaster(dst);
+    const depth = dst.format.depth;
+    const W = raster.width;
+    const H = raster.height;
+    const sample = makeSampler(src);
+    const s = [0, 0, 0, 0];
+    const d = [0, 0, 0, 0];
+
+    let penX = 0;
+    let penY = 0;
+    let srcOffX = 0; // srcX/srcY align the source with the first glyph origin
+    let srcOffY = 0;
+    let first = true;
+
+    let off = 24;
+    while (off + 8 <= body.length) {
+        const n = body.readUInt8(off);
+        if (n === 255) { // glyphset switch elt
+            gs = getGlyphset(server, body.readUInt32LE(off + 8));
+            off += 12;
+            continue;
+        }
+        penX += body.readInt16LE(off + 4);
+        penY += body.readInt16LE(off + 6);
+        off += 8;
+        for (let k = 0; k < n; k++) {
+            const id =
+                idBytes === 1 ? body.readUInt8(off + k) :
+                idBytes === 2 ? body.readUInt16LE(off + k * 2) :
+                body.readUInt32LE(off + k * 4);
+            const g = gs.glyphs.get(id);
+            if (!g)
+                throw renderError(server, ERR_GLYPH, id);
+            if (first) {
+                first = false;
+                srcOffX = srcX - penX;
+                srcOffY = srcY - penY;
+            }
+            // glyph image origin: pen - (info.x, info.y)
+            const gx = penX - g.x;
+            const gy = penY - g.y;
+            for (let row = 0; row < g.height; row++) {
+                const Y = gy + row;
+                if (Y < 0 || Y >= H)
+                    continue;
+                for (let col = 0; col < g.width; col++) {
+                    const X = gx + col;
+                    if (X < 0 || X >= W || !inClip(dst, X, Y))
+                        continue;
+                    const c = g.data[row * g.stride + col];
+                    if (c === 0 && (op === 3 || op === 12))
+                        continue; // Over/Add: no-op
+                    const f = c / 255;
+                    sample(X + srcOffX + 0.5, Y + srcOffY + 0.5, s);
+                    readPx(raster, depth, X, Y, d);
+                    const factors = blendFactors(op, (s[0] * f) / 255, d[0] / 255);
+                    if (!factors)
+                        throw renderError(server, ERR_PICTOP, op);
+                    const [fa, fb] = factors;
+                    writePx(
+                        raster, depth, X, Y,
+                        s[0] * f * fa + d[0] * fb,
+                        s[1] * f * fa + d[1] * fb,
+                        s[2] * f * fa + d[2] * fb,
+                        s[3] * f * fa + d[3] * fb
+                    );
+                }
+            }
+            penX += g.offX;
+            penY += g.offY;
+        }
+        off += pad4(n * idBytes);
+    }
+    damage(server, dst);
+}
+
+// CreateCursor (27): snapshot the ARGB32 source picture so the backing
+// pixmap can be freed. The JS server has no visible cursor; the resource
+// exists so core requests (ChangeWindowAttributes cursor, FreeCursor) and
+// clients that define cursors keep working.
+function createCursor(server, client, body) {
+    const cid = body.readUInt32LE(0);
+    const src = getPicture(server, body.readUInt32LE(4));
+    const raster = targetRaster(src);
+    server.checkIdFree(client, cid);
+    server.resources.set(cid, {
+        type: 'cursor',
+        id: cid,
+        owner: client,
+        width: raster.width,
+        height: raster.height,
+        x: body.readUInt16LE(8),
+        y: body.readUInt16LE(10),
+        pixels: raster.data.slice()
+    });
+}
+
+function createAnimCursor(server, client, body) {
+    const cid = body.readUInt32LE(0);
+    const frames = [];
+    for (let off = 4; off + 8 <= body.length; off += 8) {
+        const xid = body.readUInt32LE(off);
+        const cursor = server.resources.get(xid);
+        if (!cursor || cursor.type !== 'cursor')
+            throw new XError(codes.Cursor, xid);
+        frames.push({ cursor: xid, delay: body.readUInt32LE(off + 4) });
+    }
+    server.checkIdFree(client, cid);
+    server.resources.set(cid, { type: 'cursor', id: cid, owner: client, frames });
+}
+
+module.exports = {
+    name: 'RENDER',
+    eventsCount: 0,
+    errorsCount: 5, // PictFormat, Picture, PictOp, GlyphSet, Glyph
+
+    init(server, extInfo) {
+        firstErrors.set(server, extInfo.firstError);
+    },
+
+    handleRequest(server, client, minor, body) {
+        switch (minor) {
+            case 0: { // QueryVersion -> 0.11
+                const b = client.startReply(0, 0);
+                b.writeUInt32LE(0, 8);
+                b.writeUInt32LE(11, 12);
+                client.send(b);
+                return;
+            }
+            case 1: // QueryPictFormats
+                return queryPictFormats(server, client);
+            case 2: // QueryPictIndexValues: no indexed formats on this server
+                throw new XError(codes.Match, body.readUInt32LE(0));
+            case 4: // CreatePicture
+                return createPicture(server, client, body);
+            case 5: { // ChangePicture
+                const pict = getPicture(server, body.readUInt32LE(0));
+                applyPictureValues(pict, body, 4);
+                return;
+            }
+            case 6: // SetPictureClipRectangles
+                return setPictureClipRectangles(server, body);
+            case 7: { // FreePicture
+                const pict = getPicture(server, body.readUInt32LE(0));
+                server.resources.delete(pict.id);
+                return;
+            }
+            case 8: // Composite
+                return composite(server, body);
+            case 10: // Trapezoids
+                return trapezoids(server, body);
+            case 11: // Triangles
+                return triangleRequest(server, body, 'list');
+            case 12: // TriStrip
+                return triangleRequest(server, body, 'strip');
+            case 13: // TriFan
+                return triangleRequest(server, body, 'fan');
+            case 17: { // CreateGlyphSet
+                const gsid = body.readUInt32LE(0);
+                const format = formats.get(body.readUInt32LE(4));
+                if (!format)
+                    throw renderError(server, ERR_PICTFORMAT, body.readUInt32LE(4));
+                if (format.depth !== 8)
+                    throw new XError(codes.Match, format.id); // a8 only
+                server.checkIdFree(client, gsid);
+                server.resources.set(gsid, {
+                    type: 'glyphset',
+                    id: gsid,
+                    owner: client,
+                    glyphs: new Map()
+                });
+                return;
+            }
+            case 18: { // ReferenceGlyphSet: new id sharing the same glyphs
+                const gsid = body.readUInt32LE(0);
+                const existing = getGlyphset(server, body.readUInt32LE(4));
+                server.checkIdFree(client, gsid);
+                server.resources.set(gsid, {
+                    type: 'glyphset',
+                    id: gsid,
+                    owner: client,
+                    glyphs: existing.glyphs
+                });
+                return;
+            }
+            case 19: { // FreeGlyphSet
+                const gs = getGlyphset(server, body.readUInt32LE(0));
+                server.resources.delete(gs.id);
+                return;
+            }
+            case 20: // AddGlyphs
+                return addGlyphs(server, body);
+            case 22: { // FreeGlyphs
+                const gs = getGlyphset(server, body.readUInt32LE(0));
+                for (let off = 4; off + 4 <= body.length; off += 4)
+                    gs.glyphs.delete(body.readUInt32LE(off));
+                return;
+            }
+            case 23: // CompositeGlyphs8
+                return compositeGlyphs(server, body, 1);
+            case 24: // CompositeGlyphs16
+                return compositeGlyphs(server, body, 2);
+            case 25: // CompositeGlyphs32
+                return compositeGlyphs(server, body, 4);
+            case 26: // FillRectangles
+                return fillRectangles(server, body);
+            case 27: // CreateCursor
+                return createCursor(server, client, body);
+            case 28: // SetPictureTransform
+                return setPictureTransform(server, body);
+            case 29: // QueryFilters
+                return queryFilters(client);
+            case 30: // SetPictureFilter
+                return setPictureFilter(server, body);
+            case 31: // CreateAnimCursor
+                return createAnimCursor(server, client, body);
+            case 32: // AddTraps
+                return addTraps(server, body);
+            case 33: // CreateSolidFill
+                return createSourcePicture(server, client, body.readUInt32LE(0), {
+                    kind: 'solid',
+                    color: readColor(body, 4)
+                });
+            case 34: // CreateLinearGradient
+                return createSourcePicture(server, client, body.readUInt32LE(0), {
+                    kind: 'linear',
+                    p1: [body.readInt32LE(4) / FIXED, body.readInt32LE(8) / FIXED],
+                    p2: [body.readInt32LE(12) / FIXED, body.readInt32LE(16) / FIXED],
+                    stops: readStops(body, 20)
+                });
+            case 35: // CreateRadialGradient
+                return createSourcePicture(server, client, body.readUInt32LE(0), {
+                    kind: 'radial',
+                    p1: [body.readInt32LE(4) / FIXED, body.readInt32LE(8) / FIXED],
+                    p2: [body.readInt32LE(12) / FIXED, body.readInt32LE(16) / FIXED],
+                    r1: body.readInt32LE(20) / FIXED,
+                    r2: body.readInt32LE(24) / FIXED,
+                    stops: readStops(body, 28)
+                });
+            case 36: // CreateConicalGradient
+                return createSourcePicture(server, client, body.readUInt32LE(0), {
+                    kind: 'conical',
+                    p1: [body.readInt32LE(4) / FIXED, body.readInt32LE(8) / FIXED],
+                    angle: body.readInt32LE(12) / FIXED,
+                    stops: readStops(body, 16)
+                });
+            default:
+                // AddGlyphsFromPicture(21) is unimplemented everywhere;
+                // 3/9/14-16 are unused in renderproto
+                throw new XError(codes.Implementation, 0, minor);
+        }
+    }
+};

--- a/lib/xserver/server.js
+++ b/lib/xserver/server.js
@@ -252,6 +252,7 @@ class XServer extends EventEmitter {
         // built-in extensions
         this.registerExtension('BIG-REQUESTS', require('./extensions/big-requests'));
         this.registerExtension('XC-MISC', require('./extensions/xc-misc'));
+        this.registerExtension('RENDER', require('./extensions/render'));
     }
 
     addClientStream(stream) {
@@ -422,7 +423,7 @@ class XServer extends EventEmitter {
     // test/display-protocols.js buildServerHello)
     buildSetup(client) {
         const vendorPadded = padLength(VENDOR.length);
-        const formats = [[1, 1, 32], [24, 32, 32]]; // depth, bpp, scanline pad
+        const formats = [[1, 1, 32], [8, 8, 32], [24, 32, 32], [32, 32, 32]]; // depth, bpp, scanline pad
         const extra = 32 + vendorPadded + 8 * formats.length + 40 + 8 + 24;
         const b = Buffer.alloc(8 + extra);
         let o = 0;

--- a/test/xserver/render.js
+++ b/test/xserver/render.js
@@ -1,0 +1,623 @@
+const assert = require('assert');
+const { boot } = require('./boot');
+
+const W = 16, H = 16;
+const WHITE = 0xffffff;
+const BLACK = 0;
+
+describe('xserver: RENDER', () => {
+
+    let server, display, X, root, render;
+
+    beforeEach(done => {
+        boot((err, ctx) => {
+            if (err) return done(err);
+            ({ server, display, X } = ctx);
+            root = display.screen[0].root;
+            X.require('render', (err2, ext) => {
+                if (err2) return done(err2);
+                render = ext;
+                done();
+            });
+        });
+    });
+
+    afterEach(() => {
+        X.terminate();
+        server = display = X = render = null;
+    });
+
+    // depth-24 pixmap wrapped in an rgb24 picture, filled solid black
+    function mkCanvas() {
+        const pixmap = X.AllocID();
+        X.CreatePixmap(pixmap, root, 24, W, H);
+        const pic = X.AllocID();
+        render.CreatePicture(pic, pixmap, render.rgb24);
+        render.FillRectangles(render.PictOp.Src, pic, [0, 0, 0, 1], [0, 0, W, H]);
+        return { pixmap, pic };
+    }
+
+    // a8 pixmap wrapped in a picture, cleared to alpha 0
+    function mkMask() {
+        const pixmap = X.AllocID();
+        X.CreatePixmap(pixmap, root, 8, W, H);
+        const pic = X.AllocID();
+        render.CreatePicture(pic, pixmap, render.a8);
+        render.FillRectangles(render.PictOp.Src, pic, [0, 0, 0, 0], [0, 0, W, H]);
+        return { pixmap, pic };
+    }
+
+    function readBack(drawable, cb) {
+        X.GetImage(2, drawable, 0, 0, W, H, 0xffffffff, (err, img) => {
+            if (err) throw err;
+            cb(img.data);
+        });
+    }
+
+    function px(data, x, y) {
+        return data.readUInt32LE((y * W + x) * 4) & 0xffffff;
+    }
+
+    const red = v => (v >> 16) & 0xff;
+    const green = v => (v >> 8) & 0xff;
+    const blue = v => v & 0xff;
+
+    function approx(actual, expected, tol, msg) {
+        assert.ok(Math.abs(actual - expected) <= tol,
+            `${msg || 'value'}: ${actual} not within ${tol} of ${expected}`);
+    }
+
+    describe('handshake', () => {
+
+        it('QueryVersion reports 0.11', done => {
+            render.QueryVersion(0, 11, (err, ver) => {
+                if (err) return done(err);
+                assert.deepStrictEqual(ver, [0, 11]);
+                done();
+            });
+        });
+
+        it('require() derives the standard picture formats', () => {
+            assert.ok(render.rgba32, 'rgba32');
+            assert.ok(render.rgb24, 'rgb24');
+            assert.ok(render.a8, 'a8');
+            assert.ok(render.mono1, 'mono1');
+        });
+
+        it('QueryFilters lists nearest/bilinear/convolution', done => {
+            render.QueryFilters((err, res) => {
+                if (err) return done(err);
+                const filters = res[1];
+                for (const f of ['nearest', 'bilinear', 'convolution'])
+                    assert.ok(filters.includes(f), f);
+                done();
+            });
+        });
+
+        it('QueryPictIndexValues answers with Match (no indexed formats)', done => {
+            render.QueryPictIndexValues(render.rgb24, err => {
+                assert.strictEqual(err.error, 8); // BadMatch
+                done();
+                return true;
+            });
+        });
+    });
+
+    describe('FillRectangles', () => {
+
+        it('Src fills exactly the requested rect', done => {
+            const { pixmap, pic } = mkCanvas();
+            render.FillRectangles(render.PictOp.Src, pic, [1, 0, 0, 1], [2, 3, 4, 5]);
+            readBack(pixmap, data => {
+                for (let y = 0; y < H; y++)
+                    for (let x = 0; x < W; x++) {
+                        const inside = x >= 2 && x < 6 && y >= 3 && y < 8;
+                        assert.strictEqual(px(data, x, y), inside ? 0xff0000 : BLACK,
+                            `pixel ${x},${y}`);
+                    }
+                done();
+            });
+        });
+
+        it('Over blends premultiplied color with the destination', done => {
+            const { pixmap, pic } = mkCanvas();
+            render.FillRectangles(render.PictOp.Src, pic, [1, 1, 1, 1], [0, 0, W, H]);
+            // premultiplied half-transparent red over white
+            render.FillRectangles(render.PictOp.Over, pic, [0.5, 0, 0, 0.5], [0, 0, W, H]);
+            readBack(pixmap, data => {
+                const v = px(data, 4, 4);
+                approx(red(v), 255, 2, 'red');
+                approx(green(v), 127, 2, 'green');
+                approx(blue(v), 127, 2, 'blue');
+                done();
+            });
+        });
+
+        it('Clear zeroes the rect regardless of color', done => {
+            const { pixmap, pic } = mkCanvas();
+            render.FillRectangles(render.PictOp.Src, pic, [1, 1, 1, 1], [0, 0, W, H]);
+            render.FillRectangles(render.PictOp.Clear, pic, [1, 1, 1, 1], [0, 0, 4, 4]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 1, 1), BLACK);
+                assert.strictEqual(px(data, 5, 5), WHITE);
+                done();
+            });
+        });
+    });
+
+    describe('Composite', () => {
+
+        it('solid fill source composites into the destination region', done => {
+            const { pixmap, pic } = mkCanvas();
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 0, 1, 0, 1);
+            render.Composite(render.PictOp.Over, solid, 0, pic, 0, 0, 0, 0, 2, 2, 5, 5);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 3, 3), 0x00ff00);
+                assert.strictEqual(px(data, 1, 1), BLACK);
+                assert.strictEqual(px(data, 7, 7), BLACK);
+                done();
+            });
+        });
+
+        it('a8 mask gates the source', done => {
+            const { pixmap, pic } = mkCanvas();
+            const mask = mkMask();
+            render.FillRectangles(render.PictOp.Src, mask.pic, [0, 0, 0, 1], [4, 4, 4, 4]);
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 0, 0, 1, 1);
+            render.Composite(render.PictOp.Over, solid, mask.pic, pic, 0, 0, 0, 0, 0, 0, W, H);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 5, 5), 0x0000ff);
+                assert.strictEqual(px(data, 2, 2), BLACK);
+                assert.strictEqual(px(data, 9, 9), BLACK);
+                done();
+            });
+        });
+
+        it('depth-32 source keeps PutImage alpha (premultiplied Over)', done => {
+            const { pixmap, pic } = mkCanvas();
+            render.FillRectangles(render.PictOp.Src, pic, [1, 1, 1, 1], [0, 0, W, H]);
+            const src = X.AllocID();
+            X.CreatePixmap(src, root, 32, 4, 4);
+            const gc = X.AllocID();
+            X.CreateGC(gc, src);
+            // premultiplied half-transparent red: a=0x80, r=0x80
+            const data = Buffer.alloc(4 * 4 * 4);
+            for (let i = 0; i < 16; i++)
+                data.writeUInt32LE(0x80800000, i * 4);
+            X.PutImage(2, src, gc, 4, 4, 0, 0, 0, 32, data);
+            const srcPic = X.AllocID();
+            render.CreatePicture(srcPic, src, render.rgba32);
+            render.Composite(render.PictOp.Over, srcPic, 0, pic, 0, 0, 0, 0, 0, 0, 4, 4);
+            readBack(pixmap, out => {
+                const v = px(out, 1, 1);
+                approx(red(v), 255, 2, 'red');
+                approx(green(v), 127, 2, 'green');
+                approx(blue(v), 127, 2, 'blue');
+                assert.strictEqual(px(out, 5, 5), WHITE);
+                done();
+            });
+        });
+
+        it('repeat Normal tiles the source', done => {
+            const { pixmap, pic } = mkCanvas();
+            const src = X.AllocID();
+            X.CreatePixmap(src, root, 24, 2, 2);
+            const gc = X.AllocID();
+            X.CreateGC(gc, src, { foreground: WHITE });
+            X.PolyFillRectangle(src, gc, [0, 0, 2, 2]);
+            X.ChangeGC(gc, { foreground: BLACK });
+            X.PolyPoint(0, src, gc, [1, 0, 0, 1]); // checker: white on the main diagonal
+            const srcPic = X.AllocID();
+            render.CreatePicture(srcPic, src, render.rgb24, { repeat: render.Repeat.Normal });
+            render.Composite(render.PictOp.Src, srcPic, 0, pic, 0, 0, 0, 0, 0, 0, 8, 8);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 0, 0), WHITE);
+                assert.strictEqual(px(data, 1, 0), BLACK);
+                assert.strictEqual(px(data, 4, 4), WHITE);
+                assert.strictEqual(px(data, 5, 4), BLACK);
+                assert.strictEqual(px(data, 6, 6), WHITE);
+                done();
+            });
+        });
+
+        it('SetPictureTransform maps destination into source space', done => {
+            const { pixmap, pic } = mkCanvas();
+            const src = X.AllocID();
+            X.CreatePixmap(src, root, 24, 8, 8);
+            const gc = X.AllocID();
+            X.CreateGC(gc, src, { foreground: BLACK });
+            X.PolyFillRectangle(src, gc, [0, 0, 8, 8]);
+            X.ChangeGC(gc, { foreground: WHITE });
+            X.PolyPoint(0, src, gc, [7, 7]);
+            const srcPic = X.AllocID();
+            render.CreatePicture(srcPic, src, render.rgb24);
+            render.SetPictureTransform(srcPic, [2, 0, 0, 0, 2, 0, 0, 0, 1]);
+            render.Composite(render.PictOp.Src, srcPic, 0, pic, 0, 0, 0, 0, 0, 0, 4, 4);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 3, 3), WHITE); // (3.5, 3.5) -> src (7, 7)
+                assert.strictEqual(px(data, 2, 2), BLACK);
+                done();
+            });
+        });
+
+        it('bilinear filter interpolates between texels', done => {
+            const { pixmap, pic } = mkCanvas();
+            const src = X.AllocID();
+            X.CreatePixmap(src, root, 24, 2, 1);
+            const gc = X.AllocID();
+            X.CreateGC(gc, src, { foreground: BLACK });
+            X.PolyFillRectangle(src, gc, [0, 0, 2, 1]);
+            X.ChangeGC(gc, { foreground: WHITE });
+            X.PolyPoint(0, src, gc, [1, 0]);
+            const srcPic = X.AllocID();
+            render.CreatePicture(srcPic, src, render.rgb24, { repeat: render.Repeat.Pad });
+            render.SetPictureTransform(srcPic, [0.5, 0, 0, 0, 0.5, 0, 0, 0, 1]);
+            render.SetPictureFilter(srcPic, 'bilinear');
+            render.Composite(render.PictOp.Src, srcPic, 0, pic, 0, 0, 0, 0, 0, 0, 4, 1);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 0, 0), BLACK);
+                assert.strictEqual(px(data, 3, 0), WHITE);
+                const a = red(px(data, 1, 0));
+                const b = red(px(data, 2, 0));
+                assert.ok(a > 30 && a < 100, `quarter blend, got ${a}`);
+                assert.ok(b > 155 && b < 225, `three-quarter blend, got ${b}`);
+                done();
+            });
+        });
+    });
+
+    describe('gradients', () => {
+
+        it('linear gradient ramps between the stops', done => {
+            const { pixmap, pic } = mkCanvas();
+            const grad = X.AllocID();
+            render.LinearGradient(grad, [0, 0], [W, 0],
+                [[0, [0, 0, 0, 1]], [1, [1, 1, 1, 1]]]);
+            render.Composite(render.PictOp.Src, grad, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            readBack(pixmap, data => {
+                assert.ok(red(px(data, 0, 8)) < 20, 'left edge dark');
+                assert.ok(red(px(data, 15, 8)) > 235, 'right edge bright');
+                const mid = red(px(data, 8, 8));
+                assert.ok(mid > 100 && mid < 160, `midpoint gray, got ${mid}`);
+                done();
+            });
+        });
+
+        it('radial gradient is bright at the center, dark at the rim', done => {
+            const { pixmap, pic } = mkCanvas();
+            const grad = X.AllocID();
+            render.RadialGradient(grad, [8, 8], [8, 8], 0, 8,
+                [[0, [1, 1, 1, 1]], [1, [0, 0, 0, 1]]]);
+            render.Composite(render.PictOp.Src, grad, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            readBack(pixmap, data => {
+                assert.ok(red(px(data, 8, 8)) > 200, 'center bright');
+                assert.ok(red(px(data, 0, 0)) < 30, 'corner dark');
+                done();
+            });
+        });
+
+        it('conical gradient varies with the angle around the center', done => {
+            const { pixmap, pic } = mkCanvas();
+            const grad = X.AllocID();
+            render.ConicalGradient(grad, [8, 8], 0,
+                [[0, [0, 0, 0, 1]], [1, [1, 1, 1, 1]]]);
+            render.Composite(render.PictOp.Src, grad, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            readBack(pixmap, data => {
+                assert.ok(red(px(data, 12, 8)) < 30, 'angle ~0 near the first stop');
+                const left = red(px(data, 4, 8));
+                assert.ok(left > 100 && left < 155, `angle ~pi mid-ramp, got ${left}`);
+                done();
+            });
+        });
+    });
+
+    describe('geometry', () => {
+
+        it('Triangles fills with antialiased edges', done => {
+            const { pixmap, pic } = mkCanvas();
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.Triangles(render.PictOp.Over, solid, 0, 0, pic, 0,
+                [0, 0, 8, 0, 0, 8]);
+            readBack(pixmap, data => {
+                assert.ok(red(px(data, 1, 1)) > 200, 'inside');
+                assert.strictEqual(px(data, 7, 7), BLACK);
+                const edge = red(px(data, 3, 4)); // hypotenuse crosses this pixel
+                assert.ok(edge > 0 && edge < 255, `antialiased edge, got ${edge}`);
+                done();
+            });
+        });
+
+        it('Trapezoids with vertical edges fills the exact rect', done => {
+            const { pixmap, pic } = mkCanvas();
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            // top 3, bottom 8, left line x=2, right line x=6
+            render.Trapezoids(render.PictOp.Over, solid, 0, 0, pic, 0,
+                [3, 8, 2, 3, 2, 8, 6, 3, 6, 8]);
+            readBack(pixmap, data => {
+                for (let y = 0; y < H; y++)
+                    for (let x = 0; x < W; x++) {
+                        const inside = x >= 2 && x < 6 && y >= 3 && y < 8;
+                        assert.strictEqual(px(data, x, y), inside ? WHITE : BLACK,
+                            `pixel ${x},${y}`);
+                    }
+                done();
+            });
+        });
+
+        it('TriStrip covers the quad', done => {
+            const { pixmap, pic } = mkCanvas();
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.TriStrip(render.PictOp.Over, solid, 0, 0, pic, 0,
+                [2, 2, 6, 2, 2, 6, 6, 6]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 3, 3), WHITE);
+                assert.strictEqual(px(data, 4, 4), WHITE);
+                assert.strictEqual(px(data, 0, 0), BLACK);
+                assert.strictEqual(px(data, 7, 7), BLACK);
+                done();
+            });
+        });
+
+        it('TriFan covers the quad', done => {
+            const { pixmap, pic } = mkCanvas();
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.TriFan(render.PictOp.Over, solid, 0, 0, pic, 0,
+                [2, 2, 6, 2, 6, 6, 2, 6]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 3, 3), WHITE);
+                assert.strictEqual(px(data, 4, 4), WHITE);
+                assert.strictEqual(px(data, 0, 0), BLACK);
+                assert.strictEqual(px(data, 7, 7), BLACK);
+                done();
+            });
+        });
+
+        it('AddTraps accumulates coverage into an a8 picture', done => {
+            const { pixmap, pic } = mkCanvas();
+            const mask = mkMask();
+            // spanfix rect [1..5) x [2..6): top l/r/y, bottom l/r/y
+            render.AddTraps(mask.pic, 0, 0, [1, 5, 2, 1, 5, 6]);
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 0, 0, 1);
+            render.Composite(render.PictOp.Over, solid, mask.pic, pic, 0, 0, 0, 0, 0, 0, W, H);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 2, 3), 0xff0000);
+                assert.strictEqual(px(data, 0, 0), BLACK);
+                assert.strictEqual(px(data, 6, 3), BLACK);
+                done();
+            });
+        });
+    });
+
+    describe('glyphs', () => {
+
+        function addGlyph(gsid, id, value, offX) {
+            render.AddGlyphs(gsid, [{
+                id,
+                width: 4,
+                height: 4,
+                x: 0,
+                y: 4,
+                offX: (offX || 0) * 64,
+                offY: 0,
+                image: Buffer.alloc(16, value)
+            }]);
+        }
+
+        it('CompositeGlyphs8 draws added glyphs at the pen position', done => {
+            const { pixmap, pic } = mkCanvas();
+            const gs = X.AllocID();
+            render.CreateGlyphSet(gs, render.a8);
+            addGlyph(gs, 65, 255);
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.CompositeGlyphs8(render.PictOp.Over, solid, pic, 0, gs, 0, 0,
+                [[2, 8, 'A']]);
+            readBack(pixmap, data => {
+                // image origin: pen (2,8) - (x=0, y=4) -> cols 2..6, rows 4..8
+                assert.strictEqual(px(data, 3, 5), WHITE);
+                assert.strictEqual(px(data, 1, 5), BLACK);
+                assert.strictEqual(px(data, 3, 3), BLACK);
+                assert.strictEqual(px(data, 3, 8), BLACK);
+                done();
+            });
+        });
+
+        it('glyphset-switch elements and glyph advances apply', done => {
+            const { pixmap, pic } = mkCanvas();
+            const gs1 = X.AllocID();
+            const gs2 = X.AllocID();
+            render.CreateGlyphSet(gs1, render.a8);
+            render.CreateGlyphSet(gs2, render.a8);
+            addGlyph(gs1, 65, 255, 4);
+            addGlyph(gs2, 66, 128, 4);
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.CompositeGlyphs8(render.PictOp.Over, solid, pic, 0, gs1, 0, 0,
+                [[2, 8, 'A'], gs2, [0, 0, 'B']]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 3, 5), WHITE);        // 'A' at pen (2,8)
+                const v = red(px(data, 7, 5));                    // 'B' at pen (6,8), alpha 128
+                approx(v, 128, 4, 'half-coverage glyph');
+                done();
+            });
+        });
+
+        it('CompositeGlyphs32 accepts wide ids', done => {
+            const { pixmap, pic } = mkCanvas();
+            const gs = X.AllocID();
+            render.CreateGlyphSet(gs, render.a8);
+            addGlyph(gs, 0xbeef, 255);
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.CompositeGlyphs32(render.PictOp.Over, solid, pic, 0, gs, 0, 0,
+                [[2, 8, String.fromCharCode(0xbeef)]]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 3, 5), WHITE);
+                done();
+            });
+        });
+
+        it('ReferenceGlyphSet shares glyphs with the original set', done => {
+            const { pixmap, pic } = mkCanvas();
+            const gs = X.AllocID();
+            render.CreateGlyphSet(gs, render.a8);
+            addGlyph(gs, 65, 255);
+            const ref = X.AllocID();
+            render.ReferenceGlyphSet(ref, gs);
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.CompositeGlyphs8(render.PictOp.Over, solid, pic, 0, ref, 0, 0,
+                [[2, 8, 'A']]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 3, 5), WHITE);
+                done();
+            });
+        });
+
+        it('FreeGlyphs makes the glyph undefined (Glyph error)', done => {
+            const { pic } = mkCanvas();
+            const gs = X.AllocID();
+            render.CreateGlyphSet(gs, render.a8);
+            addGlyph(gs, 65, 255);
+            render.FreeGlyphs(gs, [65]);
+            const solid = X.AllocID();
+            render.CreateSolidFill(solid, 1, 1, 1, 1);
+            render.CompositeGlyphs8(render.PictOp.Over, solid, pic, 0, gs, 0, 0, ['A']);
+            X.once('error', err => {
+                assert.strictEqual(err.error, render.firstError + 4); // BadGlyph
+                done();
+            });
+        });
+    });
+
+    describe('clip rectangles', () => {
+
+        it('SetPictureClipRectangles restricts rendering', done => {
+            const { pixmap, pic } = mkCanvas();
+            render.SetPictureClipRectangles(pic, 0, 0, [1, 1, 4, 4]);
+            render.FillRectangles(render.PictOp.Src, pic, [1, 1, 1, 1], [0, 0, W, H]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 2, 2), WHITE);
+                assert.strictEqual(px(data, 0, 0), BLACK);
+                assert.strictEqual(px(data, 6, 6), BLACK);
+                done();
+            });
+        });
+
+        it('clip origin offsets the rectangles; clipMask None clears', done => {
+            const { pixmap, pic } = mkCanvas();
+            render.SetPictureClipRectangles(pic, 8, 8, [0, 0, 2, 2]);
+            render.FillRectangles(render.PictOp.Src, pic, [1, 1, 1, 1], [0, 0, W, H]);
+            render.ChangePicture(pic, { clipMask: 0 });
+            render.FillRectangles(render.PictOp.Src, pic, [1, 0, 0, 1], [0, 0, 4, 4]);
+            readBack(pixmap, data => {
+                assert.strictEqual(px(data, 8, 8), WHITE);   // clipped fill landed here
+                assert.strictEqual(px(data, 4, 4), BLACK);   // outside the clip
+                assert.strictEqual(px(data, 1, 1), 0xff0000); // clip cleared
+                done();
+            });
+        });
+    });
+
+    describe('cursors', () => {
+
+        it('CreateCursor and CreateAnimCursor from an rgba32 picture', done => {
+            const src = X.AllocID();
+            X.CreatePixmap(src, root, 32, 8, 8);
+            const srcPic = X.AllocID();
+            render.CreatePicture(srcPic, src, render.rgba32);
+            render.FillRectangles(render.PictOp.Src, srcPic, [0, 0, 1, 1], [0, 0, 8, 8]);
+            const cur = X.AllocID();
+            render.CreateCursor(cur, srcPic, 1, 1);
+            const anim = X.AllocID();
+            render.CreateAnimCursor(anim, [[cur, 100]]);
+            X.FreeCursor(anim);
+            X.FreeCursor(cur);
+            X.on('error', done);
+            X.GetInputFocus(() => done());
+        });
+    });
+
+    describe('core support for RENDER', () => {
+
+        it('depth-8 pixmap PutImage/GetImage round-trip', done => {
+            const pixmap = X.AllocID();
+            X.CreatePixmap(pixmap, root, 8, W, 4);
+            const gc = X.AllocID();
+            X.CreateGC(gc, pixmap);
+            const data = Buffer.alloc(W * 4);
+            for (let i = 0; i < data.length; i++)
+                data[i] = (i * 7) & 0xff;
+            X.PutImage(2, pixmap, gc, W, 4, 0, 0, 0, 8, data);
+            X.GetImage(2, pixmap, 0, 0, W, 4, 0xffffffff, (err, img) => {
+                if (err) return done(err);
+                assert.ok(img.data.subarray(0, data.length).equals(data));
+                done();
+            });
+        });
+
+        it('depth-32 pixmap PutImage/GetImage keeps the alpha byte', done => {
+            const pixmap = X.AllocID();
+            X.CreatePixmap(pixmap, root, 32, 4, 4);
+            const gc = X.AllocID();
+            X.CreateGC(gc, pixmap);
+            const data = Buffer.alloc(4 * 4 * 4);
+            for (let i = 0; i < 16; i++)
+                data.writeUInt32LE((0xab000000 + i * 0x010203) >>> 0, i * 4);
+            X.PutImage(2, pixmap, gc, 4, 4, 0, 0, 0, 32, data);
+            X.GetImage(2, pixmap, 0, 0, 4, 4, 0xffffffff, (err, img) => {
+                if (err) return done(err);
+                assert.ok(img.data.equals(data));
+                done();
+            });
+        });
+    });
+
+    describe('errors', () => {
+
+        it('bad picture ids raise the Picture error', done => {
+            render.FreePicture(0xbadf00d);
+            X.once('error', err => {
+                assert.strictEqual(err.error, render.firstError + 1); // BadPicture
+                assert.strictEqual(err.badParam, 0xbadf00d);
+                done();
+            });
+        });
+
+        it('CreatePicture with mismatched depth raises Match', done => {
+            const pixmap = X.AllocID();
+            X.CreatePixmap(pixmap, root, 24, 4, 4);
+            const pic = X.AllocID();
+            render.CreatePicture(pic, pixmap, render.a8);
+            X.once('error', err => {
+                assert.strictEqual(err.error, 8); // BadMatch
+                done();
+            });
+        });
+
+        it('bad glyphset ids raise the GlyphSet error', done => {
+            render.FreeGlyphSet(0xbadbad);
+            X.once('error', err => {
+                assert.strictEqual(err.error, render.firstError + 3); // BadGlyphSet
+                done();
+            });
+        });
+
+        it('AddGlyphsFromPicture is unimplemented', done => {
+            const gs = X.AllocID();
+            render.CreateGlyphSet(gs, render.a8);
+            render.AddGlyphsFromPicture(gs, 0, []);
+            X.once('error', err => {
+                assert.strictEqual(err.error, 17); // BadImplementation
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Ports the server-side RENDER implementation from [ntk#53](https://github.com/sidorares/ntk/pull/53) into the JS X server proper, so ntk (and any XRender client) can run against x11's pure-JS server without out-of-tree patches. Once released, ntk's `lib/xserver/` glue can shrink to just its `createServer` convenience wrapper.

## What's included

**`lib/xserver/extensions/render.js`** — registered as a built-in extension alongside BIG-REQUESTS/XC-MISC:

- Pictures over drawables with rgba32 / rgb24 / a8 / mono1 formats (`QueryPictFormats` emits exactly what the client's `require('render')` handshake derives the format ids from)
- Solid fill and linear/radial/conical gradient source pictures
- The full Porter-Duff op set; `Composite` with a8 masks; `FillRectangles`
- Antialiased coverage rasterization for `Trapezoids`, `Triangles`, `TriStrip`, `TriFan` and `AddTraps` (analytic horizontal coverage, 4 vertical sub-bands per pixel row)
- Glyphsets: `CreateGlyphSet`, `ReferenceGlyphSet`, `AddGlyphs`, `FreeGlyphs`, `CompositeGlyphs8/16/32` including glyphset-switch elements
- Picture transforms with nearest / bilinear / convolution filters, repeat None/Normal/Pad/Reflect
- `SetPictureClipRectangles` honored by every drawing op (`clipMask: None` clears it)
- RENDER cursors (`CreateCursor`, `CreateAnimCursor`)
- The five RENDER error codes, wired through the server's extension error allocation

**Core support** (previously monkey-patched from ntk's side):

- `CreatePixmap` accepts depth 8 (a8 mask pixmaps); depth-8 ZPixmap `PutImage`/`GetImage` use 1 byte per pixel with 4-byte row padding
- Depth-32 `PutImage` into depth-32 drawables preserves the alpha byte (premultiplied BGRA uploads); depth-24 targets still store only the low 24 bits
- Connection setup advertises pixmap formats for depths 8 and 32

**Beyond the ntk version:** `Trapezoids`/`TriStrip`/`TriFan`, `ReferenceGlyphSet`, cursors and honored clip rectangles are new (they're part of this repo's client API surface), plus a fix for the radial gradient root selection — the ntk copy picks the smaller quadratic root whenever `a < 0`, which is the case for **every** concentric two-circle gradient.

## Verification

- New `test/xserver/render.js`: 35 tests covering the handshake, fills and blend ops, masks, gradients, transforms/filters/repeat, all the geometry requests, glyphs, clip rects, cursors, the depth-8/32 core paths and error codes
- `test/xserver/` suite: 144 passing; eslint clean
- Full `npm test` failures against XQuartz (dbe/present/xkb/WM-redirect suites) are pre-existing on a clean tree and never load `lib/xserver`