### PR TITLE
fix(glx): size Lightfv and Materialfv by their pname

### DIFF
--- a/lib/ext/glxrender.js
+++ b/lib/ext/glxrender.js
@@ -6,6 +6,22 @@ const constants = require('./glxconstants');
 
 const MAX_SMALL_RENDER = 65536 - 16;
 
+// how many floats each pname carries (see the GL spec's glLight/glMaterial);
+// anything unlisted is the 4-float default
+const LIGHT_PARAM_COUNT = {
+    [constants.SPOT_EXPONENT]: 1,
+    [constants.SPOT_CUTOFF]: 1,
+    [constants.CONSTANT_ATTENUATION]: 1,
+    [constants.LINEAR_ATTENUATION]: 1,
+    [constants.QUADRATIC_ATTENUATION]: 1,
+    [constants.SPOT_DIRECTION]: 3
+};
+
+const MATERIAL_PARAM_COUNT = {
+    [constants.SHININESS]: 1,
+    [constants.COLOR_INDEXES]: 3
+};
+
 module.exports = (GLX, ctx) => {
     let buffers = [];
     let currentLength = 0;
@@ -137,6 +153,21 @@ module.exports = (GLX, ctx) => {
         res.writeFloatLE(f2, 16);
         res.writeFloatLE(f3, 20);
         res.writeFloatLE(f4, 24);
+        buffers.push(res);
+    }
+
+    // GL *fv commands are variable length: the number of floats on the wire
+    // is fixed by the pname, and a server rejects the request outright (X
+    // BadLength) when it does not match. glLightfv(GL_SPOT_CUTOFF) carries
+    // one float, not four.
+    function serializeParams(opcode, ints, values, count) {
+        const n = count || 4;
+        const res = commandBuffer(opcode, 4 + ints.length * 4 + n * 4);
+        for (let i = 0; i < ints.length; ++i)
+            res.writeUInt32LE(ints[i] >>> 0, 4 + i * 4);
+        const base = 4 + ints.length * 4;
+        for (let i = 0; i < n; ++i)
+            res.writeFloatLE(values[i] || 0, base + i * 4);
         buffers.push(res);
     }
 
@@ -273,10 +304,8 @@ module.exports = (GLX, ctx) => {
             buffers.push(res);
         },
         Lightfv(light, name, p1, p2, p3, p4) {
-            if (p1.length)
-                serialize2i4f(87, light, name, p1[0], p1[1], p1[2], p1[3]);
-            else
-                serialize2i4f(87, light, name, p1, p2, p3, p4);
+            const values = p1.length ? p1 : [p1, p2, p3, p4];
+            serializeParams(87, [light, name], values, LIGHT_PARAM_COUNT[name]);
         },
         LightModelf(pname, param) {
             serialize1i1f(90, pname, param);
@@ -285,10 +314,8 @@ module.exports = (GLX, ctx) => {
             serialize2i1f(96, face, pname, param);
         },
         Materialfv(face, name, p1, p2, p3, p4) {
-            if (p1.length)
-                serialize2i4f(97, face, name, p1[0], p1[1], p1[2], p1[3]);
-            else
-                serialize2i4f(97, face, name, p1, p2, p3, p4);
+            const values = p1.length ? p1 : [p1, p2, p3, p4];
+            serializeParams(97, [face, name], values, MATERIAL_PARAM_COUNT[name]);
         },
         Clear(mask) {
             serialize1i(127, mask);

--- a/test/glx-render-encoding.js
+++ b/test/glx-render-encoding.js
@@ -1,0 +1,86 @@
+// GL render-command encoding. Unit-level: the pipeline is driven with a fake
+// GLX object, so no server and no display are involved.
+//
+// The *fv commands are variable length — the float count is fixed by the
+// pname, and a real X server answers BadLength on the whole GLX request when
+// the command does not match (glLightfv(GL_SPOT_CUTOFF) carries one float,
+// not four). That made spot lights and light attenuation unusable.
+const should = require('should');
+const renderPipeline = require('../lib/ext/glxrender');
+
+function pipeline() {
+    const commands = [];
+    const glx = {
+        Render(ctx, buffers) {
+            commands.push(...buffers);
+        }
+    };
+    for (const name of ['NewList', 'EndList', 'DeleteLists', 'GenLists',
+        'GenTextures', 'DeleteTextures', 'IsTexture', 'SwapBuffers', 'Finish',
+        'Flush'])
+        glx[name] = () => {};
+    return { gl: renderPipeline(glx, 1), commands };
+}
+
+// [length, opcode] of every command emitted by `draw`
+function encode(draw) {
+    const { gl, commands } = pipeline();
+    draw(gl);
+    gl.Render();
+    return commands.map(b => [b.readUInt16LE(0), b.readUInt16LE(2)]);
+}
+
+describe('GLX render command encoding', function() {
+    it('sizes glLightfv by its pname', function() {
+        const { gl } = pipeline();
+        encode(g => g.Lightfv(gl.LIGHT0, gl.POSITION, [1, 2, 3, 1]))
+            .should.eql([[28, 87]]);
+        encode(g => g.Lightfv(gl.LIGHT0, gl.DIFFUSE, [1, 1, 1, 1]))
+            .should.eql([[28, 87]]);
+        encode(g => g.Lightfv(gl.LIGHT0, gl.SPOT_DIRECTION, 0, -1, 0, 0))
+            .should.eql([[24, 87]]);
+        for (const pname of ['SPOT_CUTOFF', 'SPOT_EXPONENT',
+            'CONSTANT_ATTENUATION', 'LINEAR_ATTENUATION',
+            'QUADRATIC_ATTENUATION'])
+            encode(g => g.Lightfv(gl.LIGHT0, gl[pname], 25, 0, 0, 0))
+                .should.eql([[16, 87]], pname);
+    });
+
+    it('sizes glMaterialfv by its pname', function() {
+        const { gl } = pipeline();
+        encode(g => g.Materialfv(gl.FRONT_AND_BACK, gl.AMBIENT_AND_DIFFUSE,
+            [0.1, 0.2, 0.3, 1])).should.eql([[28, 97]]);
+        encode(g => g.Materialfv(gl.FRONT_AND_BACK, gl.SHININESS, 40))
+            .should.eql([[16, 97]]);
+        // the scalar entry point keeps its own opcode
+        encode(g => g.Materialf(gl.FRONT_AND_BACK, gl.SHININESS, 40))
+            .should.eql([[16, 96]]);
+    });
+
+    it('writes the values it was given, array or varargs', function() {
+        const { gl, commands } = pipeline();
+        gl.Lightfv(gl.LIGHT0, gl.POSITION, [4, 5, 6, 1]);
+        gl.Lightfv(gl.LIGHT0, gl.SPOT_CUTOFF, 25, 0, 0, 0);
+        gl.Render();
+
+        const position = commands[0];
+        position.readUInt32LE(4).should.equal(gl.LIGHT0);
+        position.readUInt32LE(8).should.equal(gl.POSITION);
+        [12, 16, 20, 24].map(o => position.readFloatLE(o))
+            .should.eql([4, 5, 6, 1]);
+
+        const cutoff = commands[1];
+        cutoff.readUInt32LE(8).should.equal(gl.SPOT_CUTOFF);
+        cutoff.readFloatLE(12).should.equal(25);
+        cutoff.length.should.equal(16);
+    });
+
+    it('keeps every command a whole number of 4-byte words', function() {
+        const { gl, commands } = pipeline();
+        gl.Lightfv(gl.LIGHT0, gl.SPOT_DIRECTION, 0, -1, 0, 0);
+        gl.Materialfv(gl.FRONT_AND_BACK, gl.SHININESS, 40);
+        gl.Render();
+        for (const command of commands)
+            (command.length % 4).should.equal(0);
+    });
+});


### PR DESCRIPTION
The GL `*fv` render commands are **variable length** — the number of floats on the wire is fixed by the pname, and a real X server answers `BadLength` on the whole GLX request when the command does not match. Both encoders always wrote four floats:

```js
Lightfv(light, name, p1, p2, p3, p4) {
    serialize2i4f(87, light, name, ...);   // always 28 bytes
}
```

So anything with a scalar or 3-float parameter was rejected outright:

| call | expected | was sent |
| --- | --- | --- |
| `Lightfv(GL_LIGHT0, GL_POSITION, [x, y, z, w])` | 28 bytes | 28 ✅ |
| `Lightfv(GL_LIGHT0, GL_SPOT_CUTOFF, 25)` | 16 bytes | 28 ❌ |
| `Lightfv(GL_LIGHT0, GL_SPOT_DIRECTION, x, y, z)` | 24 bytes | 28 ❌ |
| `Lightfv(GL_LIGHT0, GL_CONSTANT_ATTENUATION, 1)` | 16 bytes | 28 ❌ |
| `Materialfv(GL_FRONT_AND_BACK, GL_SHININESS, 40)` | 16 bytes | 28 ❌ |

In practice that meant **spot lights and light attenuation could not be used at all** — every frame that touched them filled the client log with `Bad length` and dropped the request.

Fixed by sizing the command from a pname → float-count table, defaulting to 4 for everything unlisted. The array and varargs call styles both keep working.

`test/glx-render-encoding.js` is a new unit suite over the pipeline with a fake GLX object — no server, no display — asserting the encoded length and payload of each shape, and that every command stays a whole number of 4-byte words.

Verified on XQuartz through react-x11's `<glarea>`: a scene with an ambient, a point and a directional light renders shaded instead of logging `BadLength` per frame.