### PR TITLE
fix: re-arm the packet parser even when dispatch throws

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -455,19 +455,25 @@ XClient.prototype.expectReplyHeader = function()
                     }
 
                     client._sweepVoid(seq_num - 1);
-                    const handler = client.replies[seq_num];
-                    if (handler) {
-                        const callback = handler[1];
-                        const handled = callback(error);
-                        if (!handled)
+                    // dispatch can throw — most commonly emit('error') with no
+                    // listener attached. Re-arm the parser regardless: without
+                    // it the connection silently drops every later packet
+                    try {
+                        const handler = client.replies[seq_num];
+                        if (handler) {
+                            const callback = handler[1];
+                            const handled = callback(error);
+                            if (!handled)
+                                client.emit('error', error);
+                            // TODO: should we delete seq2stack and reply even if there is no handler?
+                            if (client.options.debug)
+                                delete client.seq2stack[seq_num];
+                            delete client.replies[seq_num];
+                        } else
                             client.emit('error', error);
-                        // TODO: should we delete seq2stack and reply even if there is no handler?
-			if (client.options.debug)
-                          delete client.seq2stack[seq_num];
-                        delete client.replies[seq_num];
-                    } else
-                        client.emit('error', error);
-                    client.expectReplyHeader();
+                    } finally {
+                        client.expectReplyHeader();
+                    }
                 } );
                 return;
             } else if (type > 1)
@@ -488,17 +494,21 @@ XClient.prototype.expectReplyHeader = function()
                     headerBuf.copy(ev.rawData);
                     buf.copy(ev.rawData, 8);
 
-                    client.emit('event', ev);
-                    let ee = client.event_consumers[ev.wid];
-                    if (ee) {
-                       ee.emit('event', ev);
+                    // a throwing event consumer must not kill the parser
+                    try {
+                        client.emit('event', ev);
+                        let ee = client.event_consumers[ev.wid];
+                        if (ee) {
+                           ee.emit('event', ev);
+                        }
+                        if (ev.parent) {
+                           ee = client.event_consumers[ev.parent];
+                           if (ee)
+                             ee.emit('child-event', ev);
+                        }
+                    } finally {
+                        client.expectReplyHeader();
                     }
-                    if (ev.parent) {
-                       ee = client.event_consumers[ev.parent];
-                       if (ee)
-                         ee.emit('child-event', ev);
-                    }
-                    client.expectReplyHeader();
                 } );
                 return;
             }
@@ -510,31 +520,35 @@ XClient.prototype.expectReplyHeader = function()
             client.pack_stream.get( bodylength, data => {
 
                 client._sweepVoid(seq_num);
-                const handler = client.replies[seq_num];
-                if (handler) {
-                    const unpack = handler[0];
-                    if (client.pending_atoms[seq_num]) {
-                        opt_data = seq_num;
-                    }
-
-                    const result = unpack.call(client, data, opt_data);
-                    const callback = handler[1];
-                    if (handler[2]) {
-                        // multi-reply request (eg ListFontsWithInfo):
-                        // unpack returns undefined for the terminating reply
-                        if (result === undefined) {
-                            callback(null, handler[3] || []);
-                            delete client.replies[seq_num];
-                        } else {
-                            (handler[3] = handler[3] || []).push(result);
+                // a throwing reply callback must not kill the parser
+                try {
+                    const handler = client.replies[seq_num];
+                    if (handler) {
+                        const unpack = handler[0];
+                        if (client.pending_atoms[seq_num]) {
+                            opt_data = seq_num;
                         }
-                    } else {
-                        callback(null, result);
-                        delete client.replies[seq_num];
+
+                        const result = unpack.call(client, data, opt_data);
+                        const callback = handler[1];
+                        if (handler[2]) {
+                            // multi-reply request (eg ListFontsWithInfo):
+                            // unpack returns undefined for the terminating reply
+                            if (result === undefined) {
+                                callback(null, handler[3] || []);
+                                delete client.replies[seq_num];
+                            } else {
+                                (handler[3] = handler[3] || []).push(result);
+                            }
+                        } else {
+                            callback(null, result);
+                            delete client.replies[seq_num];
+                        }
                     }
+                } finally {
+                    // wait for new packet from server
+                    client.expectReplyHeader();
                 }
-                // wait for new packet from server
-                client.expectReplyHeader();
             });
         }
     );

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,6 +1,8 @@
 const x11 = require('../lib');
 const should = require('should');
 const assert = require('assert');
+const { execFile } = require('child_process');
+const path = require('path');
 
 describe('Client', () => {
 
@@ -30,6 +32,32 @@ describe('Client', () => {
           display.client.CreateWindow(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, {}); // should emit error
           seq = display.client.seq_num;
        }
+    });
+  });
+
+  // #226: an unclaimed X error with no 'error' listener makes the emit throw
+  // from inside the packet parser; the parser must re-arm regardless, or the
+  // connection silently drops every later packet. Needs a child process:
+  // the throw surfaces as an uncaughtException, which mocha would otherwise
+  // attribute to this test — swallowing it in-process is exactly the
+  // test-runner behavior that turns the dead parser into a silent hang.
+  it('re-arms the packet parser when the error emit throws (no listener)', done => {
+    const script = `
+      const x11 = require(${JSON.stringify(path.join(__dirname, '..', 'lib'))});
+      process.on('uncaughtException', () => {});
+      x11.createClient((err, display) => {
+        if (err) process.exit(3);
+        const X = display.client;
+        X.CreateWindow(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, {}); // invalid -> unclaimed X error
+        setTimeout(() => {
+          X.GetInputFocus(() => process.exit(0)); // round-trip proves the parser is alive
+          setTimeout(() => process.exit(2), 4000);
+        }, 200);
+      });
+    `;
+    execFile(process.execPath, ['-e', script], { env: process.env, timeout: 15000 }, (err) => {
+      assert.ifError(err && err.code === 2 ? new Error('parser wedged: reply after unclaimed error never arrived') : err);
+      done();
     });
   });
 });


### PR DESCRIPTION
Fixes #226.

## Problem

All three dispatch branches of `expectReplyHeader()` (X error, event, reply) invoke user-facing code — `emit('error')`, `emit('event')`, request callbacks — *before* re-arming the parser with `client.expectReplyHeader()`. If any of that throws, the parser is never re-armed and the client silently ignores every subsequent byte from the server: pending and future replies simply never resolve.

The most common trigger is an **unclaimed X error with no `'error'` listener attached** — `EventEmitter.emit('error')` throws by design. Standalone that crashes the process (loud, at least), but under anything that intercepts uncaught exceptions (`node:test`, mocha, an app-level `uncaughtException` handler) the wedge is silent and permanent. This is what hung sidorares/ntk#60's CI for hours: a `ChangeProperty` racing a `DestroyWindow` produced a benign `BadWindow`, and every later round-trip (frame fences, `close()`'s ping) waited forever.

## Fix

Wrap the dispatch in each of the three `pack_stream.get` callbacks in `try { … } finally { client.expectReplyHeader(); }`.

- No behavior change on the happy path — dispatch then re-arm, same order as before.
- The exception still propagates after the `finally`, so unhandled `'error'` keeps Node's crash-by-default semantics; the connection just can no longer be left deaf.

## Test

The regression test spawns a child process: it swallows the expected `uncaughtException` (mirroring exactly the test-runner behavior that converts the dead parser into a hang — and mocha would otherwise attribute the throw to the running test), triggers an unclaimed error with an invalid `CreateWindow`, then proves the parser survived with a `GetInputFocus` round-trip. Before the fix it fails with `parser wedged: reply after unclaimed error never arrived`; after, it passes.

Verified locally: `test-local.sh` 301 passing, `test:xserver` 144 passing, `test:glx-emu` 52 passing, eslint clean.
