### PR TITLE
fix(apple-wm): FrameHitTest sent px/py two bytes early

### DIFF
--- a/lib/ext/apple-wm.js
+++ b/lib/ext/apple-wm.js
@@ -85,8 +85,9 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(2, 1);
             b.writeUInt16LE(7, 2);
             b.writeUInt16LE(frame_class, 4);
-            b.writeUInt16LE(px, 6);
-            b.writeUInt16LE(py, 8);
+            // offset 6 is pad1 in xAppleWMFrameHitTestReq; px/py start at 8
+            b.writeUInt16LE(px, 8);
+            b.writeUInt16LE(py, 10);
             b.writeUInt16LE(ix, 12);
             b.writeUInt16LE(iy, 14);
             b.writeUInt16LE(iw, 16);
@@ -329,16 +330,6 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.flush();
         }
 
-        callback(null, ext);
-        /*
-        ext.QueryVersion(function(err, vers) {
-            ext.major = vers[0];
-            ext.minor = vers[1];
-            ext.patch = vers[2];
-            callback(null, ext);
-        });
-        */
-
         ext.events = {
             AppleWMControllerNotify: 0,
             AppleWMActivationNotify: 1,
@@ -384,6 +375,8 @@ exports.requireExt = (display, callback) => {
             return event;
         };
 
-
+        // must come last: consumers reach for ext.events / ext.EventKind
+        // inside this callback, so nothing may be assigned after it
+        callback(null, ext);
     });
 }

--- a/test/apple-wm.js
+++ b/test/apple-wm.js
@@ -1,0 +1,153 @@
+// Wire-format tests for the Apple-WM extension. These stub the client, so
+// they need neither a real X server nor XQuartz and run everywhere.
+//
+// Field offsets below are from applewmproto.h (XQuartz), e.g.
+//   typedef struct _AppleWMFrameHitTest {
+//       CARD8 reqType; CARD8 wmReqType; CARD16 length;
+//       CARD16 frame_class; CARD16 pad1;
+//       CARD16 px; CARD16 py;                  <-- note the pad before px
+//       CARD16 ix, iy, iw, ih, ox, oy, ow, oh;
+//   } xAppleWMFrameHitTestReq;   /* sz = 28 */
+
+const assert = require('assert');
+const appleWM = require('../lib/ext/apple-wm');
+
+const MAJOR = 130;
+const FIRST_EVENT = 68;
+
+/** Build an ext with a stubbed client, capturing everything written. */
+function makeExt() {
+  const written = [];
+  const X = {
+    seq_num: 0,
+    replies: {},
+    eventParsers: {},
+    pack_stream: {
+      put: (buf) => written.push(buf),
+      flush: () => {},
+    },
+    QueryExtension: (name, cb) => {
+      assert.strictEqual(name, 'Apple-WM');
+      cb(null, { present: true, majorOpcode: MAJOR, firstEvent: FIRST_EVENT });
+    },
+  };
+  let ext = null;
+  appleWM.requireExt({ client: X }, (err, e) => {
+    assert.ifError(err);
+    ext = e;
+  });
+  return { ext, X, written, last: () => written[written.length - 1] };
+}
+
+describe('Apple-WM', () => {
+  it('exposes events and EventKind by the time the callback runs', () => {
+    // these used to be assigned *after* callback(null, ext), so a consumer
+    // reading them inside the callback got undefined
+    const X = {
+      seq_num: 0,
+      replies: {},
+      eventParsers: {},
+      pack_stream: { put: () => {}, flush: () => {} },
+      QueryExtension: (name, cb) =>
+        cb(null, { present: true, majorOpcode: MAJOR, firstEvent: FIRST_EVENT }),
+    };
+    let seen = null;
+    appleWM.requireExt({ client: X }, (err, ext) => {
+      seen = {
+        events: ext.events,
+        eventKind: ext.EventKind,
+        notifyMask: ext.NotifyMask,
+      };
+    });
+    assert.ok(seen, 'callback should have run');
+    assert.deepStrictEqual(seen.events, {
+      AppleWMControllerNotify: 0,
+      AppleWMActivationNotify: 1,
+      AppleWMPasteboardNotify: 2,
+    });
+    assert.strictEqual(seen.eventKind.Controller.CloseWindow, 2);
+    assert.strictEqual(seen.notifyMask.All, 7);
+  });
+
+  it('registers event parsers for all three notify events', () => {
+    const { X } = makeExt();
+    for (const offset of [0, 1, 2]) {
+      assert.strictEqual(
+        typeof X.eventParsers[FIRST_EVENT + offset],
+        'function',
+        `parser missing for event ${FIRST_EVENT + offset}`,
+      );
+    }
+  });
+
+  it('encodes FrameHitTest with px/py after the pad word', () => {
+    const { ext, last } = makeExt();
+    ext.FrameHitTest(
+      1, // frame_class
+      11, // px
+      22, // py
+      33, // ix
+      44, // iy
+      55, // iw
+      66, // ih
+      77, // ox
+      88, // oy
+      99, // ow
+      111, // oh
+      () => {},
+    );
+    const b = last();
+    assert.strictEqual(b.length, 28, 'sz_xAppleWMFrameHitTestReq');
+    assert.strictEqual(b.readUInt8(0), MAJOR);
+    assert.strictEqual(b.readUInt8(1), 2, 'X_AppleWMFrameHitTest');
+    assert.strictEqual(b.readUInt16LE(2), 7, 'request length in words');
+    assert.strictEqual(b.readUInt16LE(4), 1, 'frame_class');
+    assert.strictEqual(b.readUInt16LE(6), 0, 'pad1 must stay zero');
+    assert.strictEqual(b.readUInt16LE(8), 11, 'px');
+    assert.strictEqual(b.readUInt16LE(10), 22, 'py');
+    assert.strictEqual(b.readUInt16LE(12), 33, 'ix');
+    assert.strictEqual(b.readUInt16LE(14), 44, 'iy');
+    assert.strictEqual(b.readUInt16LE(16), 55, 'iw');
+    assert.strictEqual(b.readUInt16LE(18), 66, 'ih');
+    assert.strictEqual(b.readUInt16LE(20), 77, 'ox');
+    assert.strictEqual(b.readUInt16LE(22), 88, 'oy');
+    assert.strictEqual(b.readUInt16LE(24), 99, 'ow');
+    assert.strictEqual(b.readUInt16LE(26), 111, 'oh');
+  });
+
+  it('encodes FrameGetRect (frame_rect occupies the second word)', () => {
+    const { ext, last } = makeExt();
+    ext.FrameGetRect(1, 2, 33, 44, 55, 66, 77, 88, 99, 111, () => {});
+    const b = last();
+    assert.strictEqual(b.length, 24, 'sz_xAppleWMFrameGetRectReq');
+    assert.strictEqual(b.readUInt8(1), 1, 'X_AppleWMFrameGetRect');
+    assert.strictEqual(b.readUInt16LE(2), 6, 'request length in words');
+    assert.strictEqual(b.readUInt16LE(4), 1, 'frame_class');
+    assert.strictEqual(b.readUInt16LE(6), 2, 'frame_rect');
+    assert.strictEqual(b.readUInt16LE(8), 33, 'ix');
+    assert.strictEqual(b.readUInt16LE(22), 111, 'oh');
+  });
+
+  it('encodes SetWindowLevel', () => {
+    const { ext, last } = makeExt();
+    ext.SetWindowLevel(0x1234, ext.WindowLevel.Floating);
+    const b = last();
+    assert.strictEqual(b.length, 12);
+    assert.strictEqual(b.readUInt8(1), 9, 'X_AppleWMSetWindowLevel');
+    assert.strictEqual(b.readUInt32LE(4), 0x1234, 'window');
+    assert.strictEqual(b.readUInt32LE(8), 1, 'level');
+  });
+
+  it('encodes SetWindowMenu items as shortcut byte + NUL-terminated label', () => {
+    const { ext, last } = makeExt();
+    ext.SetWindowMenu(['one', ['C', 'two']]);
+    const b = last();
+    assert.strictEqual(b.readUInt8(1), 11, 'X_AppleWMSetWindowMenu');
+    assert.strictEqual(b.readUInt16LE(4), 2, 'item count');
+    assert.strictEqual(b.readUInt8(8), 0, 'no shortcut for the first item');
+    assert.strictEqual(b.toString('latin1', 9, 12), 'one');
+    assert.strictEqual(b.readUInt8(12), 0, 'NUL terminator');
+    assert.strictEqual(String.fromCharCode(b.readUInt8(13)), 'C', 'shortcut');
+    assert.strictEqual(b.toString('latin1', 14, 17), 'two');
+  });
+});


### PR DESCRIPTION
## The bug

`xAppleWMFrameHitTestReq` (applewmproto.h) has a pad word between `frame_class` and the hit point:

```c
CARD16 frame_class;  /* offset 4  */
CARD16 pad1;         /* offset 6  */
CARD16 px;           /* offset 8  */
CARD16 py;           /* offset 10 */
```

`FrameHitTest` wrote `px` at 6 and `py` at 8 — so `px` landed in the pad, `py` landed in `px`'s slot, and `py` was always left zero. (`FrameGetRect`, which has `frame_rect` where this one has the pad, was already correct.)

## Impact, measured against real XQuartz (Apple-WM 1.3.0)

Sweeping a 320×222 frame with a 22px titlebar (inner `0,22,320,200`, outer `0,0,320,222`), `frame_class = DecorLarge|Managed`:

**Before — every point returns 0, the request is entirely non-functional:**

```
y=  4 (all zero)
y=  8 (all zero)
y= 18 (all zero)
y= 30 (all zero)
y=120 (all zero)
```

**After — the three traffic lights are reported, and only inside the titlebar:**

```
y=  4 8:256 12:256 16:256 20:256 24:256  28:512 32:512 36:512 40:512 44:512  52:1024 56:1024 60:1024 64:1024 68:1024
y=  8 (same)
y= 18 (same)
y= 30 (all zero)
y=120 (all zero)
```

256/512/1024 are `CloseBox`/`Collapse`/`Zoom` from `FrameAttr`.

## Also

`callback(null, ext)` ran *before* `ext.events` and `ext.EventKind` were assigned, so a consumer reading them inside the callback got `undefined`. Moved the callback to the end of `requireExt`.

## Tests

New `test/apple-wm.js` stubs the client and pins the request encoding, so it needs neither a real X server nor XQuartz and runs in CI. Reverting the offset fix fails it on `pad1 must stay zero`.

Full suite on a live XQuartz display is unchanged: it is flaky there (baseline runs gave 12, 12, 13 failures; with this change 13, 16 — the 16 coincided with a 5-minute run vs the usual 1 minute, i.e. contention). No failing suite touches apple-wm, which is only loaded on explicit `X.require('apple-wm')`.