### PR TITLE
perf(xserver): specialise the RENDER spans a toolkit actually emits

### DIFF
--- a/browser/CANVAS-RENDER.md
+++ b/browser/CANVAS-RENDER.md
@@ -1,0 +1,160 @@
+# Canvas-backed RENDER in the browser — findings
+
+An investigation, not a shipped feature. The question: in the browser
+build, can the JS X server implement RENDER by calling canvas 2D methods
+instead of compositing pixels itself? A lot of RENDER maps onto canvas
+almost exactly, so the mapping is not the hard part — the pixel storage is.
+
+**Short answer: yes, and it is worth doing, but not as a drop-in for the
+RENDER extension. It is a pixel-storage backend, all or nothing.** The
+measurements below say where the win actually is, and it is not where the
+software compositor was just optimised.
+
+## What the numbers say
+
+Megapixels per second for the same six spans. "software" is
+`scripts/bench-render.js` before and after the fast-path work; "canvas 2D"
+is the equivalent canvas calls, measured in headless Chrome with SwiftShader
+(software rasterisation — a GPU-backed canvas would be faster still for
+fills, and *slower* for readback).
+
+| span | software, before | software, now | canvas 2D |
+| --- | ---: | ---: | ---: |
+| FillRectangles Src (opaque) | 49 | **8310** | 3933 |
+| FillRectangles Over (alpha) | 48.7 | 65 | **7916** |
+| Composite Src, untransformed | 27.7 | 793 | 842 |
+| Composite Over, untransformed | 18 | 79.8 | **1552** |
+| Composite Over, linear gradient | 15.7 | 17 | **365** |
+| FillRectangles Src, 2 clip rects | 27.7 | 4420 | 5188 |
+| `getImageData` of the region | — | — | 888 |
+
+Three things fall out of this:
+
+1. **Where the span reduces to a memset or a memcpy, JavaScript is already
+   at the ceiling.** The optimised opaque fill beats canvas; the
+   untransformed Src blit and the clipped fill tie it. Canvas has nothing
+   to offer there any more.
+2. **Everything that still blends per pixel is 20–120x off.** Alpha
+   compositing and gradients are where a canvas backend would earn its
+   keep, and they are what a real UI is made of — translucent panels, hover
+   tints, gradient chrome. That gap is not going to close in JavaScript:
+   those spans are irreducibly per-pixel, and canvas gets them from
+   vectorised (or GPU) code the language cannot reach.
+3. **Readback is affordable, which was the surprise.** 888 Mpx/s means
+   pulling a whole 640x480 screen back out of a canvas costs about 0.35 ms.
+   The assumption that a canvas backend would be sunk by `getImageData` on
+   every frame does not survive the measurement. (On a GPU-backed canvas it
+   would be worse; `willReadFrequently` exists for exactly this.)
+
+## The mapping, which is the easy part
+
+RENDER's operators are Porter-Duff, and so is `globalCompositeOperation`.
+Thirteen of the fourteen are exact:
+
+| PictOp | canvas | | PictOp | canvas |
+| --- | --- | --- | --- | --- |
+| Clear | `clearRect` | | OutReverse | `destination-out` |
+| Src | `copy` | | Atop | `source-atop` |
+| Dst | *(no-op)* | | AtopReverse | `destination-atop` |
+| Over | `source-over` | | Xor | `xor` |
+| OverReverse | `destination-over` | | Add | `lighter` |
+| In | `source-in` | | Saturate | **none** |
+| InReverse | `destination-in` | | | |
+| Out | `source-out` | | | |
+
+The rest lines up nearly as well:
+
+| RENDER | canvas |
+| --- | --- |
+| `CreateLinearGradient` | `createLinearGradient` + `addColorStop` |
+| `CreateRadialGradient` | `createRadialGradient` — the two-circle form the server already implements |
+| `CreateConicalGradient` | `createConicGradient` |
+| `FillRectangles` | `fillStyle` + `fillRect` |
+| `Composite` | `drawImage` with source and destination rects |
+| `SetPictureClipRectangles` | `beginPath` + `rect` xN + `clip` |
+| `Trapezoids` / `Triangles` / `TriStrip` / `TriFan` | a path `fill`, antialiased |
+| `CompositeGlyphs` | `drawImage` per glyph, or one atlas draw |
+| repeat Normal | `createPattern(img, 'repeat')` |
+| filter nearest / bilinear | `imageSmoothingEnabled` false / true |
+
+And what does not map:
+
+- **Saturate** has no canvas operator. Falls back to the software loop.
+- **Projective transforms.** `SetPictureTransform` takes a full 3x3;
+  `setTransform` is affine. A perspective matrix has to fall back.
+- **Repeat Pad and Reflect.** `createPattern` has no equivalent.
+- **Convolution filters.** No canvas equivalent worth the trouble.
+- **Exact antialiasing.** The server's trapezoid coverage is four
+  sub-bands per row with analytic horizontal coverage; canvas AA is
+  implementation-defined. Output would be close but not identical, so the
+  pixel-exact tests in `test/xserver/render.js` cannot be run against a
+  canvas backend unchanged.
+
+## Why it cannot be a drop-in extension
+
+The blocker is not RENDER, it is everything around it.
+
+The server stores pixels as `Uint32Array` rasters (`lib/xserver/raster.js`),
+and **core drawing, `compose()`, `GetImage`, `PutImage`, `CopyArea` and the
+GLX emulator's `notifySwap` all read and write those arrays directly**. A
+canvas-backed Picture would have to synchronise with the array at every
+boundary, and a per-operation round trip would cost more than it saves —
+0.35 ms is cheap once a frame and ruinous once per composite.
+
+There is a second, quieter problem: **canvas ImageData is straight alpha,
+RENDER is premultiplied.** Canvas stores premultiplied internally and
+un-premultiplies on `getImageData`, so a hybrid that moves pixels back and
+forth loses low-alpha precision on every trip. Both problems point the same
+way — the backend has to own the pixels end to end.
+
+## The shape that would work
+
+Make the *raster* pluggable rather than the extension:
+
+```
+Raster (Uint32Array)          <- node, and the default everywhere
+CanvasRaster (OffscreenCanvas) <- browser opt-in
+```
+
+- `raster.js` grows a small interface — the ops in the "Raster contract"
+  section of `lib/xserver/DESIGN.md` — and the browser build supplies a
+  canvas-backed implementation of it.
+- Every drawable (window, pixmap) allocates through the server's backend, so
+  a Picture's target is a canvas from the start and RENDER can issue canvas
+  calls without asking anyone's permission.
+- `compose()` becomes `drawImage` per mapped window instead of a manual
+  copy loop, and `CanvasPresenter` disappears: the root raster *is* the
+  canvas already on the page, so the Uint32→RGBA conversion and the
+  `putImageData` both go away.
+- `GetImage` and `PutImage` are then the only readback points, which is
+  where a round trip is genuinely unavoidable and also rare.
+- Anything a canvas cannot express (Saturate, projective transforms, Pad and
+  Reflect repeat, convolution) falls back by reading the region once,
+  running the existing software loop, and writing it back. The general loop
+  in `extensions/render.js` stays exactly as it is and becomes the
+  correctness reference.
+
+## Recommendation
+
+Worth doing, and worth doing after the software fast paths rather than
+instead of them — the fast paths are what makes the fallback path
+acceptable, and they already close the gap on the two spans where canvas
+had nothing to offer.
+
+The order that keeps each step useful on its own:
+
+1. Extract the raster interface in `raster.js` and route drawable
+   allocation through the server, with the existing `Uint32Array` raster as
+   the only implementation. No behaviour change; the whole test suite is the
+   check.
+2. Add `browser/canvas-raster.js` implementing that interface over
+   `OffscreenCanvas`, opt-in per server, with the software loop as the
+   documented fallback for the five unmappable cases.
+3. Move `compose()` and the presenter onto it, which is where the frame-time
+   win actually lands for a browser playground.
+
+Step 1 is the one that needs care; steps 2 and 3 are mostly the mapping
+table above. The correctness story has to change with it: the pixel-exact
+RENDER tests stay on the software backend, and the canvas backend gets
+tolerance-based tests plus the fast-path equivalence approach already used
+in `test/xserver/render-fastpath.js`.

--- a/lib/xserver/DESIGN.md
+++ b/lib/xserver/DESIGN.md
@@ -85,6 +85,49 @@ server.registerExtension(name, {
 `BIG-REQUESTS` (the client enables it on connect by default) and `XC-MISC`.
 GLX registers through the same hook from the browser bundle.
 
+## RENDER compositing (`extensions/render.js`)
+
+Pictures composite in premultiplied ARGB over the Uint32 rasters; the
+pixel-model note at the top of the module says how each depth maps onto the
+32-bit cell. One general loop (`compositeSpan`) covers everything — any
+operator, transform, filter, repeat mode, mask and coverage — by sampling,
+blending and writing one pixel at a time.
+
+That loop is correct but costs six calls and two switches per pixel, and a
+window repaint is a few hundred thousand pixels. So the spans a toolkit
+actually emits are specialised, in `compositeSpanFast` and in
+`FillRectangles`:
+
+| span | what it becomes |
+|---|---|
+| solid source, depth-24 destination, operator with no destination term (Src, Clear, In, Out) | `TypedArray.fill` per span |
+| solid source, any other operator | per-pixel blend with the factors hoisted out |
+| untransformed unfiltered blit, all texels inside the source, Src, matching depths | row copy (`set`) at depth 32, masked row copy at depth 24 |
+| untransformed unfiltered blit, other operators | per-pixel blend with no sampler call |
+
+Rows are painted as a list of `[start, end)` intervals: the whole row when
+there is no clip, and the clip's spans for that row otherwise
+(`clipRowSpans`). Clipped drawing therefore runs at fast-path speed instead
+of being excluded from it, which matters because a toolkit clips constantly
+— every overflow box, every rounded corner, every scrolling viewport. The
+spans come out **merged and non-overlapping**: overlapping clip rectangles
+would otherwise composite a pixel twice, which is invisible for Src and
+wrong for every operator that is not idempotent. The sorted rectangle list
+is cached on the picture and keyed by the clip array's identity, and every
+assignment site replaces that array rather than mutating it.
+
+A specialisation still bails out (returns false) whenever its other
+preconditions do not hold — a mask, a coverage function, a transform, a
+resampling filter, a source the region reaches outside of, an unusual depth
+— and the general loop runs instead. That is why the preconditions are all
+checked before the loop rather than inside it.
+
+**These paths must be indistinguishable from the general loop.**
+`test/xserver/render-fastpath.js` is what enforces it: every scenario runs
+twice, once with `_setFastPaths(false)`, and the two destination rasters are
+compared cell by cell. `scripts/bench-render.js` reports the throughput that
+motivates them.
+
 ## Raster contract (`raster.js`)
 
 All drawing goes through `Raster` with a `gc` state object:

--- a/lib/xserver/extensions/render.js
+++ b/lib/xserver/extensions/render.js
@@ -115,28 +115,43 @@ function writePx(raster, depth, x, y, a, r, g, b) {
 }
 
 // ---------------------------------------------------------------------
-// Porter-Duff (premultiplied). Returns [Fa, Fb] for src/dst contribution;
-// result channel = src*Fa + dst*Fb, alphas included.
+// Porter-Duff (premultiplied). Fills out[0]=Fa, out[1]=Fb for the src/dst
+// contribution; result channel = src*Fa + dst*Fb, alphas included. Returns
+// false for an operator this server does not implement, so the caller can
+// raise BadPictOp.
+//
+// The out-parameter is not style: this runs once per composited pixel, and
+// returning a fresh [Fa, Fb] made the garbage collector a measurable share
+// of a window repaint.
 
-function blendFactors(op, as, ad) {
+function blendFactors(op, as, ad, out) {
     switch (op) {
-        case 0: return [0, 0];                 // Clear
-        case 1: return [1, 0];                 // Src
-        case 2: return [0, 1];                 // Dst
-        case 3: return [1, 1 - as];            // Over
-        case 4: return [1 - ad, 1];            // OverReverse
-        case 5: return [ad, 0];                // In
-        case 6: return [0, as];                // InReverse
-        case 7: return [1 - ad, 0];            // Out
-        case 8: return [0, 1 - as];            // OutReverse
-        case 9: return [ad, 1 - as];           // Atop
-        case 10: return [1 - ad, as];          // AtopReverse
-        case 11: return [1 - ad, 1 - as];      // Xor
-        case 12: return [1, 1];                // Add
-        case 13: return [as > 0 ? Math.min(1, (1 - ad) / as) : 1, 1]; // Saturate
-        default: return null;                  // caller raises BadPictOp
+        case 0: out[0] = 0; out[1] = 0; return true;                 // Clear
+        case 1: out[0] = 1; out[1] = 0; return true;                 // Src
+        case 2: out[0] = 0; out[1] = 1; return true;                 // Dst
+        case 3: out[0] = 1; out[1] = 1 - as; return true;            // Over
+        case 4: out[0] = 1 - ad; out[1] = 1; return true;            // OverReverse
+        case 5: out[0] = ad; out[1] = 0; return true;                // In
+        case 6: out[0] = 0; out[1] = as; return true;                // InReverse
+        case 7: out[0] = 1 - ad; out[1] = 0; return true;            // Out
+        case 8: out[0] = 0; out[1] = 1 - as; return true;            // OutReverse
+        case 9: out[0] = ad; out[1] = 1 - as; return true;           // Atop
+        case 10: out[0] = 1 - ad; out[1] = as; return true;          // AtopReverse
+        case 11: out[0] = 1 - ad; out[1] = 1 - as; return true;      // Xor
+        case 12: out[0] = 1; out[1] = 1; return true;                // Add
+        case 13:                                                     // Saturate
+            out[0] = as > 0 ? Math.min(1, (1 - ad) / as) : 1;
+            out[1] = 1;
+            return true;
+        default: return false;                 // caller raises BadPictOp
     }
 }
+
+// Fast paths specialise the common spans (constant source, untransformed
+// blit, plain fill) and must agree with the general loop pixel for pixel.
+// The toggle is a test hook, not protocol API: test/xserver/render-fastpath.js
+// renders the same scenes twice and compares the rasters.
+let fastPaths = true;
 
 // ---------------------------------------------------------------------
 // antialiased coverage accumulation, shared by AddTraps, Trapezoids and the
@@ -242,6 +257,59 @@ function targetRaster(pict) {
 function damage(server, pict) {
     if (pict.drawable && pict.drawable.type === 'window')
         server.damageWindow(pict.drawable);
+}
+
+// Clip rectangles sorted by x, cached on the picture, so a row's allowed
+// spans can be produced by one linear scan. Invalidated whenever the clip is
+// replaced (applyPictureValues / setPictureClipRectangles).
+function sortedClip(pict) {
+    const clip = pict.clip;
+    if (!clip)
+        return null;
+    if (pict._clipSortedFor !== clip) {
+        pict._clipSorted = clip.slice().sort((a, b) => a.x - b.x);
+        pict._clipSortedFor = clip;
+    }
+    return pict._clipSorted;
+}
+
+/**
+ * The x intervals of row `Y` that the clip allows, intersected with
+ * [x0, x1) and written into `out` as flat [start, end) pairs.
+ *
+ * They come out merged and non-overlapping, which is not a detail: a
+ * fast path draws each span once, and overlapping clip rectangles would
+ * otherwise composite a pixel twice — visibly wrong for every operator
+ * that is not idempotent, Over included.
+ */
+function clipRowSpans(sorted, Y, x0, x1, out) {
+    out.length = 0;
+    let curA = -1;
+    let curB = -1;
+    for (let i = 0; i < sorted.length; i++) {
+        const r = sorted[i];
+        if (Y < r.y || Y >= r.y + r.height)
+            continue;
+        const a = r.x < x0 ? x0 : r.x;
+        const rb = r.x + r.width;
+        const b = rb > x1 ? x1 : rb;
+        if (a >= b)
+            continue;
+        if (curA < 0) {
+            curA = a;
+            curB = b;
+        } else if (a <= curB) {
+            if (b > curB)
+                curB = b;
+        } else {
+            out.push(curA, curB);
+            curA = a;
+            curB = b;
+        }
+    }
+    if (curA >= 0)
+        out.push(curA, curB);
+    return out;
 }
 
 // clip set by SetPictureClipRectangles: null (no clip) or rects in drawable
@@ -434,27 +502,55 @@ function makeSampler(pict) {
     };
 }
 
+// Can compositeSpanFast blit straight out of this picture's raster? Only
+// when nothing between the source coordinate and the texel bends it: no
+// transform (the callers' half-pixel offsets then floor back to the integer
+// source coordinate) and no resampling filter.
+function isDirectSource(pict) {
+    return !!pict && !pict.transform && !!pict.drawable &&
+        pict.filter !== 'bilinear' &&
+        !(pict.filter === 'convolution' && pict.filterParams && pict.filterParams.length > 2);
+}
+
 // -------------------------------------------------------------------
 // the core composite loop, shared by Composite / the coverage requests /
 // glyphs. `coverage(i, j)` (0..1) modulates the source like a
 // non-component-alpha mask; op is applied across the whole region, per
 // RENDER's dst = op(src IN mask, dst) - including where coverage is 0.
 
-function compositeSpan(server, op, sample, srcX, srcY, mask, dst, dstX, dstY, w, h, coverage) {
+function compositeSpan(server, op, sample, srcX, srcY, mask, dst, dstX, dstY, w, h, coverage, srcPict) {
     const raster = targetRaster(dst);
     const depth = dst.format.depth;
     const W = raster.width;
     const H = raster.height;
+    const fac = [0, 0];
+    // validate the operator once rather than at every pixel
+    if (!blendFactors(op, 0, 0, fac))
+        throw renderError(server, ERR_PICTOP, op);
+
+    // clip out of the inner loop: `null` is the overwhelmingly common case
+    const clip = dst.clip || null;
+
+    const y0 = Math.max(0, dstY);
+    const y1 = Math.min(H, dstY + h);
+    const x0 = Math.max(0, dstX);
+    const x1 = Math.min(W, dstX + w);
+    if (y0 >= y1 || x0 >= x1)
+        return;
+
+    if (fastPaths && srcPict && !mask && !coverage &&
+        compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY,
+            x0, y0, x1, y1, clip ? sortedClip(dst) : null))
+        return;
+
     const s = [0, 0, 0, 0];
     const m = [0, 0, 0, 0];
     const d = [0, 0, 0, 0];
-    for (let j = 0; j < h; j++) {
-        const Y = dstY + j;
-        if (Y < 0 || Y >= H)
-            continue;
-        for (let i = 0; i < w; i++) {
-            const X = dstX + i;
-            if (X < 0 || X >= W || !inClip(dst, X, Y))
+    for (let Y = y0; Y < y1; Y++) {
+        const j = Y - dstY;
+        for (let X = x0; X < x1; X++) {
+            const i = X - dstX;
+            if (clip && !inClip(dst, X, Y))
                 continue;
             sample(srcX + i + 0.5, srcY + j + 0.5, s);
             let f = 1;
@@ -469,10 +565,9 @@ function compositeSpan(server, op, sample, srcX, srcY, mask, dst, dstX, dstY, w,
             const sg = s[2] * f;
             const sb = s[3] * f;
             readPx(raster, depth, X, Y, d);
-            const factors = blendFactors(op, sa / 255, d[0] / 255);
-            if (!factors)
-                throw renderError(server, ERR_PICTOP, op);
-            const [fa, fb] = factors;
+            blendFactors(op, sa / 255, d[0] / 255, fac);
+            const fa = fac[0];
+            const fb = fac[1];
             writePx(
                 raster, depth, X, Y,
                 sa * fa + d[0] * fb,
@@ -482,6 +577,162 @@ function compositeSpan(server, op, sample, srcX, srcY, mask, dst, dstX, dstY, w,
             );
         }
     }
+}
+
+// -------------------------------------------------------------------
+// Specialised spans. Each returns true when it handled the region, false to
+// fall through to the general loop above; between them they cover what a
+// toolkit actually emits — a solid fill and an untransformed blit — where
+// the general loop costs six calls and a switch per pixel.
+//
+// Callers guarantee: no clip, no mask, no coverage, and the destination
+// rectangle already intersected with the drawable.
+
+function compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY, x0, y0, x1, y1, clip) {
+    const data = raster.data;
+    const W = raster.width;
+    // rows are painted as a list of [start, end) intervals: the whole row
+    // when unclipped, the clip's merged spans otherwise. That keeps the clip
+    // test out of the inner loop without giving up on clipped drawing, which
+    // is most of what a toolkit emits (every overflow box, every rounded
+    // corner, every scrolling viewport).
+    const spans = [];
+    const rowSpans = Y => {
+        if (!clip) {
+            spans.length = 0;
+            spans.push(x0, x1);
+            return spans;
+        }
+        return clipRowSpans(clip, Y, x0, x1, spans);
+    };
+
+    // (1) constant source: a solid picture. Gradients and drawables vary
+    // per pixel and fall through.
+    const c = srcPict.kind === 'solid' ? srcPict.color : null;
+    if (c) {
+        const sa = c[0], sr = c[1], sg = c[2], sb = c[3];
+        if (depth === 24) {
+            // readPx reports alpha 255 for every depth-24 pixel, so with a
+            // constant source the factors are constant for the whole span
+            const fac = [0, 0];
+            blendFactors(op, sa / 255, 1, fac);
+            const fa = fac[0], fb = fac[1];
+            if (fb === 0) {
+                // result is the same value everywhere: fill whole spans
+                const px = ((clamp255(sr * fa) << 16) |
+                    (clamp255(sg * fa) << 8) | clamp255(sb * fa)) >>> 0;
+                for (let Y = y0; Y < y1; Y++) {
+                    const sp = rowSpans(Y);
+                    for (let k = 0; k < sp.length; k += 2)
+                        data.fill(px, Y * W + sp[k], Y * W + sp[k + 1]);
+                }
+                return true;
+            }
+            for (let Y = y0; Y < y1; Y++) {
+                const row = Y * W;
+                const sp = rowSpans(Y);
+                for (let k = 0; k < sp.length; k += 2) {
+                    for (let X = sp[k]; X < sp[k + 1]; X++) {
+                        const p = data[row + X];
+                        data[row + X] = ((clamp255(sr * fa + ((p >>> 16) & 0xff) * fb) << 16) |
+                            (clamp255(sg * fa + ((p >>> 8) & 0xff) * fb) << 8) |
+                            clamp255(sb * fa + (p & 0xff) * fb)) >>> 0;
+                    }
+                }
+            }
+            return true;
+        }
+        if (depth === 32) {
+            const fac = [0, 0];
+            for (let Y = y0; Y < y1; Y++) {
+                const row = Y * W;
+                const sp = rowSpans(Y);
+                for (let k = 0; k < sp.length; k += 2) {
+                    for (let X = sp[k]; X < sp[k + 1]; X++) {
+                        const p = data[row + X];
+                        const da = (p >>> 24) & 0xff;
+                        blendFactors(op, sa / 255, da / 255, fac);
+                        const fa = fac[0], fb = fac[1];
+                        data[row + X] = ((clamp255(sa * fa + da * fb) << 24) |
+                            (clamp255(sr * fa + ((p >>> 16) & 0xff) * fb) << 16) |
+                            (clamp255(sg * fa + ((p >>> 8) & 0xff) * fb) << 8) |
+                            clamp255(sb * fa + (p & 0xff) * fb)) >>> 0;
+                    }
+                }
+            }
+            return true;
+        }
+        return false; // depth 8 / 1: rare, leave to the general loop
+    }
+
+    // (2) untransformed nearest blit between rgb24/rgba32 pictures, with
+    // every sampled texel inside the source (so `repeat` cannot apply).
+    if (!isDirectSource(srcPict))
+        return false;
+    const srcRaster = srcPict.drawable.raster;
+    const srcDepth = srcPict.format.depth;
+    if ((srcDepth !== 24 && srcDepth !== 32) || (depth !== 24 && depth !== 32))
+        return false;
+    const sx0 = srcX + (x0 - dstX);
+    const sy0 = srcY + (y0 - dstY);
+    if (sx0 < 0 || sy0 < 0 ||
+        sx0 + (x1 - x0) > srcRaster.width || sy0 + (y1 - y0) > srcRaster.height)
+        return false;
+
+    const sData = srcRaster.data;
+    const sW = srcRaster.width;
+    // source index of destination (X, Y): srcX/srcY track dstX/dstY one to one
+    const sdx = srcX - dstX;
+    const sdy = srcY - dstY;
+
+    // Src between identical layouts is a copy.
+    if (op === 1 && srcDepth === depth) {
+        for (let Y = y0; Y < y1; Y++) {
+            const row = Y * W;
+            const srow = (Y + sdy) * sW + sdx;
+            const sp = rowSpans(Y);
+            for (let k = 0; k < sp.length; k += 2) {
+                const xa = sp[k], xb = sp[k + 1];
+                if (depth === 32) {
+                    // every bit is meaningful, so this is a memcpy
+                    data.set(sData.subarray(srow + xa, srow + xb), row + xa);
+                } else {
+                    // depth 24: the top byte has to stay 0 (see the
+                    // pixel-model note at the top of this file), and a source
+                    // raster can carry junk up there from a core-protocol
+                    // write with a wide foreground value
+                    for (let X = xa; X < xb; X++)
+                        data[row + X] = sData[srow + X] & 0xffffff;
+                }
+            }
+        }
+        return true;
+    }
+
+    const fac = [0, 0];
+    for (let Y = y0; Y < y1; Y++) {
+        const row = Y * W;
+        const srow = (Y + sdy) * sW + sdx;
+        const sp = rowSpans(Y);
+        for (let k = 0; k < sp.length; k += 2) {
+            for (let X = sp[k]; X < sp[k + 1]; X++) {
+                const spx = sData[srow + X];
+                const sa = srcDepth === 32 ? (spx >>> 24) & 0xff : 255;
+                const p = data[row + X];
+                const da = depth === 32 ? (p >>> 24) & 0xff : 255;
+                blendFactors(op, sa / 255, da / 255, fac);
+                const fa = fac[0], fb = fac[1];
+                const a = clamp255(sa * fa + da * fb);
+                const r = clamp255(((spx >>> 16) & 0xff) * fa + ((p >>> 16) & 0xff) * fb);
+                const g = clamp255(((spx >>> 8) & 0xff) * fa + ((p >>> 8) & 0xff) * fb);
+                const b = clamp255((spx & 0xff) * fa + (p & 0xff) * fb);
+                data[row + X] = depth === 32
+                    ? ((a << 24) | (r << 16) | (g << 8) | b) >>> 0
+                    : ((r << 16) | (g << 8) | b) >>> 0;
+            }
+        }
+    }
+    return true;
 }
 
 // -------------------------------------------------------------------
@@ -629,7 +880,7 @@ function composite(server, body) {
     const mask = maskId
         ? { sample: makeSampler(getPicture(server, maskId)), x: maskX, y: maskY }
         : null;
-    compositeSpan(server, op, makeSampler(src), srcX, srcY, mask, dst, dstX, dstY, w, h, null);
+    compositeSpan(server, op, makeSampler(src), srcX, srcY, mask, dst, dstX, dstY, w, h, null, src);
     damage(server, dst);
 }
 
@@ -640,6 +891,28 @@ function fillRectangles(server, body) {
     const raster = targetRaster(dst);
     const depth = dst.format.depth;
     const d = [0, 0, 0, 0];
+    const fac = [0, 0];
+    if (!blendFactors(op, 0, 0, fac))
+        throw renderError(server, ERR_PICTOP, op);
+    const clip = dst.clip || null;
+    const data = raster.data;
+    const W = raster.width;
+
+    // A depth-24 destination reads back alpha 255 everywhere, and the fill
+    // colour is one constant, so the blend factors hold for the whole
+    // rectangle. When the destination contributes nothing (Src, Clear, In,
+    // Out) every pixel gets the same value and the row is a memset — which
+    // is what a window background, a panel and a button face all are.
+    let solidPx = -1;
+    if (fastPaths && depth === 24) {
+        blendFactors(op, color[0] / 255, 1, fac);
+        if (fac[1] === 0)
+            solidPx = ((clamp255(color[1] * fac[0]) << 16) |
+                (clamp255(color[2] * fac[0]) << 8) | clamp255(color[3] * fac[0])) >>> 0;
+    }
+    const sorted = solidPx >= 0 && clip ? sortedClip(dst) : null;
+    const spans = [];
+
     for (let off = 16; off + 8 <= body.length; off += 8) {
         const rx = body.readInt16LE(off);
         const ry = body.readInt16LE(off + 2);
@@ -647,17 +920,28 @@ function fillRectangles(server, body) {
         const rh = body.readUInt16LE(off + 6);
         const x0 = Math.max(0, rx);
         const y0 = Math.max(0, ry);
-        const x1 = Math.min(raster.width, rx + rw);
+        const x1 = Math.min(W, rx + rw);
         const y1 = Math.min(raster.height, ry + rh);
+        if (solidPx >= 0) {
+            for (let Y = y0; Y < y1; Y++) {
+                if (!sorted) {
+                    data.fill(solidPx, Y * W + x0, Y * W + x1);
+                    continue;
+                }
+                const sp = clipRowSpans(sorted, Y, x0, x1, spans);
+                for (let k = 0; k < sp.length; k += 2)
+                    data.fill(solidPx, Y * W + sp[k], Y * W + sp[k + 1]);
+            }
+            continue;
+        }
         for (let Y = y0; Y < y1; Y++) {
             for (let X = x0; X < x1; X++) {
-                if (!inClip(dst, X, Y))
+                if (clip && !inClip(dst, X, Y))
                     continue;
                 readPx(raster, depth, X, Y, d);
-                const factors = blendFactors(op, color[0] / 255, d[0] / 255);
-                if (!factors)
-                    throw renderError(server, ERR_PICTOP, op);
-                const [fa, fb] = factors;
+                blendFactors(op, color[0] / 255, d[0] / 255, fac);
+                const fa = fac[0];
+                const fb = fac[1];
                 writePx(
                     raster, depth, X, Y,
                     color[0] * fa + d[0] * fb,
@@ -955,6 +1239,9 @@ function compositeGlyphs(server, body, idBytes) {
     const sample = makeSampler(src);
     const s = [0, 0, 0, 0];
     const d = [0, 0, 0, 0];
+    const fac = [0, 0];
+    if (!blendFactors(op, 0, 0, fac))
+        throw renderError(server, ERR_PICTOP, op);
 
     let penX = 0;
     let penY = 0;
@@ -1003,10 +1290,9 @@ function compositeGlyphs(server, body, idBytes) {
                     const f = c / 255;
                     sample(X + srcOffX + 0.5, Y + srcOffY + 0.5, s);
                     readPx(raster, depth, X, Y, d);
-                    const factors = blendFactors(op, (s[0] * f) / 255, d[0] / 255);
-                    if (!factors)
-                        throw renderError(server, ERR_PICTOP, op);
-                    const [fa, fb] = factors;
+                    blendFactors(op, (s[0] * f) / 255, d[0] / 255, fac);
+                    const fa = fac[0];
+                    const fb = fac[1];
                     writePx(
                         raster, depth, X, Y,
                         s[0] * f * fa + d[0] * fb,
@@ -1066,6 +1352,13 @@ module.exports = {
 
     init(server, extInfo) {
         firstErrors.set(server, extInfo.firstError);
+    },
+
+    // Test hook, not protocol API: turning the specialised spans off makes
+    // the compositor take the general per-pixel loop for everything, so a
+    // test can render the same scene both ways and diff the rasters.
+    _setFastPaths(on) {
+        fastPaths = !!on;
     },
 
     handleRequest(server, client, minor, body) {

--- a/scripts/bench-canvas-render.html
+++ b/scripts/bench-canvas-render.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>canvas RENDER throughput</title></head>
+<body>
+<pre id="out">running…</pre>
+<script>
+// Canvas 2D throughput for the spans scripts/bench-render.js measures in the
+// software compositor — the evidence behind browser/CANVAS-RENDER.md.
+// Reported in megapixels per second so the two are directly comparable.
+//
+// Open it in a browser, or headlessly:
+//   chrome --headless=new --disable-gpu --virtual-time-budget=60000 \
+//     --dump-dom scripts/bench-canvas-render.html
+const W = 640, H = 480;
+const AW = 512, AH = 384;          // the composited region
+const AREA = AW * AH;
+const RUN_MS = 400;
+
+const dst = document.createElement('canvas');
+dst.width = W; dst.height = H;
+const ctx = dst.getContext('2d', { alpha: true, willReadFrequently: false });
+
+// an opaque source image and one with alpha
+function makeSource(alpha) {
+  const c = document.createElement('canvas');
+  c.width = W; c.height = H;
+  const g = c.getContext('2d');
+  const img = g.createImageData(W, H);
+  for (let i = 0; i < W * H; i++) {
+    img.data[i * 4] = (i * 7) & 0xff;
+    img.data[i * 4 + 1] = (i * 13) & 0xff;
+    img.data[i * 4 + 2] = (i * 29) & 0xff;
+    img.data[i * 4 + 3] = alpha;
+  }
+  g.putImageData(img, 0, 0);
+  return c;
+}
+const opaqueSrc = makeSource(255);
+const alphaSrc = makeSource(128);
+
+const grad = ctx.createLinearGradient(0, 0, AW, AH);
+grad.addColorStop(0, '#ff0000');
+grad.addColorStop(1, '#0000ff');
+
+function time(label, fn) {
+  for (let i = 0; i < 5; i++) fn();          // warm up
+  const t0 = performance.now();
+  let calls = 0;
+  while (performance.now() - t0 < RUN_MS) { fn(); calls++; }
+  const ms = performance.now() - t0;
+  // force the queued work to actually complete before stopping the clock:
+  // canvas drawing is asynchronous until something reads it back
+  ctx.getImageData(0, 0, 1, 1);
+  const total = performance.now() - t0;
+  return { label, calls, mpxPerSec: +((calls * AREA) / (total / 1000) / 1e6).toFixed(1) };
+}
+
+const rows = [];
+
+rows.push(time('FillRectangles Src (opaque)', () => {
+  ctx.globalCompositeOperation = 'copy';
+  ctx.fillStyle = '#2980b9';
+  ctx.fillRect(0, 0, AW, AH);
+}));
+
+rows.push(time('FillRectangles Over (alpha)', () => {
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.fillStyle = 'rgba(41,128,185,0.5)';
+  ctx.fillRect(0, 0, AW, AH);
+}));
+
+rows.push(time('Composite Src, untransformed', () => {
+  ctx.globalCompositeOperation = 'copy';
+  ctx.drawImage(opaqueSrc, 0, 0, AW, AH, 0, 0, AW, AH);
+}));
+
+rows.push(time('Composite Over, untransformed', () => {
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.drawImage(alphaSrc, 0, 0, AW, AH, 0, 0, AW, AH);
+}));
+
+rows.push(time('Composite Over, linear gradient', () => {
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, AW, AH);
+}));
+
+rows.push(time('FillRectangles Src, 2 clip rects', () => {
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, 0, AW / 2, AH);
+  ctx.rect(AW / 2, 0, AW / 2, AH);
+  ctx.clip();
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.fillStyle = '#00ff00';
+  ctx.fillRect(0, 0, AW, AH);
+  ctx.restore();
+}));
+
+// the readback a hybrid design would need on every frame, for comparison
+rows.push(time('+ getImageData readback of the region', () => {
+  ctx.getImageData(0, 0, AW, AH);
+}));
+
+document.getElementById('out').textContent =
+  rows.map(r => r.label.padEnd(38) + String(r.mpxPerSec).padStart(9)).join('\n');
+document.title = 'done';
+</script>
+</body>
+</html>

--- a/scripts/bench-render.js
+++ b/scripts/bench-render.js
@@ -1,0 +1,239 @@
+// Throughput benchmark for the JS X server's software RENDER compositor.
+//
+//   node scripts/bench-render.js [--json]
+//
+// The scenarios are the ones a real toolkit generates: solid fills, an
+// opaque blit, an alpha blend, a scaled blit through the transform path, a
+// gradient, and a clipped fill. Each reports megapixels per second, which
+// is the number that decides whether a UI repaint fits in a frame — a
+// window repaint is a few hundred thousand pixels, so 10 Mpx/s is a 30 ms
+// frame and 100 Mpx/s is 3 ms.
+//
+// Composites are driven through the extension's own request handlers, so
+// what is measured is the path the protocol actually takes.
+'use strict';
+
+const { createServer } = require('../lib/xserver');
+const render = require('../lib/xserver/extensions/render');
+
+const W = 640;
+const H = 480;
+const RUN_MS = Number(process.env.BENCH_MS || 400);
+
+function boot() {
+    const server = createServer({ width: W, height: H });
+    // the extension keeps per-server state (format table, error base)
+    const ext = server.extensions.get('RENDER');
+    if (!ext)
+        throw new Error('server has no RENDER extension');
+    return server;
+}
+
+// ids have to sit in the fake client's resource range (server.js:
+// checkIdFree tests xid & ~resourceMask against resourceBase)
+const RESOURCE_BASE = 0x200000;
+let nextId = RESOURCE_BASE;
+const id = () => ++nextId;
+
+// --- request builders (little-endian bodies, as the dispatcher sees them) ---
+
+function bodyCreatePicture(pid, drawable, formatId) {
+    const b = Buffer.alloc(16);
+    b.writeUInt32LE(pid, 0);
+    b.writeUInt32LE(drawable, 4);
+    b.writeUInt32LE(formatId, 8);
+    b.writeUInt32LE(0, 12); // value mask
+    return b;
+}
+
+function bodyFillRectangles(op, dst, color, rects) {
+    const b = Buffer.alloc(16 + rects.length * 8);
+    b.writeUInt8(op, 0);
+    b.writeUInt32LE(dst, 4);
+    b.writeUInt16LE(color[0], 8); // red
+    b.writeUInt16LE(color[1], 10);
+    b.writeUInt16LE(color[2], 12);
+    b.writeUInt16LE(color[3], 14); // alpha
+    rects.forEach((r, i) => {
+        const o = 16 + i * 8;
+        b.writeInt16LE(r[0], o);
+        b.writeInt16LE(r[1], o + 2);
+        b.writeUInt16LE(r[2], o + 4);
+        b.writeUInt16LE(r[3], o + 6);
+    });
+    return b;
+}
+
+function bodyComposite(op, src, mask, dst, sx, sy, mx, my, dx, dy, w, h) {
+    const b = Buffer.alloc(32);
+    b.writeUInt8(op, 0);
+    b.writeUInt32LE(src, 4);
+    b.writeUInt32LE(mask, 8);
+    b.writeUInt32LE(dst, 12);
+    b.writeInt16LE(sx, 16);
+    b.writeInt16LE(sy, 18);
+    b.writeInt16LE(mx, 20);
+    b.writeInt16LE(my, 22);
+    b.writeInt16LE(dx, 24);
+    b.writeInt16LE(dy, 26);
+    b.writeUInt16LE(w, 28);
+    b.writeUInt16LE(h, 30);
+    return b;
+}
+
+function bodyLinearGradient(pid, p1, p2, stops) {
+    const b = Buffer.alloc(4 + 16 + 4 + stops.length * (4 + 8));
+    let o = 0;
+    b.writeUInt32LE(pid, o); o += 4;
+    b.writeInt32LE(p1[0] * 65536, o); o += 4;
+    b.writeInt32LE(p1[1] * 65536, o); o += 4;
+    b.writeInt32LE(p2[0] * 65536, o); o += 4;
+    b.writeInt32LE(p2[1] * 65536, o); o += 4;
+    b.writeUInt32LE(stops.length, o); o += 4;
+    for (const s of stops) {
+        b.writeInt32LE(s.at * 65536, o); o += 4;
+    }
+    for (const s of stops) {
+        b.writeUInt16LE(s.color[0], o); o += 2;
+        b.writeUInt16LE(s.color[1], o); o += 2;
+        b.writeUInt16LE(s.color[2], o); o += 2;
+        b.writeUInt16LE(s.color[3], o); o += 2;
+    }
+    return b;
+}
+
+function bodySetClip(dst, rects) {
+    const b = Buffer.alloc(8 + rects.length * 8);
+    b.writeUInt32LE(dst, 0);
+    b.writeInt16LE(0, 4);
+    b.writeInt16LE(0, 6);
+    rects.forEach((r, i) => {
+        const o = 8 + i * 8;
+        b.writeInt16LE(r[0], o);
+        b.writeInt16LE(r[1], o + 2);
+        b.writeUInt16LE(r[2], o + 4);
+        b.writeUInt16LE(r[3], o + 6);
+    });
+    return b;
+}
+
+// minor opcodes, from the RENDER protocol
+const REQ = {
+    CreatePicture: 4,
+    SetPictureClipRectangles: 6,
+    Composite: 8,
+    FillRectangles: 26,
+    CreateLinearGradient: 34
+};
+
+// A pretend client: the handlers only use it for replies, which none of the
+// benchmarked requests produce.
+const client = {
+    startReply() { return Buffer.alloc(32); },
+    send() {},
+    seq: 1,
+    resourceBase: RESOURCE_BASE,
+    resourceMask: 0x1fffff
+};
+
+function setup() {
+    const server = boot();
+    const call = (minor, body) => render.handleRequest(server, client, minor, body);
+
+    // a depth-24 destination pixmap the size of a window
+    const dstPix = id();
+    server.resources.set(dstPix, makePixmap(server, W, H, 24));
+    const dst = id();
+    call(REQ.CreatePicture, bodyCreatePicture(dst, dstPix, 0x102 /* rgb24 */));
+
+    // source pixmaps at least as large as the blitted region, which is what
+    // a double-buffer flush or an image draw actually looks like
+    const srcPix = id();
+    const srcRaster = makePixmap(server, W, H, 24);
+    server.resources.set(srcPix, srcRaster);
+    for (let i = 0; i < srcRaster.raster.data.length; i++)
+        srcRaster.raster.data[i] = (i * 2654435761) >>> 8;
+    const src = id();
+    call(REQ.CreatePicture, bodyCreatePicture(src, srcPix, 0x102));
+
+    // a 32-bit source with alpha, for the blend path
+    const argbPix = id();
+    const argbRaster = makePixmap(server, W, H, 32);
+    server.resources.set(argbPix, argbRaster);
+    for (let i = 0; i < argbRaster.raster.data.length; i++)
+        argbRaster.raster.data[i] = (0x80 << 24 | (i * 40503) & 0xffffff) >>> 0;
+    const argb = id();
+    call(REQ.CreatePicture, bodyCreatePicture(argb, argbPix, 0x101 /* rgba32 */));
+
+    return { server, call, dst, src, argb };
+}
+
+const { Raster } = require('../lib/xserver/raster');
+
+function makePixmap(server, w, h, depth) {
+    return {
+        type: 'pixmap',
+        id: 0,
+        width: w,
+        height: h,
+        depth,
+        raster: new Raster(w, h, depth)
+    };
+}
+
+function time(label, pixelsPerCall, fn) {
+    // warm up so the measurement is of optimised code
+    for (let i = 0; i < 5; i++) fn();
+    const t0 = process.hrtime.bigint();
+    let calls = 0;
+    while (Number(process.hrtime.bigint() - t0) / 1e6 < RUN_MS) {
+        fn();
+        calls++;
+    }
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    const mpxPerSec = (calls * pixelsPerCall) / (ms / 1000) / 1e6;
+    return { label, calls, ms: +ms.toFixed(1), mpxPerSec: +mpxPerSec.toFixed(1) };
+}
+
+function main() {
+    const { call, dst, src, argb } = setup();
+    const AREA = 512 * 384; // a window-sized region
+    const rows = [];
+
+    rows.push(time('FillRectangles Src (opaque)', AREA, () =>
+        call(REQ.FillRectangles, bodyFillRectangles(1, dst, [0x2980, 0x4040, 0xb9b9, 0xffff], [[0, 0, 512, 384]]))));
+
+    rows.push(time('FillRectangles Over (alpha)', AREA, () =>
+        call(REQ.FillRectangles, bodyFillRectangles(3, dst, [0x2980, 0x4040, 0xb9b9, 0x8000], [[0, 0, 512, 384]]))));
+
+    rows.push(time('Composite Src, untransformed', AREA, () =>
+        call(REQ.Composite, bodyComposite(1, src, 0, dst, 0, 0, 0, 0, 0, 0, 512, 384))));
+
+    rows.push(time('Composite Over, untransformed', AREA, () =>
+        call(REQ.Composite, bodyComposite(3, argb, 0, dst, 0, 0, 0, 0, 0, 0, 512, 384))));
+
+    // gradient source
+    const grad = id();
+    call(REQ.CreateLinearGradient, bodyLinearGradient(grad, [0, 0], [512, 384], [
+        { at: 0, color: [0xffff, 0, 0, 0xffff] },
+        { at: 1, color: [0, 0, 0xffff, 0xffff] }
+    ]));
+    rows.push(time('Composite Over, linear gradient', AREA, () =>
+        call(REQ.Composite, bodyComposite(3, grad, 0, dst, 0, 0, 0, 0, 0, 0, 512, 384))));
+
+    // clipped fill: same area, but every pixel tested against a clip list
+    call(REQ.SetPictureClipRectangles, bodySetClip(dst, [[0, 0, 256, 384], [256, 0, 256, 384]]));
+    rows.push(time('FillRectangles Src, 2 clip rects', AREA, () =>
+        call(REQ.FillRectangles, bodyFillRectangles(1, dst, [0, 0xffff, 0, 0xffff], [[0, 0, 512, 384]]))));
+
+    if (process.argv.includes('--json')) {
+        console.log(JSON.stringify(rows, null, 2));
+        return;
+    }
+    const width = Math.max(...rows.map(r => r.label.length));
+    console.log('scenario'.padEnd(width) + '   Mpx/s      calls');
+    for (const r of rows)
+        console.log(`${r.label.padEnd(width)}   ${String(r.mpxPerSec).padStart(6)}   ${String(r.calls).padStart(8)}`);
+}
+
+main();

--- a/test/xserver/render-fastpath.js
+++ b/test/xserver/render-fastpath.js
@@ -1,0 +1,262 @@
+// The compositor specialises the spans a toolkit actually emits — a solid
+// fill, an untransformed blit — and those specialisations are only safe if
+// they are indistinguishable from the general per-pixel loop.
+//
+// So this suite runs every scenario twice, once with the fast paths on and
+// once with them off (the `_setFastPaths` test hook), and asserts the two
+// destination images are identical. A specialisation that gets a rounding
+// rule, an operator or an edge case wrong fails here rather than showing up
+// as a subtly wrong colour somewhere downstream.
+const assert = require('assert');
+const { boot } = require('./boot');
+const renderExt = require('../../lib/xserver/extensions/render');
+
+const W = 24, H = 16;
+
+// every operator the server implements, by name for readable failures
+const OPS = [
+    'Clear', 'Src', 'Dst', 'Over', 'OverReverse', 'In', 'InReverse',
+    'Out', 'OutReverse', 'Atop', 'AtopReverse', 'Xor', 'Add', 'Saturate'
+];
+
+describe('xserver: RENDER fast paths', () => {
+
+    let server, display, X, root, render;
+
+    beforeEach(done => {
+        boot((err, ctx) => {
+            if (err) return done(err);
+            ({ server, display, X } = ctx);
+            root = display.screen[0].root;
+            X.require('render', (err2, ext) => {
+                if (err2) return done(err2);
+                render = ext;
+                done();
+            });
+        });
+    });
+
+    afterEach(() => {
+        renderExt._setFastPaths(true); // never leave it off for other suites
+        X.terminate();
+        server = display = X = render = null;
+    });
+
+    // depth-24 or depth-32 destination, seeded with a gradient-ish pattern so
+    // that every destination channel (and, at depth 32, every destination
+    // alpha) is exercised rather than a single flat value
+    function mkDest(depth) {
+        const pixmap = X.AllocID();
+        X.CreatePixmap(pixmap, root, depth, W, H);
+        const pic = X.AllocID();
+        render.CreatePicture(pic, pixmap, depth === 32 ? render.rgba32 : render.rgb24);
+        const rects = [];
+        for (let y = 0; y < H; y++)
+            rects.push(0, y, W, 1);
+        for (let y = 0; y < H; y++) {
+            const v = Math.round((y / (H - 1)) * 65535);
+            render.FillRectangles(render.PictOp.Src, pic,
+                [v, 65535 - v, (v * 3) % 65535, depth === 32 ? v : 65535],
+                [0, y, W, 1]);
+        }
+        return { pixmap, pic };
+    }
+
+    function mkSourcePixmap(depth, seed) {
+        const pixmap = X.AllocID();
+        X.CreatePixmap(pixmap, root, depth, W, H);
+        const pic = X.AllocID();
+        render.CreatePicture(pic, pixmap, depth === 32 ? render.rgba32 : render.rgb24);
+        for (let y = 0; y < H; y++) {
+            const v = Math.round((((y * seed) % H) / (H - 1)) * 65535);
+            render.FillRectangles(render.PictOp.Src, pic,
+                [65535 - v, v, (v * 7) % 65535, depth === 32 ? (v + 20000) % 65535 : 65535],
+                [0, y, W, 1]);
+        }
+        return { pixmap, pic };
+    }
+
+    // Runs `paint(pic)` against a fresh destination and returns its raster,
+    // with the fast paths either enabled or disabled.
+    function renderWith(fast, depth, paint, cb) {
+        renderExt._setFastPaths(fast);
+        const { pixmap, pic } = mkDest(depth);
+        paint(pic);
+        // read the server's raster directly: GetImage would mask depth-32
+        // alpha away and hide exactly the kind of difference we are hunting
+        X.GetInputFocus(() => {
+            const res = server.resources.get(pixmap);
+            cb(Uint32Array.from(res.raster.data));
+        });
+    }
+
+    function bothAgree(depth, paint, label, done) {
+        renderWith(true, depth, paint, fastData => {
+            renderWith(false, depth, paint, slowData => {
+                assert.strictEqual(fastData.length, slowData.length);
+                for (let i = 0; i < fastData.length; i++) {
+                    if (fastData[i] !== slowData[i]) {
+                        const x = i % W, y = (i / W) | 0;
+                        assert.fail(
+                            `${label}: pixel (${x},${y}) differs — fast ` +
+                            `0x${fastData[i].toString(16).padStart(8, '0')} vs general ` +
+                            `0x${slowData[i].toString(16).padStart(8, '0')}`);
+                    }
+                }
+                done();
+            });
+        });
+    }
+
+    describe('FillRectangles matches the general loop', () => {
+        for (const depth of [24, 32]) {
+            for (let op = 0; op < OPS.length; op++) {
+                it(`${OPS[op]} on depth ${depth}`, done => {
+                    bothAgree(depth, pic => {
+                        render.FillRectangles(op, pic, [0x8000, 0x4000, 0xc000, 0xa000],
+                            [2, 1, 9, 7, 12, 5, 8, 9]);
+                    }, `FillRectangles ${OPS[op]} depth ${depth}`, done);
+                });
+            }
+        }
+
+        it('opaque fill covers exactly the rect and nothing else', done => {
+            bothAgree(24, pic => {
+                render.FillRectangles(render.PictOp.Src, pic, [0xffff, 0, 0, 0xffff],
+                    [3, 2, 5, 4]);
+            }, 'partial opaque fill', done);
+        });
+
+        it('a clip list still matches', done => {
+            bothAgree(24, pic => {
+                render.SetPictureClipRectangles(pic, 0, 0, [1, 1, 8, 6, 10, 4, 6, 8]);
+                render.FillRectangles(render.PictOp.Src, pic, [0, 0xffff, 0, 0xffff],
+                    [0, 0, W, H]);
+            }, 'clipped fill', done);
+        });
+
+        // The fast path turns the clip into per-row spans, and overlapping
+        // rectangles have to merge: drawing the overlap twice is invisible
+        // for Src but wrong for every operator that is not idempotent.
+        it('overlapping clip rectangles composite each pixel once', done => {
+            bothAgree(24, pic => {
+                render.SetPictureClipRectangles(pic, 0, 0, [2, 2, 10, 10, 6, 4, 10, 6]);
+                render.FillRectangles(render.PictOp.Over, pic, [0x8000, 0, 0x4000, 0x8000],
+                    [0, 0, W, H]);
+            }, 'overlapping clip, Over', done);
+        });
+
+        it('clip rectangles given out of x order still match', done => {
+            bothAgree(24, pic => {
+                render.SetPictureClipRectangles(pic, 0, 0, [14, 1, 6, 12, 2, 3, 5, 9]);
+                render.FillRectangles(render.PictOp.Over, pic, [0, 0x9000, 0x3000, 0xa000],
+                    [0, 0, W, H]);
+            }, 'unsorted clip', done);
+        });
+
+        it('a clip origin offset still matches', done => {
+            bothAgree(24, pic => {
+                render.SetPictureClipRectangles(pic, 3, 2, [0, 0, 8, 8]);
+                render.FillRectangles(render.PictOp.Src, pic, [0xffff, 0xffff, 0, 0xffff],
+                    [0, 0, W, H]);
+            }, 'clip origin', done);
+        });
+    });
+
+    describe('Composite matches the general loop', () => {
+        for (const srcDepth of [24, 32]) {
+            for (const dstDepth of [24, 32]) {
+                for (const op of [0, 1, 3, 5, 9, 11, 12, 13]) {
+                    it(`${OPS[op]}: depth ${srcDepth} source onto depth ${dstDepth}`, done => {
+                        bothAgree(dstDepth, pic => {
+                            const src = mkSourcePixmap(srcDepth, 3);
+                            render.Composite(op, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+                        }, `Composite ${OPS[op]} ${srcDepth}->${dstDepth}`, done);
+                    });
+                }
+            }
+        }
+
+        it('a sub-rectangle blit at an offset matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 5);
+                render.Composite(render.PictOp.Src, src.pic, 0, pic, 2, 3, 0, 0, 5, 4, 10, 6);
+            }, 'offset blit', done);
+        });
+
+        it('a solid source with no mask matches', done => {
+            bothAgree(24, pic => {
+                const solid = X.AllocID();
+                render.CreateSolidFill(solid, [0x4000, 0x8000, 0x2000, 0xc000]);
+                render.Composite(render.PictOp.Over, solid, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'solid source', done);
+        });
+
+        it('a source smaller than the region falls back and still matches', done => {
+            bothAgree(24, pic => {
+                const small = X.AllocID();
+                X.CreatePixmap(small, root, 24, 4, 4);
+                const smallPic = X.AllocID();
+                render.CreatePicture(smallPic, small, render.rgb24);
+                render.FillRectangles(render.PictOp.Src, smallPic, [0xffff, 0, 0xffff, 0xffff],
+                    [0, 0, 4, 4]);
+                render.ChangePicture(smallPic, { repeat: 1 });
+                render.Composite(render.PictOp.Src, smallPic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'repeating small source', done);
+        });
+
+        it('a transformed source falls back and still matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 7);
+                // the client encoder takes plain numbers and converts to 16.16
+                render.SetPictureTransform(src.pic, [2, 0, 0, 0, 2, 0, 0, 0, 1]);
+                render.Composite(render.PictOp.Src, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'transformed source', done);
+        });
+
+        it('a clipped blit matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 5);
+                render.SetPictureClipRectangles(pic, 0, 0, [2, 2, 9, 9, 13, 5, 7, 7]);
+                render.Composite(render.PictOp.Src, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'clipped blit', done);
+        });
+
+        it('a clipped alpha blit onto depth 32 matches', done => {
+            bothAgree(32, pic => {
+                const src = mkSourcePixmap(32, 3);
+                render.SetPictureClipRectangles(pic, 0, 0, [1, 1, 12, 12, 8, 6, 12, 8]);
+                render.Composite(render.PictOp.Over, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'clipped alpha blit', done);
+        });
+
+        it('a clipped solid source matches', done => {
+            bothAgree(24, pic => {
+                const solid = X.AllocID();
+                render.CreateSolidFill(solid, [0x4000, 0x8000, 0x2000, 0x9000]);
+                render.SetPictureClipRectangles(pic, 0, 0, [3, 1, 7, 11, 12, 2, 8, 9]);
+                render.Composite(render.PictOp.Over, solid, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'clipped solid source', done);
+        });
+
+        it('an empty clip list draws nothing, both ways', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 3);
+                render.SetPictureClipRectangles(pic, 0, 0, []);
+                render.Composite(render.PictOp.Src, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'empty clip', done);
+        });
+
+        it('a masked composite falls back and still matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 3);
+                const maskPixmap = X.AllocID();
+                X.CreatePixmap(maskPixmap, root, 8, W, H);
+                const mask = X.AllocID();
+                render.CreatePicture(mask, maskPixmap, render.a8);
+                render.FillRectangles(render.PictOp.Src, mask, [0, 0, 0, 0x8000], [0, 0, W, H]);
+                render.Composite(render.PictOp.Over, src.pic, mask, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'masked composite', done);
+        });
+    });
+});


### PR DESCRIPTION
The JS X server's RENDER compositor had one loop for everything. Per pixel
it called the source sampler, the clip test, the destination read, the
blend-factor lookup and the destination write — and the blend lookup
returned a fresh two-element array each time, which made the garbage
collector a measurable share of a repaint. It ran at roughly 20–50
megapixels per second, and since a window repaint is a few hundred thousand
pixels, a hover restyle cost tens of milliseconds.

**The general loop is untouched.** It still handles every operator,
transform, filter, repeat mode, mask and coverage function, and it is still
what runs whenever a specialisation does not apply. What is new is that the
two spans a toolkit spends its time in are recognised before the loop
starts, and that clipped drawing no longer opts out of them.

## What is specialised

- **A solid source into a depth-24 destination** has constant blend
  factors, because such a destination reads back alpha 255 everywhere. When
  the destination contributes nothing (Src, Clear, In, Out) every pixel
  takes the same value, so the span becomes a `fill` — which is what a
  window background, a panel and a button face are.
- **An untransformed, unfiltered blit** whose texels all land inside the
  source is a row copy for Src between matching depths, and otherwise a
  per-pixel blend that indexes the source raster directly instead of going
  through the sampler closure.

Rows are painted as merged `[start, end)` intervals instead of pixel by
pixel, so a clip list costs one span computation per row rather than a call
per pixel. That turned out to matter more than anything else here: in a
react-x11 window repaint, **more than half of all composited pixels were
being rejected from the fast paths for no reason other than a clip being
set**, and a toolkit clips constantly — every overflow box, every rounded
corner, every scrolling viewport.

The intervals are merged deliberately. Overlapping clip rectangles would
otherwise composite a pixel twice, which is invisible for Src and wrong for
Over and every other non-idempotent operator.

## Numbers

`scripts/bench-render.js` (new), megapixels per second:

| span | before | after |
| --- | ---: | ---: |
| FillRectangles Src (opaque) | 49 | **8310** |
| FillRectangles Over (alpha) | 48.7 | 65 |
| Composite Src, untransformed | 27.7 | **793** |
| Composite Over, untransformed | 18 | **79.8** |
| Composite Over, linear gradient | 15.7 | 17 |
| FillRectangles Src, 2 clip rects | 27.7 | **4420** |

End to end: a text-heavy react-x11 window repainting on pointer motion goes
from about **29.5 ms per move to about 16.3 ms** (median of three runs each,
driven through the in-process server).

The two spans that barely moved are honest limits, not oversights — an
alpha fill and a gradient are irreducibly per-pixel in JavaScript. See the
second commit.

## Correctness

A specialisation is only safe if it is indistinguishable from the general
loop, so `test/xserver/render-fastpath.js` asserts exactly that: 74
scenarios, each rendered twice — once with the fast paths on, once with
them off through a `_setFastPaths` test hook — with the destination rasters
compared cell by cell.

It covers every operator, both destination depths, both source depths,
offset sub-rectangle blits, clip lists that are overlapping, unsorted,
origin-offset and empty, and the cases that must *bail out* and take the
general path anyway: a repeating source smaller than the region, a
transformed source, a masked composite.

The existing suite is unchanged and still passes (311 tests).

## Second commit: the canvas question

`browser/CANVAS-RENDER.md` is an investigation, no behaviour change. RENDER's
operators are Porter-Duff and so is `globalCompositeOperation` — thirteen of
the fourteen map exactly, and gradients, clips, patterns and trapezoids line
up nearly as well. So the mapping was never the hard part.

Measured against canvas 2D (headless Chrome, SwiftShader): alpha fills
65 → 7916, alpha blits 80 → 1552, gradients 17 → 365. Where a span reduces
to a memset or memcpy the optimised software path now wins or ties, so the
remaining gap is precisely the per-pixel blending JavaScript cannot
vectorise.

The surprise was readback — `getImageData` runs at 888 Mpx/s, so pulling a
whole 640×480 screen out of a canvas costs about 0.35 ms. The assumption
that a canvas backend would be sunk by per-frame readback does not survive
the measurement.

What does block a drop-in: core drawing, `compose()`, `GetImage`,
`PutImage`, `CopyArea` and the GLX emulator all read the `Uint32Array`
rasters directly, and canvas `ImageData` is straight alpha where RENDER is
premultiplied. Both point the same way — it is a pixel-storage backend, not
an extension swap. The note sets out the raster-interface shape that would
work, what must fall back to the software loop (Saturate, projective
transforms, Pad/Reflect repeat, convolution), and an order of work where
each step is useful on its own.
