### PR TITLE
perf(xserver): fast paths for a8 coverage masks and 1x1 repeating paint

### DIFF
--- a/lib/xserver/DESIGN.md
+++ b/lib/xserver/DESIGN.md
@@ -100,10 +100,28 @@ actually emits are specialised, in `compositeSpanFast` and in
 
 | span | what it becomes |
 |---|---|
-| solid source, depth-24 destination, operator with no destination term (Src, Clear, In, Out) | `TypedArray.fill` per span |
-| solid source, any other operator | per-pixel blend with the factors hoisted out |
-| untransformed unfiltered blit, all texels inside the source, Src, matching depths | row copy (`set`) at depth 32, masked row copy at depth 24 |
+| constant source, depth-24 or a8 destination, operator with no destination term (Src, Clear, In, Out) | `TypedArray.fill` per span |
+| constant source, any other operator or depth | per-pixel blend with the factors hoisted out where the operator allows |
+| untransformed unfiltered blit, all texels inside the source, Src, matching depths | row copy (`set`) at depth 32, masked row copy at depth 24 and a8 |
 | untransformed unfiltered blit, other operators | per-pixel blend with no sampler call |
+| a8 to a8 blit | alpha-only loop; a copy for Src |
+| source through a **direct a8 mask** (`compositeSpanMasked`) | mask read straight from its raster, source either constant or a matching blit |
+
+**"Constant source" is not the same as "solid picture".** A toolkit
+routinely expresses flat paint as a **1x1 pixmap with repeat** rather than
+through `CreateSolidFill` — ntk does — and such a picture samples to the
+same texel at every coordinate whatever the transform. `constantColorOf`
+recognises both, and without it the constant-source paths almost never fire
+on real drawing: in a react-x11 repaint every single masked composite was
+falling through to the general loop for that one reason.
+
+Coverage masks are the other thing worth knowing about. A toolkit draws
+antialiased shapes and runs of text by rasterising coverage into an a8
+picture and compositing paint through it, so a8 fills, a8 blits and
+"source through an a8 mask" are three of the four biggest spans in a real
+repaint. They were all excluded from the fast paths at first, and adding
+them took the share of composited pixels on a specialised path from about
+40% to **98.6%** — the remainder being the trapezoid coverage path.
 
 Rows are painted as a list of `[start, end)` intervals: the whole row when
 there is no clip, and the clip's spans for that row otherwise
@@ -127,6 +145,12 @@ checked before the loop rather than inside it.
 twice, once with `_setFastPaths(false)`, and the two destination rasters are
 compared cell by cell. `scripts/bench-render.js` reports the throughput that
 motivates them.
+
+That equivalence check has one blind spot worth remembering: a scenario
+where *neither* path is taken passes trivially. When adding a
+specialisation, confirm it actually fires — a benchmark row that moves, or
+the pixel-bucket counting described above — rather than trusting a green
+suite.
 
 ## Raster contract (`raster.js`)
 

--- a/lib/xserver/extensions/render.js
+++ b/lib/xserver/extensions/render.js
@@ -147,6 +147,19 @@ function blendFactors(op, as, ad, out) {
     }
 }
 
+/**
+ * True when this operator's factors do not depend on the destination alpha,
+ * in which case a constant-alpha source gives one pair of factors for a
+ * whole span. Probed rather than listed, so it cannot drift out of step with
+ * blendFactors; `out` is left holding those factors.
+ */
+function constantFactors(op, as, out) {
+    const lo = [0, 0];
+    blendFactors(op, as, 0, lo);
+    blendFactors(op, as, 1, out);
+    return lo[0] === out[0] && lo[1] === out[1];
+}
+
 // Fast paths specialise the common spans (constant source, untransformed
 // blit, plain fill) and must agree with the general loop pixel for pixel.
 // The toggle is a test hook, not protocol API: test/xserver/render-fastpath.js
@@ -502,6 +515,32 @@ function makeSampler(pict) {
     };
 }
 
+/**
+ * The one colour this picture samples to everywhere, or null if it varies.
+ *
+ * A solid fill is the obvious case. The other one matters more in practice:
+ * toolkits routinely express flat paint as a **1x1 pixmap with repeat**,
+ * which samples to the same texel at every coordinate no matter the
+ * transform — ntk does exactly this, so without it the constant-source fast
+ * paths almost never fire on real drawing.
+ *
+ * Repeat None is excluded because outside the single texel it is transparent
+ * black rather than the texel, and a convolution filter is excluded because
+ * it scales the result by the kernel sum.
+ */
+function constantColorOf(pict) {
+    if (pict.kind === 'solid')
+        return pict.color;
+    if (!pict.drawable || pict.repeat === 0)
+        return null;
+    if (pict.filter === 'convolution' && pict.filterParams && pict.filterParams.length > 2)
+        return null;
+    const raster = pict.drawable.raster;
+    if (!raster || raster.width !== 1 || raster.height !== 1)
+        return null;
+    return readPx(raster, pict.format.depth, 0, 0, [0, 0, 0, 0]);
+}
+
 // Can compositeSpanFast blit straight out of this picture's raster? Only
 // when nothing between the source coordinate and the texel bends it: no
 // transform (the callers' half-pixel offsets then floor back to the integer
@@ -538,10 +577,17 @@ function compositeSpan(server, op, sample, srcX, srcY, mask, dst, dstX, dstY, w,
     if (y0 >= y1 || x0 >= x1)
         return;
 
-    if (fastPaths && srcPict && !mask && !coverage &&
-        compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY,
-            x0, y0, x1, y1, clip ? sortedClip(dst) : null))
-        return;
+    if (fastPaths && srcPict && !coverage) {
+        const rows = clip ? sortedClip(dst) : null;
+        if (!mask) {
+            if (compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY,
+                x0, y0, x1, y1, rows))
+                return;
+        } else if (compositeSpanMasked(op, srcPict, srcX, srcY, mask, raster, depth,
+            dstX, dstY, x0, y0, x1, y1, rows)) {
+            return;
+        }
+    }
 
     const s = [0, 0, 0, 0];
     const m = [0, 0, 0, 0];
@@ -606,9 +652,9 @@ function compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY, x
         return clipRowSpans(clip, Y, x0, x1, spans);
     };
 
-    // (1) constant source: a solid picture. Gradients and drawables vary
-    // per pixel and fall through.
-    const c = srcPict.kind === 'solid' ? srcPict.color : null;
+    // (1) constant source: a solid picture, or a 1x1 repeating one.
+    // Gradients and larger drawables vary per pixel and fall through.
+    const c = constantColorOf(srcPict);
     if (c) {
         const sa = c[0], sr = c[1], sg = c[2], sb = c[3];
         if (depth === 24) {
@@ -662,7 +708,43 @@ function compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY, x
             }
             return true;
         }
-        return false; // depth 8 / 1: rare, leave to the general loop
+        if (depth === 8) {
+            // an a8 destination carries alpha only, so only sa matters
+            const fac = [0, 0];
+            if (constantFactors(op, sa / 255, fac)) {
+                const fa = fac[0], fb = fac[1];
+                if (fb === 0) {
+                    const px = clamp255(sa * fa);
+                    for (let Y = y0; Y < y1; Y++) {
+                        const sp = rowSpans(Y);
+                        for (let k = 0; k < sp.length; k += 2)
+                            data.fill(px, Y * W + sp[k], Y * W + sp[k + 1]);
+                    }
+                    return true;
+                }
+                for (let Y = y0; Y < y1; Y++) {
+                    const row = Y * W;
+                    const sp = rowSpans(Y);
+                    for (let k = 0; k < sp.length; k += 2)
+                        for (let X = sp[k]; X < sp[k + 1]; X++)
+                            data[row + X] = clamp255(sa * fa + (data[row + X] & 0xff) * fb);
+                }
+                return true;
+            }
+            for (let Y = y0; Y < y1; Y++) {
+                const row = Y * W;
+                const sp = rowSpans(Y);
+                for (let k = 0; k < sp.length; k += 2) {
+                    for (let X = sp[k]; X < sp[k + 1]; X++) {
+                        const da = data[row + X] & 0xff;
+                        blendFactors(op, sa / 255, da / 255, fac);
+                        data[row + X] = clamp255(sa * fac[0] + da * fac[1]);
+                    }
+                }
+            }
+            return true;
+        }
+        return false; // depth 1: rare, leave to the general loop
     }
 
     // (2) untransformed nearest blit between rgb24/rgba32 pictures, with
@@ -671,7 +753,11 @@ function compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY, x
         return false;
     const srcRaster = srcPict.drawable.raster;
     const srcDepth = srcPict.format.depth;
-    if ((srcDepth !== 24 && srcDepth !== 32) || (depth !== 24 && depth !== 32))
+    const colourBlit = (srcDepth === 24 || srcDepth === 32) && (depth === 24 || depth === 32);
+    // a8 to a8 is its own case: both sides are alpha-only, and it is how a
+    // coverage mask gets copied around
+    const alphaBlit = srcDepth === 8 && depth === 8;
+    if (!colourBlit && !alphaBlit)
         return false;
     const sx0 = srcX + (x0 - dstX);
     const sy0 = srcY + (y0 - dstY);
@@ -684,6 +770,28 @@ function compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY, x
     // source index of destination (X, Y): srcX/srcY track dstX/dstY one to one
     const sdx = srcX - dstX;
     const sdy = srcY - dstY;
+
+    if (alphaBlit) {
+        const fac = [0, 0];
+        for (let Y = y0; Y < y1; Y++) {
+            const row = Y * W;
+            const srow = (Y + sdy) * sW + sdx;
+            const sp = rowSpans(Y);
+            for (let k = 0; k < sp.length; k += 2) {
+                for (let X = sp[k]; X < sp[k + 1]; X++) {
+                    const sa = sData[srow + X] & 0xff;
+                    if (op === 1) { // Src: a masked copy (the cell's top bits
+                        data[row + X] = sa; // are not part of an a8 pixel)
+                        continue;
+                    }
+                    const da = data[row + X] & 0xff;
+                    blendFactors(op, sa / 255, da / 255, fac);
+                    data[row + X] = clamp255(sa * fac[0] + da * fac[1]);
+                }
+            }
+        }
+        return true;
+    }
 
     // Src between identical layouts is a copy.
     if (op === 1 && srcDepth === depth) {
@@ -728,6 +836,106 @@ function compositeSpanFast(op, srcPict, srcX, srcY, raster, depth, dstX, dstY, x
                 const b = clamp255((spx & 0xff) * fa + (p & 0xff) * fb);
                 data[row + X] = depth === 32
                     ? ((a << 24) | (r << 16) | (g << 8) | b) >>> 0
+                    : ((r << 16) | (g << 8) | b) >>> 0;
+            }
+        }
+    }
+    return true;
+}
+
+// -------------------------------------------------------------------
+// Source through an a8 coverage mask — how a toolkit draws every
+// antialiased shape and every run of text: rasterise coverage into an a8
+// picture once, then composite the paint through it. The general loop pays
+// two sampler calls per pixel for this; here the mask is read straight out
+// of its raster and the source is either one colour or a matching blit.
+//
+// Restricted to what is actually emitted: a depth-8 mask with no transform
+// or resampling filter, entirely inside its own raster, and a destination
+// of depth 24 or 32. Anything else returns false for the general loop.
+
+function compositeSpanMasked(op, srcPict, srcX, srcY, mask, raster, depth,
+    dstX, dstY, x0, y0, x1, y1, clip) {
+    const maskPict = mask.pict;
+    if (!maskPict || maskPict.format.depth !== 8 || !isDirectSource(maskPict))
+        return false;
+    if (depth !== 24 && depth !== 32)
+        return false;
+
+    const mRaster = maskPict.drawable.raster;
+    const mx0 = mask.x + (x0 - dstX);
+    const my0 = mask.y + (y0 - dstY);
+    if (mx0 < 0 || my0 < 0 ||
+        mx0 + (x1 - x0) > mRaster.width || my0 + (y1 - y0) > mRaster.height)
+        return false;
+
+    // the source: one colour, or a blit lined up with the destination
+    const solid = constantColorOf(srcPict);
+    let sData = null, sW = 0, sdx = 0, sdy = 0, srcDepth = 0;
+    if (!solid) {
+        if (!isDirectSource(srcPict))
+            return false;
+        srcDepth = srcPict.format.depth;
+        if (srcDepth !== 24 && srcDepth !== 32)
+            return false;
+        const sRaster = srcPict.drawable.raster;
+        const sx0 = srcX + (x0 - dstX);
+        const sy0 = srcY + (y0 - dstY);
+        if (sx0 < 0 || sy0 < 0 ||
+            sx0 + (x1 - x0) > sRaster.width || sy0 + (y1 - y0) > sRaster.height)
+            return false;
+        sData = sRaster.data;
+        sW = sRaster.width;
+        sdx = srcX - dstX;
+        sdy = srcY - dstY;
+    }
+
+    const data = raster.data;
+    const W = raster.width;
+    const mData = mRaster.data;
+    const mW = mRaster.width;
+    const mdx = mask.x - dstX;
+    const mdy = mask.y - dstY;
+    const spans = [];
+    const fac = [0, 0];
+
+    for (let Y = y0; Y < y1; Y++) {
+        const row = Y * W;
+        const mrow = (Y + mdy) * mW + mdx;
+        const srow = solid ? 0 : (Y + sdy) * sW + sdx;
+        let sp;
+        if (clip) {
+            sp = clipRowSpans(clip, Y, x0, x1, spans);
+        } else {
+            spans.length = 0;
+            spans.push(x0, x1);
+            sp = spans;
+        }
+        for (let k = 0; k < sp.length; k += 2) {
+            for (let X = sp[k]; X < sp[k + 1]; X++) {
+                const f = (mData[mrow + X] & 0xff) / 255;
+                let sa, sr, sg, sb;
+                if (solid) {
+                    sa = solid[0] * f;
+                    sr = solid[1] * f;
+                    sg = solid[2] * f;
+                    sb = solid[3] * f;
+                } else {
+                    const spx = sData[srow + X];
+                    sa = (srcDepth === 32 ? (spx >>> 24) & 0xff : 255) * f;
+                    sr = ((spx >>> 16) & 0xff) * f;
+                    sg = ((spx >>> 8) & 0xff) * f;
+                    sb = (spx & 0xff) * f;
+                }
+                const p = data[row + X];
+                const da = depth === 32 ? (p >>> 24) & 0xff : 255;
+                blendFactors(op, sa / 255, da / 255, fac);
+                const fa = fac[0], fb = fac[1];
+                const r = clamp255(sr * fa + ((p >>> 16) & 0xff) * fb);
+                const g = clamp255(sg * fa + ((p >>> 8) & 0xff) * fb);
+                const b = clamp255(sb * fa + (p & 0xff) * fb);
+                data[row + X] = depth === 32
+                    ? ((clamp255(sa * fa + da * fb) << 24) | (r << 16) | (g << 8) | b) >>> 0
                     : ((r << 16) | (g << 8) | b) >>> 0;
             }
         }
@@ -877,8 +1085,11 @@ function composite(server, body) {
     const dstY = body.readInt16LE(26);
     const w = body.readUInt16LE(28);
     const h = body.readUInt16LE(30);
-    const mask = maskId
-        ? { sample: makeSampler(getPicture(server, maskId)), x: maskX, y: maskY }
+    // `pict` rides along so compositeSpanMasked can read a plain a8 mask
+    // straight out of its raster instead of going through the sampler
+    const maskPict = maskId ? getPicture(server, maskId) : null;
+    const mask = maskPict
+        ? { sample: makeSampler(maskPict), x: maskX, y: maskY, pict: maskPict }
         : null;
     compositeSpan(server, op, makeSampler(src), srcX, srcY, mask, dst, dstX, dstY, w, h, null, src);
     damage(server, dst);
@@ -909,6 +1120,12 @@ function fillRectangles(server, body) {
         if (fac[1] === 0)
             solidPx = ((clamp255(color[1] * fac[0]) << 16) |
                 (clamp255(color[2] * fac[0]) << 8) | clamp255(color[3] * fac[0])) >>> 0;
+    } else if (fastPaths && depth === 8 && constantFactors(op, color[0] / 255, fac) &&
+        fac[1] === 0) {
+        // an a8 picture holds alpha only, so a constant-factor operator that
+        // ignores the destination writes one value everywhere. Clearing and
+        // filling coverage masks is a big share of a toolkit's traffic.
+        solidPx = clamp255(color[0] * fac[0]);
     }
     const sorted = solidPx >= 0 && clip ? sortedClip(dst) : null;
     const spans = [];

--- a/scripts/bench-render.js
+++ b/scripts/bench-render.js
@@ -165,7 +165,22 @@ function setup() {
     const argb = id();
     call(REQ.CreatePicture, bodyCreatePicture(argb, argbPix, 0x101 /* rgba32 */));
 
-    return { server, call, dst, src, argb };
+    // a8 coverage pictures: a destination to fill and blit into, a source to
+    // blit from, and the mask a toolkit composites paint through
+    const a8DstPix = id();
+    server.resources.set(a8DstPix, makePixmap(server, W, H, 8));
+    const a8Dst = id();
+    call(REQ.CreatePicture, bodyCreatePicture(a8Dst, a8DstPix, 0x103 /* a8 */));
+
+    const a8SrcPix = id();
+    const a8SrcRaster = makePixmap(server, W, H, 8);
+    server.resources.set(a8SrcPix, a8SrcRaster);
+    for (let i = 0; i < a8SrcRaster.raster.data.length; i++)
+        a8SrcRaster.raster.data[i] = i & 0xff;
+    const a8Src = id();
+    call(REQ.CreatePicture, bodyCreatePicture(a8Src, a8SrcPix, 0x103));
+
+    return { server, call, dst, src, argb, a8Dst, a8Src };
 }
 
 const { Raster } = require('../lib/xserver/raster');
@@ -196,7 +211,7 @@ function time(label, pixelsPerCall, fn) {
 }
 
 function main() {
-    const { call, dst, src, argb } = setup();
+    const { call, dst, src, argb, a8Dst, a8Src } = setup();
     const AREA = 512 * 384; // a window-sized region
     const rows = [];
 
@@ -211,6 +226,15 @@ function main() {
 
     rows.push(time('Composite Over, untransformed', AREA, () =>
         call(REQ.Composite, bodyComposite(3, argb, 0, dst, 0, 0, 0, 0, 0, 0, 512, 384))));
+
+    rows.push(time('FillRectangles Src onto a8 (mask clear)', AREA, () =>
+        call(REQ.FillRectangles, bodyFillRectangles(1, a8Dst, [0, 0, 0, 0x8000], [[0, 0, 512, 384]]))));
+
+    rows.push(time('Composite Src, a8 -> a8', AREA, () =>
+        call(REQ.Composite, bodyComposite(1, a8Src, 0, a8Dst, 0, 0, 0, 0, 0, 0, 512, 384))));
+
+    rows.push(time('Composite Over through an a8 mask', AREA, () =>
+        call(REQ.Composite, bodyComposite(3, argb, a8Src, dst, 0, 0, 0, 0, 0, 0, 512, 384))));
 
     // gradient source
     const grad = id();

--- a/test/xserver/render-fastpath.js
+++ b/test/xserver/render-fastpath.js
@@ -42,17 +42,22 @@ describe('xserver: RENDER fast paths', () => {
         server = display = X = render = null;
     });
 
-    // depth-24 or depth-32 destination, seeded with a gradient-ish pattern so
-    // that every destination channel (and, at depth 32, every destination
-    // alpha) is exercised rather than a single flat value
+    // destination seeded with a gradient-ish pattern so that every channel
+    // (and, at depth 32 or 8, every destination alpha) is exercised rather
+    // than a single flat value
     function mkDest(depth) {
         const pixmap = X.AllocID();
         X.CreatePixmap(pixmap, root, depth, W, H);
         const pic = X.AllocID();
-        render.CreatePicture(pic, pixmap, depth === 32 ? render.rgba32 : render.rgb24);
-        const rects = [];
-        for (let y = 0; y < H; y++)
-            rects.push(0, y, W, 1);
+        render.CreatePicture(pic, pixmap,
+            depth === 32 ? render.rgba32 : depth === 8 ? render.a8 : render.rgb24);
+        if (depth === 8) {
+            for (let y = 0; y < H; y++) {
+                const a = Math.round((y / (H - 1)) * 65535);
+                render.FillRectangles(render.PictOp.Src, pic, [0, 0, 0, a], [0, y, W, 1]);
+            }
+            return { pixmap, pic };
+        }
         for (let y = 0; y < H; y++) {
             const v = Math.round((y / (H - 1)) * 65535);
             render.FillRectangles(render.PictOp.Src, pic,
@@ -62,7 +67,23 @@ describe('xserver: RENDER fast paths', () => {
         return { pixmap, pic };
     }
 
+    // an a8 picture seeded with a coverage ramp, the shape a toolkit
+    // rasterises an antialiased edge into
+    function mkAlphaPixmap(seed) {
+        const pixmap = X.AllocID();
+        X.CreatePixmap(pixmap, root, 8, W, H);
+        const pic = X.AllocID();
+        render.CreatePicture(pic, pixmap, render.a8);
+        for (let x = 0; x < W; x++) {
+            const a = Math.round((((x * seed) % W) / (W - 1)) * 65535);
+            render.FillRectangles(render.PictOp.Src, pic, [0, 0, 0, a], [x, 0, 1, H]);
+        }
+        return { pixmap, pic };
+    }
+
     function mkSourcePixmap(depth, seed) {
+        if (depth === 8)
+            return mkAlphaPixmap(seed);
         const pixmap = X.AllocID();
         X.CreatePixmap(pixmap, root, depth, W, H);
         const pic = X.AllocID();
@@ -109,7 +130,7 @@ describe('xserver: RENDER fast paths', () => {
     }
 
     describe('FillRectangles matches the general loop', () => {
-        for (const depth of [24, 32]) {
+        for (const depth of [24, 32, 8]) {
             for (let op = 0; op < OPS.length; op++) {
                 it(`${OPS[op]} on depth ${depth}`, done => {
                     bothAgree(depth, pic => {
@@ -192,6 +213,52 @@ describe('xserver: RENDER fast paths', () => {
             }, 'solid source', done);
         });
 
+        // A 1x1 repeating pixmap is how toolkits express flat paint, and it
+        // has to reach the constant-source path rather than the blit path.
+        for (const repeat of [1, 2, 3]) {
+            it(`a 1x1 source with repeat ${repeat} matches`, done => {
+                bothAgree(24, pic => {
+                    const dot = X.AllocID();
+                    X.CreatePixmap(dot, root, 32, 1, 1);
+                    const dotPic = X.AllocID();
+                    render.CreatePicture(dotPic, dot, render.rgba32);
+                    render.FillRectangles(render.PictOp.Src, dotPic,
+                        [0x6000, 0x2000, 0xa000, 0xc000], [0, 0, 1, 1]);
+                    render.ChangePicture(dotPic, { repeat });
+                    render.Composite(render.PictOp.Over, dotPic, 0, pic,
+                        0, 0, 0, 0, 0, 0, W, H);
+                }, `1x1 repeat ${repeat}`, done);
+            });
+        }
+
+        it('a 1x1 source with repeat None still matches (it is not constant)', done => {
+            bothAgree(24, pic => {
+                const dot = X.AllocID();
+                X.CreatePixmap(dot, root, 32, 1, 1);
+                const dotPic = X.AllocID();
+                render.CreatePicture(dotPic, dot, render.rgba32);
+                render.FillRectangles(render.PictOp.Src, dotPic,
+                    [0x6000, 0x2000, 0xa000, 0xc000], [0, 0, 1, 1]);
+                render.Composite(render.PictOp.Over, dotPic, 0, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, '1x1 repeat None', done);
+        });
+
+        it('a transformed 1x1 repeating source matches', done => {
+            bothAgree(24, pic => {
+                const dot = X.AllocID();
+                X.CreatePixmap(dot, root, 24, 1, 1);
+                const dotPic = X.AllocID();
+                render.CreatePicture(dotPic, dot, render.rgb24);
+                render.FillRectangles(render.PictOp.Src, dotPic,
+                    [0, 0xffff, 0x4000, 0xffff], [0, 0, 1, 1]);
+                render.ChangePicture(dotPic, { repeat: 1 });
+                render.SetPictureTransform(dotPic, [3, 0, 0, 0, 3, 0, 0, 0, 1]);
+                render.Composite(render.PictOp.Src, dotPic, 0, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, 'transformed 1x1 repeat', done);
+        });
+
         it('a source smaller than the region falls back and still matches', done => {
             bothAgree(24, pic => {
                 const small = X.AllocID();
@@ -247,7 +314,7 @@ describe('xserver: RENDER fast paths', () => {
             }, 'empty clip', done);
         });
 
-        it('a masked composite falls back and still matches', done => {
+        it('a flat mask matches', done => {
             bothAgree(24, pic => {
                 const src = mkSourcePixmap(24, 3);
                 const maskPixmap = X.AllocID();
@@ -256,7 +323,137 @@ describe('xserver: RENDER fast paths', () => {
                 render.CreatePicture(mask, maskPixmap, render.a8);
                 render.FillRectangles(render.PictOp.Src, mask, [0, 0, 0, 0x8000], [0, 0, W, H]);
                 render.Composite(render.PictOp.Over, src.pic, mask, pic, 0, 0, 0, 0, 0, 0, W, H);
-            }, 'masked composite', done);
+            }, 'flat mask', done);
+        });
+    });
+
+    // How a toolkit draws every antialiased shape and every run of text:
+    // coverage into an a8 picture, then the paint composited through it.
+    describe('a8 coverage masks match the general loop', () => {
+        for (const srcDepth of [24, 32]) {
+            for (const dstDepth of [24, 32]) {
+                for (const op of [1, 3, 9, 12]) {
+                    it(`${OPS[op]}: depth ${srcDepth} through a mask onto depth ${dstDepth}`, done => {
+                        bothAgree(dstDepth, pic => {
+                            const src = mkSourcePixmap(srcDepth, 3);
+                            const mask = mkAlphaPixmap(5);
+                            render.Composite(op, src.pic, mask.pic, pic,
+                                0, 0, 0, 0, 0, 0, W, H);
+                        }, `masked ${OPS[op]} ${srcDepth}->${dstDepth}`, done);
+                    });
+                }
+            }
+        }
+
+        it('a 1x1 repeating source through a mask matches', done => {
+            bothAgree(24, pic => {
+                const dot = X.AllocID();
+                X.CreatePixmap(dot, root, 32, 1, 1);
+                const dotPic = X.AllocID();
+                render.CreatePicture(dotPic, dot, render.rgba32);
+                render.FillRectangles(render.PictOp.Src, dotPic,
+                    [0x9000, 0x3000, 0x5000, 0xd000], [0, 0, 1, 1]);
+                render.ChangePicture(dotPic, { repeat: 1 });
+                const mask = mkAlphaPixmap(5);
+                render.Composite(render.PictOp.Over, dotPic, mask.pic, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, '1x1 repeat through mask', done);
+        });
+
+        it('a solid source through a mask matches', done => {
+            bothAgree(24, pic => {
+                const solid = X.AllocID();
+                render.CreateSolidFill(solid, [0xc000, 0x2000, 0x6000, 0xffff]);
+                const mask = mkAlphaPixmap(3);
+                render.Composite(render.PictOp.Over, solid, mask.pic, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, 'solid through mask', done);
+        });
+
+        it('a mask offset by maskX/maskY matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 3);
+                const mask = mkAlphaPixmap(7);
+                render.Composite(render.PictOp.Over, src.pic, mask.pic, pic,
+                    1, 1, 4, 2, 2, 3, 12, 8);
+            }, 'offset mask', done);
+        });
+
+        it('a clipped masked composite matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(32, 3);
+                const mask = mkAlphaPixmap(5);
+                render.SetPictureClipRectangles(pic, 0, 0, [2, 2, 9, 9, 13, 5, 7, 7]);
+                render.Composite(render.PictOp.Over, src.pic, mask.pic, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, 'clipped masked composite', done);
+        });
+
+        it('a mask smaller than the region falls back and still matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 3);
+                const small = X.AllocID();
+                X.CreatePixmap(small, root, 8, 4, 4);
+                const mask = X.AllocID();
+                render.CreatePicture(mask, small, render.a8);
+                render.FillRectangles(render.PictOp.Src, mask, [0, 0, 0, 0x8000], [0, 0, 4, 4]);
+                render.ChangePicture(mask, { repeat: 1 });
+                render.Composite(render.PictOp.Over, src.pic, mask, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, 'repeating small mask', done);
+        });
+
+        it('a transformed mask falls back and still matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 3);
+                const mask = mkAlphaPixmap(5);
+                render.SetPictureTransform(mask.pic, [2, 0, 0, 0, 2, 0, 0, 0, 1]);
+                render.Composite(render.PictOp.Over, src.pic, mask.pic, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, 'transformed mask', done);
+        });
+
+        it('a depth-32 mask falls back and still matches', done => {
+            bothAgree(24, pic => {
+                const src = mkSourcePixmap(24, 3);
+                const mask = mkSourcePixmap(32, 5);
+                render.Composite(render.PictOp.Over, src.pic, mask.pic, pic,
+                    0, 0, 0, 0, 0, 0, W, H);
+            }, 'depth-32 mask', done);
+        });
+    });
+
+    describe('a8 pictures match the general loop', () => {
+        for (const op of [0, 1, 3, 5, 9, 11, 12, 13]) {
+            it(`${OPS[op]}: a8 source onto an a8 destination`, done => {
+                bothAgree(8, pic => {
+                    const src = mkAlphaPixmap(3);
+                    render.Composite(op, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+                }, `a8 blit ${OPS[op]}`, done);
+            });
+        }
+
+        it('a solid source onto an a8 destination matches', done => {
+            bothAgree(8, pic => {
+                const solid = X.AllocID();
+                render.CreateSolidFill(solid, [0, 0, 0, 0x9000]);
+                render.Composite(render.PictOp.Over, solid, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'solid onto a8', done);
+        });
+
+        it('a clipped a8 blit matches', done => {
+            bothAgree(8, pic => {
+                const src = mkAlphaPixmap(5);
+                render.SetPictureClipRectangles(pic, 0, 0, [2, 1, 8, 10, 12, 4, 8, 8]);
+                render.Composite(render.PictOp.Src, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'clipped a8 blit', done);
+        });
+
+        it('an a8 source onto a colour destination falls back and still matches', done => {
+            bothAgree(24, pic => {
+                const src = mkAlphaPixmap(3);
+                render.Composite(render.PictOp.Over, src.pic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
+            }, 'a8 onto rgb24', done);
         });
     });
 });


### PR DESCRIPTION
Follow-up to #237, driven by profiling the merged code rather than guessing.

Instrumenting a real react-x11 window repaint showed the new fast paths were
only taking about **40%** of composited pixels. The rest fell into three
buckets, and they turned out to be the same story told three ways — a
toolkit draws antialiased shapes and runs of text by rasterising coverage
into an a8 picture and compositing paint through it, and none of that was
covered:

| bucket | Mpx per repaint | why it fell through |
| --- | ---: | --- |
| `FillRectangles Src` onto a8 | 33.4 | the fast fill was depth-24 only |
| blit a8 → a8 | 30.0 | the fast blit required depth 24 or 32 |
| depth-32 source through a direct a8 mask, Over | 30.1 | any mask disabled every fast path |

## What was added

- **a8 fills.** An a8 picture holds alpha only, so a constant-factor
  operator that ignores the destination writes one value everywhere — a
  fill, exactly like the depth-24 case. This is how a coverage mask gets
  cleared.
- **a8 blits.** Alpha-only loop, a copy for Src.
- **`compositeSpanMasked`.** The paint-through-coverage span: a plain a8
  mask read straight out of its raster instead of through a sampler, with
  the source either constant or a blit lined up with the destination.
  Restricted to what is actually emitted — depth-8 mask, no transform or
  resampling filter, inside its own raster, destination depth 24 or 32 —
  and returns false for anything else.

## The finding worth keeping

After all that, **every masked composite was still falling through**, all of
them for one reason: the source was a **1×1 pixmap with repeat**.

That is how ntk expresses flat paint — not `CreateSolidFill`. Such a picture
samples to the same texel at every coordinate whatever the transform, so
`constantColorOf` now recognises it alongside a solid fill. Repeat None is
excluded (outside its one texel it is transparent black, not the texel) and
convolution filters are excluded (they scale by the kernel sum).

Without that one function the constant-source paths — including the ones
merged in #237 — almost never fire on real drawing.

Share of composited pixels on a specialised path: **about 40% → 98.6%**.
What remains is the trapezoid coverage path, at 1.4%.

## Numbers

`scripts/bench-render.js`, megapixels per second, against #237:

| span | before | after |
| --- | ---: | ---: |
| FillRectangles Src onto a8 (mask clear) | 54.4 | **8008** |
| Composite Src, a8 → a8 | 23.9 | **451** |
| Composite Over through an a8 mask | 11.8 | **81.5** |

The existing rows are unchanged within noise.

End to end, driving a text-heavy react-x11 window through pointer motion and
measuring time *inside* RENDER request handling against the pixels it
actually composited — a work-normalised figure, because how many repaints a
run performs varies:

```
published 3.2.1     ~8.5 s in RENDER
#237                 ~6.5 s     18.2 Mpx/s
this PR              ~0.5 s      128 Mpx/s
```

## Correctness

`test/xserver/render-fastpath.js` grows to **127 scenarios**, each still
rendered twice — fast paths on and off — with the destination rasters
compared cell by cell. New coverage: a8 destinations for every operator, a8
blits, masked composites across both source and destination depths, mask
offsets, clipped masked composites, 1×1 sources at every repeat mode
including None and under a transform, and the cases that must still fall
back (a mask smaller than the region, a transformed mask, a depth-32 mask).

One note added to `DESIGN.md` because it bit during this work: an
equivalence test where *neither* path is taken passes trivially. Every
specialisation here was confirmed to actually fire, by a benchmark row that
moved and by counting pixels per path — not by a green suite alone.

Full suite: 311 passing.
