### PR TITLE
fix: connect to a plain ":N" display over the unix socket on macOS

### DIFF
--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -689,6 +689,17 @@ module.exports.createClient = (options, initCb) => {
                 }
                 else if (forceUnix)
                     socketPath = `/tmp/.X11-unix/X${displayNum}`;
+                else if (!host)
+                {
+                    // Xvfb, Xephyr and Xnest on macOS create the standard
+                    // socket and advertise a plain ":N" DISPLAY, which used
+                    // to fall through to TCP 6000+N and fail to connect.
+                    // Only take it if it is really there, so a display that
+                    // genuinely means TCP still gets TCP.
+                    const candidate = `/tmp/.X11-unix/X${displayNum}`;
+                    if (require('fs').existsSync(candidate))
+                        socketPath = candidate;
+                }
             } else if(!host || forceUnix)
                 socketPath = `/tmp/.X11-unix/X${displayNum}`;
         }


### PR DESCRIPTION
## The bug

On macOS, `DISPLAY=:10` fails:

```
AggregateError [ECONNREFUSED]: connect ECONNREFUSED 127.0.0.1:6010
```

The darwin branch of the transport selection recognises only two shapes:

```js
if (display[0] == '/')      socketPath = display;            // XQuartz launchd socket
else if (forceUnix)         socketPath = `/tmp/.X11-unix/X${displayNum}`;
```

Anything else falls through to TCP `6000 + N`.

## Why it matters beyond XQuartz

That is correct for XQuartz, which advertises an absolute launchd socket path. It is wrong for every other X server on the platform. **Xvfb, Xephyr and Xnest** all create `/tmp/.X11-unix/XN` and advertise a plain `:N` — and so does a nested server to the clients started inside it.

The practical effect: anything running under `Xephyr :10` on macOS has to know to rewrite its own `DISPLAY` to `unix/:10` before node-x11 will connect. That is a papercut for headless testing, and a real obstacle when the program *is* the thing being started by the server (a window manager launched through XQuartz's `USERWM` hook inherits `DISPLAY=:5` and cannot do anything about it).

## The fix

A hostless `:N` now takes `/tmp/.X11-unix/XN` **when that socket actually exists**, and falls back to TCP when it does not — so a display that genuinely means TCP is unaffected, and the change cannot break a working setup.

## Verified on macOS

| | |
| --- | --- |
| `DISPLAY=:10` against Xephyr | connects over the unix socket (was ECONNREFUSED) |
| `DISPLAY=:77`, no socket, no server | still ECONNREFUSED from TCP — fallback intact |
| `DISPLAY=/private/tmp/…/org.xquartz:0` | unchanged, still connects |

`test/xserver/`: 154 passing.