### PR TITLE
feat(xserver): substructure redirect, so a window manager can run headlessly

### DIFF
--- a/lib/xserver/DESIGN.md
+++ b/lib/xserver/DESIGN.md
@@ -54,6 +54,16 @@ server.root.raster                         // composited screen pixels (Uint32Ar
 - Event delivery: per-window per-client event masks (`SelectInput` via
   CreateWindow/ChangeWindowAttributes), device event propagation up the
   ancestor chain, pointer/keyboard grabs (basic active grabs), focus (basic).
+- Substructure redirect: a client holding `SubstructureRedirect` on a parent
+  receives `MapRequest`/`ConfigureRequest`/`CirculateRequest` instead of the
+  request taking effect, which is what lets a window manager run against this
+  server headlessly. Redirection is skipped for override-redirect windows,
+  for requests from the redirecting client itself, and for requests that
+  would not change state (mapping an already-mapped window). Only one client
+  at a time may select `SubstructureRedirect`/`ResizeRedirect` on a window —
+  a second selector gets `BadAccess`, the way a WM discovers that another one
+  is already running. `ChangeSaveSet` is still accepted-but-untracked, so a
+  window manager exiting while it holds reparented clients is not modelled.
 - Errors: correct error codes (BadWindow, BadValue, BadMatch, BadAtom,
   BadDrawable, BadAccess, BadAlloc, BadGC, BadIDChoice, BadName, BadLength,
   BadImplementation) with major/minor opcode fields.

--- a/lib/xserver/events.js
+++ b/lib/xserver/events.js
@@ -116,6 +116,14 @@ const builders = {
         return b;
     },
 
+    // The redirected counterpart of MapWindow: sent to the one client
+    // holding SubstructureRedirect on the parent instead of mapping.
+    mapRequest(parent, wid) {
+        const b = packEvent(20, 0, parent);
+        b.writeUInt32LE(wid >>> 0, 8);
+        return b;
+    },
+
     reparentNotify(event, wid, parent, x, y, overrideRedirect) {
         const b = packEvent(21, 0, event);
         b.writeUInt32LE(wid >>> 0, 8);
@@ -139,8 +147,33 @@ const builders = {
         return b;
     },
 
+    // The redirected counterpart of ConfigureWindow. Carries the geometry
+    // the client asked for plus the value mask saying which fields it
+    // actually set — the rest are filled in from the window and must be
+    // ignored by the receiver.
+    configureRequest(parent, win, values, mask) {
+        const b = packEvent(23, values.stackMode || 0, parent);
+        b.writeUInt32LE(win.id >>> 0, 8);
+        b.writeUInt32LE((values.sibling || 0) >>> 0, 12);
+        b.writeInt16LE(values.x !== undefined ? values.x : win.x, 16);
+        b.writeInt16LE(values.y !== undefined ? values.y : win.y, 18);
+        b.writeUInt16LE(values.width !== undefined ? values.width : win.width, 20);
+        b.writeUInt16LE(values.height !== undefined ? values.height : win.height, 22);
+        b.writeUInt16LE(
+            values.borderWidth !== undefined ? values.borderWidth : win.borderWidth, 24);
+        b.writeUInt16LE(mask & 0xffff, 26);
+        return b;
+    },
+
     circulateNotify(event, wid, place) {
         const b = packEvent(26, 0, event);
+        b.writeUInt32LE(wid >>> 0, 8);
+        b[16] = place;
+        return b;
+    },
+
+    circulateRequest(parent, wid, place) {
+        const b = packEvent(27, 0, parent);
         b.writeUInt32LE(wid >>> 0, 8);
         b[16] = place;
         return b;

--- a/lib/xserver/windows.js
+++ b/lib/xserver/windows.js
@@ -108,6 +108,23 @@ class Window {
     }
 }
 
+// Masks only one client at a time may hold on a window (X11 spec, "Event
+// Masks"): a second selector gets BadAccess. This is what makes "another
+// window manager is already running" detectable — claiming the role is a
+// SubstructureRedirect selection on the root that either takes or fails.
+const EXCLUSIVE_MASKS = eventMask.SubstructureRedirect | eventMask.ResizeRedirect;
+
+// The client that redirects `win`'s substructure requests, if it is not the
+// one asking. Requests on an override-redirect window are never redirected.
+function redirectTo(win, client) {
+    if (!win || win.overrideRedirect || !win.parent)
+        return null;
+    for (const [other, mask] of win.parent.eventMasks)
+        if (other !== client && mask & eventMask.SubstructureRedirect)
+            return other;
+    return null;
+}
+
 function applyAttributes(server, client, win, bitmask, values) {
     if (values.backgroundPixel !== undefined)
         win.backgroundPixel = values.backgroundPixel & 0xffffff;
@@ -122,6 +139,11 @@ function applyAttributes(server, client, win, bitmask, values) {
     if (values.overrideRedirect !== undefined)
         win.overrideRedirect = !!values.overrideRedirect;
     if (values.eventMask !== undefined) {
+        const wanted = values.eventMask & EXCLUSIVE_MASKS;
+        if (wanted)
+            for (const [other, mask] of win.eventMasks)
+                if (other !== client && mask & wanted)
+                    throw new XError(codes.Access, 0);
         if (values.eventMask === 0)
             win.eventMasks.delete(client);
         else
@@ -359,16 +381,30 @@ function install(server) {
             mapWindow(server, win);
     };
 
-    // MapWindow (8)
+    // MapWindow (8). An already-mapped window is a no-op and is never
+    // redirected — only a state change reaches the window manager.
     h[8] = (client, detail, body) => {
-        mapWindow(server, server.getWindow(body.readUInt32LE(0)));
+        const win = server.getWindow(body.readUInt32LE(0));
+        if (win.mapped || !win.parent)
+            return;
+        const wm = redirectTo(win, client);
+        if (wm)
+            return wm.sendEvent(builders.mapRequest(win.parent.id, win.id));
+        mapWindow(server, win);
     };
 
     // MapSubwindows (9)
     h[9] = (client, detail, body) => {
         const win = server.getWindow(body.readUInt32LE(0));
-        for (const child of win.children.slice())
-            mapWindow(server, child);
+        for (const child of win.children.slice()) {
+            if (child.mapped)
+                continue;
+            const wm = redirectTo(child, client);
+            if (wm)
+                wm.sendEvent(builders.mapRequest(win.id, child.id));
+            else
+                mapWindow(server, child);
+        }
     };
 
     // UnmapWindow (10)
@@ -393,6 +429,10 @@ function install(server) {
         if ((values.width !== undefined && values.width === 0) ||
             (values.height !== undefined && values.height === 0))
             throw new XError(codes.Value, 0);
+        const wm = redirectTo(win, client);
+        if (wm)
+            return wm.sendEvent(
+                builders.configureRequest(win.parent.id, win, values, bitmask));
         if (values.x !== undefined)
             win.x = values.x;
         if (values.y !== undefined)
@@ -422,15 +462,19 @@ function install(server) {
         const win = server.getWindow(body.readUInt32LE(0));
         if (win.children.length === 0)
             return;
-        let child, place;
-        if (direction === 0) {          // RaiseLowest
+        const lowest = direction === 0;
+        const target = lowest ? win.children[0] : win.children[win.children.length - 1];
+        const place = lowest ? 0 : 1;   // Top : Bottom
+        const wm = redirectTo(target, client);
+        if (wm)
+            return wm.sendEvent(builders.circulateRequest(win.id, target.id, place));
+        let child;
+        if (lowest) {                   // RaiseLowest
             child = win.children.shift();
             win.children.push(child);
-            place = 0;                  // Top
         } else {                        // LowerHighest
             child = win.children.pop();
             win.children.unshift(child);
-            place = 1;                  // Bottom
         }
         deliver(win, eventMask.SubstructureNotify, builders.circulateNotify(win.id, child.id, place));
         deliver(child, eventMask.StructureNotify, builders.circulateNotify(child.id, child.id, place));

--- a/test/xserver/redirect.js
+++ b/test/xserver/redirect.js
@@ -1,0 +1,214 @@
+const assert = require('assert');
+const x11 = require('../../lib');
+const { createServer } = require('../../lib/xserver');
+const { boot, sync } = require('./boot');
+
+const em = x11.eventMask;
+
+// SubstructureRedirect: the window manager's half of the protocol. A client
+// holding it on a parent gets MapRequest/ConfigureRequest/CirculateRequest
+// instead of the request taking effect, and decides what really happens.
+describe('xserver: substructure redirect', () => {
+
+    let server, WM, C, root;
+
+    // WM is the redirecting client, C an ordinary application client.
+    beforeEach(done => {
+        server = createServer();
+        boot({ server }, (err, wmCtx) => {
+            if (err) return done(err);
+            WM = wmCtx.X;
+            root = wmCtx.display.screen[0].root;
+            boot({ server }, (err2, cCtx) => {
+                if (err2) return done(err2);
+                C = cCtx.X;
+                done();
+            });
+        });
+    });
+
+    afterEach(() => {
+        if (WM) WM.terminate();
+        if (C) C.terminate();
+        server = WM = C = null;
+    });
+
+    function onEvent(client, name, cb) {
+        const listener = ev => {
+            if (ev.name === name) {
+                client.removeListener('event', listener);
+                cb(ev);
+            }
+        };
+        client.on('event', listener);
+    }
+
+    const claimRoot = cb => {
+        WM.ChangeWindowAttributes(root, { eventMask: em.SubstructureRedirect });
+        sync(WM, cb);
+    };
+
+    it('MapWindow becomes a MapRequest and the window stays unmapped', done => {
+        claimRoot(() => {
+            const wid = C.AllocID();
+            C.CreateWindow(wid, root, 0, 0, 40, 30);
+            onEvent(WM, 'MapRequest', ev => {
+                assert.strictEqual(ev.parent, root);
+                assert.strictEqual(ev.wid, wid);
+                WM.GetWindowAttributes(wid, (err, attrs) => {
+                    assert.ifError(err);
+                    assert.strictEqual(attrs.mapState, 0, 'still unmapped');
+                    done();
+                });
+            });
+            C.MapWindow(wid);
+        });
+    });
+
+    it('the window manager mapping it itself is not redirected', done => {
+        claimRoot(() => {
+            const wid = C.AllocID();
+            C.CreateWindow(wid, root, 0, 0, 40, 30);
+            sync(C, () => {
+                WM.on('event', ev => {
+                    assert.notStrictEqual(ev.name, 'MapRequest', 'no self-redirect');
+                });
+                WM.MapWindow(wid);
+                sync(WM, () => {
+                    WM.GetWindowAttributes(wid, (err, attrs) => {
+                        assert.ifError(err);
+                        assert.strictEqual(attrs.mapState, 2, 'viewable');
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    it('an override-redirect window maps straight through', done => {
+        claimRoot(() => {
+            const wid = C.AllocID();
+            C.CreateWindow(wid, root, 0, 0, 40, 30, 0, 0, 0, 0, { overrideRedirect: 1 });
+            WM.on('event', ev => {
+                assert.notStrictEqual(ev.name, 'MapRequest', 'not redirected');
+            });
+            C.MapWindow(wid);
+            sync(C, () => {
+                C.GetWindowAttributes(wid, (err, attrs) => {
+                    assert.ifError(err);
+                    assert.strictEqual(attrs.mapState, 2, 'viewable');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('re-mapping an already mapped window is not redirected', done => {
+        const wid = C.AllocID();
+        C.CreateWindow(wid, root, 0, 0, 40, 30);
+        C.MapWindow(wid);
+        sync(C, () => claimRoot(() => {
+            WM.on('event', ev => {
+                assert.notStrictEqual(ev.name, 'MapRequest', 'no state change');
+            });
+            C.MapWindow(wid);
+            sync(C, () => sync(WM, done));
+        }));
+    });
+
+    it('ConfigureWindow becomes a ConfigureRequest carrying the value mask', done => {
+        claimRoot(() => {
+            const wid = C.AllocID();
+            C.CreateWindow(wid, root, 5, 6, 40, 30);
+            onEvent(WM, 'ConfigureRequest', ev => {
+                assert.strictEqual(ev.parent, root);
+                assert.strictEqual(ev.wid, wid);
+                assert.strictEqual(ev.width, 200);
+                assert.strictEqual(ev.height, 300);
+                // y was not in the request: the field carries the window's
+                // current value and the mask says to ignore it
+                assert.strictEqual(ev.y, 6);
+                assert.strictEqual(ev.mask, 0x0004 | 0x0008, 'width|height only');
+                C.GetGeometry(wid, (err, geom) => {
+                    assert.ifError(err);
+                    assert.strictEqual(geom.width, 40, 'unchanged');
+                    assert.strictEqual(geom.height, 30, 'unchanged');
+                    done();
+                });
+            });
+            C.ConfigureWindow(wid, { width: 200, height: 300 });
+        });
+    });
+
+    it('a redirected ConfigureWindow sends no ConfigureNotify', done => {
+        claimRoot(() => {
+            const wid = C.AllocID();
+            C.CreateWindow(wid, root, 0, 0, 40, 30, 0, 0, 0, 0,
+                { eventMask: em.StructureNotify });
+            C.on('event', ev => {
+                assert.notStrictEqual(ev.name, 'ConfigureNotify', 'nothing happened');
+            });
+            C.ConfigureWindow(wid, { width: 60 });
+            sync(C, () => sync(WM, done));
+        });
+    });
+
+    it('CirculateWindow becomes a CirculateRequest', done => {
+        const a = C.AllocID(), b = C.AllocID();
+        C.CreateWindow(a, root, 0, 0, 40, 30);
+        C.CreateWindow(b, root, 0, 0, 40, 30);
+        sync(C, () => claimRoot(() => {
+            onEvent(WM, 'CirculateRequest', ev => {
+                assert.strictEqual(ev.wid, a, 'the lowest child');
+                assert.strictEqual(ev.place, 0, 'Top');
+                C.QueryTree(root, (err, tree) => {
+                    assert.ifError(err);
+                    assert.deepStrictEqual(tree.children, [a, b], 'unchanged');
+                    done();
+                });
+            });
+            C.CirculateWindow(root, 0 /* RaiseLowest */);
+        }));
+    });
+
+    it('only one client at a time may redirect a window', done => {
+        claimRoot(() => {
+            C.ChangeWindowAttributes(root, { eventMask: em.SubstructureRedirect });
+            C.once('error', err => {
+                assert.strictEqual(err.error, 10, 'BadAccess');
+                done();
+            });
+            sync(C, () => {});
+        });
+    });
+
+    it('the same client may re-select its own redirect', done => {
+        claimRoot(() => {
+            WM.on('error', err => done(err));
+            WM.ChangeWindowAttributes(root, {
+                eventMask: em.SubstructureRedirect | em.SubstructureNotify
+            });
+            sync(WM, done);
+        });
+    });
+
+    it('the redirect is released when the window manager disconnects', done => {
+        claimRoot(() => {
+            WM.terminate();
+            WM = null;
+            // the server drops the client's masks with it, so the role is free
+            setTimeout(() => {
+                boot({ server }, (err, ctx) => {
+                    assert.ifError(err);
+                    const WM2 = ctx.X;
+                    WM2.on('error', err2 => done(err2));
+                    WM2.ChangeWindowAttributes(root, { eventMask: em.SubstructureRedirect });
+                    sync(WM2, () => {
+                        WM2.terminate();
+                        done();
+                    });
+                });
+            }, 10);
+        });
+    });
+});


### PR DESCRIPTION
## Why

The pure-JS X server delivered `SubstructureNotify` but never redirected anything. `MapWindow` and `ConfigureWindow` always took effect, so a client holding `SubstructureRedirect` watched windows appear instead of being asked about them first.

That is the one piece of the protocol a window manager is built on. Without it a WM can only be tested against a real X server — which rules out the headless test and screenshot workflow the rest of this server exists to support.

## What

`MapWindow`, `MapSubwindows`, `ConfigureWindow` and `CirculateWindow` now look for a redirecting client on the parent and send `MapRequest` / `ConfigureRequest` / `CirculateRequest` to it instead of acting.

Redirection is skipped exactly where the protocol says it must be:

- override-redirect windows (menus, tooltips) map straight through
- a request from the redirecting client itself is not redirected back to it
- a request that changes no state — mapping an already-mapped window — is not redirected

`ConfigureRequest` carries the **value mask**, so the receiver can tell which geometry fields the client actually asked for. The remaining fields are filled in from the window and are meaningless without the mask; a WM that ignores it will happily move windows to wherever they already were.

Selecting `SubstructureRedirect` or `ResizeRedirect` on a window where another client already holds it now fails with `BadAccess`, per the spec's "only one client at a time" rule. That error *is* the mechanism by which a window manager discovers that another one is already running, so it has to be real.

## Not in scope

`ChangeSaveSet` remains accepted-but-untracked, so a window manager exiting while it still holds reparented clients is not modelled. Noted in `DESIGN.md`.

## Tests

New `test/xserver/redirect.js` — 10 cases over the two-client harness, covering each redirected request, each skip rule, the `BadAccess` claim conflict, re-selection by the same client, and the role being released when the WM disconnects.

```
  xserver: substructure redirect
    ✔ MapWindow becomes a MapRequest and the window stays unmapped
    ✔ the window manager mapping it itself is not redirected
    ✔ an override-redirect window maps straight through
    ✔ re-mapping an already mapped window is not redirected
    ✔ ConfigureWindow becomes a ConfigureRequest carrying the value mask
    ✔ a redirected ConfigureWindow sends no ConfigureNotify
    ✔ CirculateWindow becomes a CirculateRequest
    ✔ only one client at a time may redirect a window
    ✔ the same client may re-select its own redirect
    ✔ the redirect is released when the window manager disconnects
```

Full `test/xserver/` suite: 154 passing.

## Context

Wanted by a reparenting window manager demo in [react-x11](https://github.com/sidorares/react-x11), whose frames are ordinary react-x11 `<window>`s. An ntk PR for the client-side half follows.