### PR TITLE
feat(website): runnable demos inside the guides, and nine more of them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Details the script handles for you:
 | `docs/` | API reference: README + core protocol + one page per extension |
 | `examples/` | Runnable demos (need a real X server / XQuartz) |
 | `test/` | Mocha specs, driven by `test-runner.js` |
+| `website/` | The documentation site (Docusaurus); see below |
 
 ## Commit messages: conventional commits (required)
 
@@ -101,6 +102,52 @@ your working session:
   over indirect GLX — documented") so readers don't mistake them for gaps.
 - Say how the change was verified (which servers, pixel-level tests, suite
   totals).
+
+## The documentation site (`website/`)
+
+The site runs the library rather than describing it: `browser/index.js` is
+bundled with the JS X server into `static/demo/x11-demo-runtime.js`, and every
+live demo is real client code talking to a real server over a
+`registerDisplayProtocol('demo')` transport.
+
+Two rules keep it honest:
+
+1. **Demo code lives in `website/src/demos/*.js`, never inline in a page.**
+   Guides embed them by id — `<LiveDemo demo="shapes" compact />` — because
+   `scripts/check-demos.mjs` runs every file in that directory against the
+   real server and fails when a demo stops drawing. A snippet pasted into an
+   `.mdx` file is unchecked and will rot.
+2. **A guide page that needs JSX must be `.mdx`.** `docusaurus.config.js` sets
+   `format: 'detect'`, so a `.md` file silently renders `<LiveDemo …>` as
+   literal text. Renaming also breaks inbound `…​.md` links, which fails the
+   build — grep for the old name.
+
+`LiveDemo` is global via `src/theme/MDXComponents.js`, so no import is needed.
+It mounts its iframe on an IntersectionObserver: a page with eight demos boots
+two X servers, not eight. Keep that — each runner is a server compositing on a
+rAF loop.
+
+Awkward details worth knowing before they cost you an afternoon:
+
+- **The server's built-in font is ASCII only** (chars 0-127, 8x8). An em-dash
+  in an `ImageText8` string renders as a filled box. `check-demos.mjs` wraps
+  every client's text requests and fails on non-ASCII, so this is caught — but
+  write `:` not `—` in drawn strings.
+- **`ImageText8` fills the glyph cell with the GC's `background`** before
+  drawing the glyph. Set both colours or text lands on a black box.
+- **RENDER colours are floats 0..1 and clamped** (`colorToFix`). Passing
+  16-bit values like `0xffff`/`0x3000` silently yields 1.0, so a stop list
+  written in 16-bit comes out fully opaque.
+- **A client's own requests are never redirected to itself.** A window-manager
+  demo needs a second `createClient` for the windows it manages.
+- **`npx docusaurus serve` 301-redirects `/demo/runner.html`** to a path
+  without the baseUrl, so demos show the site's own homepage in the iframe.
+  That is a preview-only artifact — `npm start` and GitHub Pages both serve it
+  correctly. Verify a build with a plain static server, not with `serve`.
+
+Gates, all wired into `npm test` in `website/`: `check-demos` (every demo
+draws, reacts to injected input, animates if it should), `check-bundle` (the
+browser bundle boots and renders), `check-share` (share links round-trip).
 
 ## Conventions
 

--- a/website/docs/guides/events.mdx
+++ b/website/docs/guides/events.mdx
@@ -35,6 +35,12 @@ Commonly used mask bits include `Exposure`, `KeyPress`, `KeyRelease`,
 `LeaveWindow`, `StructureNotify`, `SubstructureNotify`,
 `SubstructureRedirect`, `PropertyChange` and `FocusChange`.
 
+The demo below selects a deliberately broad mask and prints every event the
+server sends. Click and type inside the X screen and watch the console fill —
+then narrow the mask in the editor, press Run, and see what stops arriving:
+
+<LiveDemo demo="event-log" compact />
+
 ## Event delivery
 
 All events arrive through a single `'event'` emitter on the client. Every
@@ -64,8 +70,43 @@ X.on('event', ev => {
 });
 ```
 
+Pointer events carry both window-relative (`x`, `y`) and screen-relative
+(`rootx`, `rooty`) coordinates. Drag inside this one to paint with them:
+
+<LiveDemo demo="pointer-paint" compact />
+
+Keyboard events are lower-level than you may expect: a `KeyPress` carries a
+*keycode*, which is a physical key number, not a character. Turning it into
+something printable means looking up the keysym through
+`GetKeyboardMapping` and applying the modifier state yourself:
+
+<LiveDemo demo="keyboard" compact />
+
 Every core event and its fields is documented in the
 [core events reference](../reference/core-events.md).
+
+## Redirection
+
+Two mask bits are not notifications but *interceptions*. A client holding
+`SubstructureRedirect` on a window receives `MapRequest`, `ConfigureRequest`
+and `CirculateRequest` for its children **instead of those requests taking
+effect** — the server asks permission rather than reporting a fact.
+
+That is the entire mechanism a window manager is built from. There is no
+privileged API and no special connection: selecting one event mask on the root
+window is what makes a program a window manager, and only one client at a time
+may hold it (a second gets `BadAccess`, which is how a WM discovers another is
+already running).
+
+A client's own requests are never redirected back to itself, so the demo below
+opens **two** connections — one managing the screen, one for the toy
+applications. Drag either window by its title bar; neither application drew
+that bar, or knows it exists:
+
+<LiveDemo demo="window-manager" compact />
+
+Redirection is also skipped for override-redirect windows, which is how menus
+and tooltips escape being framed.
 
 ## Extension events
 

--- a/website/docs/guides/extensions.mdx
+++ b/website/docs/guides/extensions.mdx
@@ -24,6 +24,22 @@ X.require('randr', (err, Randr) => {
 on-the-wire extension name. Requiring an extension twice returns the cached
 instance.
 
+An absent extension gives you an `err` rather than throwing, so the callback
+is also where you put your fallback. This demo requires RENDER and uses it to
+do something the core protocol cannot — blend two translucent rectangles:
+
+<LiveDemo demo="guide-extension" compact />
+
+:::info The in-page X server implements three of these
+
+The live demos on this site run against the pure-JavaScript X server in
+`lib/xserver`, which registers BIG-REQUESTS, XC-MISC and RENDER (plus GLX in
+the browser build, backed by WebGL). `X.require('randr')` and friends will
+report the extension as missing here — the client supports all of them, but
+you need a real server to talk to.
+
+:::
+
 ## Available extensions
 
 | module | X name | what it does |

--- a/website/docs/guides/getting-started.mdx
+++ b/website/docs/guides/getting-started.mdx
@@ -87,6 +87,15 @@ Resource ids (windows, pixmaps, GCs, …) are allocated client-side with
 is destroyed. When you are done with the connection, call `X.terminate()`;
 the client emits `'end'` when the stream closes.
 
+That is already enough for a whole program. This one runs here, in this page,
+against a pure-JavaScript X server compositing to the canvas above the editor
+— no display, no `DISPLAY`, nothing installed. Edit it and press Run.
+
+<LiveDemo demo="guide-create-window" compact />
+
+Every demo on this site works the same way, and the code is the code you
+would run in node. The [playground](/playground) has the longer ones.
+
 ## Error handling
 
 X errors arrive asynchronously. Errors caused by a request with a reply are

--- a/website/docs/guides/windows-and-drawing.mdx
+++ b/website/docs/guides/windows-and-drawing.mdx
@@ -38,6 +38,8 @@ X.CreateWindow(wid, root, 0, 0, 500, 500, 0, 0, 0, 0, {
 
 A window becomes visible only after `X.MapWindow(wid)`.
 
+<LiveDemo demo="guide-create-window" compact />
+
 ## Graphics contexts
 
 All core drawing requests take a graphics context (GC) that carries pen
@@ -54,6 +56,14 @@ X.CreateGC(gc, wid, {
 
 GCs can be mutated later with `ChangeGC(gc, values)` and freed with
 `FreeGC(gc)`.
+
+The GC is where nearly all drawing state lives, which is why the same request
+can produce very different ink. Below, `PolyFillRectangle` is called four
+times with identical arguments — only `ChangeGC` differs between them, and the
+last one switches the raster operation to `GXxor` so it combines with what is
+already on screen instead of replacing it:
+
+<LiveDemo demo="guide-gc" compact />
 
 ## Drawing requests
 
@@ -72,6 +82,21 @@ X.on('event', ev => {
 Draw from an `Expose` handler — the server does not preserve window contents
 for you, and `Expose` tells you when (part of) the window needs repainting.
 
+There are no paths and no curves beyond the ellipse: every shape is one
+request carrying a flat list of 16-bit coordinates. Note that `PolyLine` and
+`PolyPoint` take `coordMode` as their *first* argument while every other
+drawing request takes the drawable first — an inconsistency worth knowing
+before it costs you an afternoon:
+
+<LiveDemo demo="shapes" compact />
+
+Drawing can also be masked. A clip list installed on the GC with
+`SetClipRectangles` turns it into a stencil, which is how core X11 produces
+shapes it has no request for — the fill is ordinary, the rectangle list is
+the shape:
+
+<LiveDemo demo="clip-rects" compact />
+
 Pixmaps are off-screen drawables, useful for double buffering:
 
 ```js
@@ -81,6 +106,13 @@ X.CreatePixmap(pixmap, wid, depth, width, height);
 X.CopyArea(pixmap, wid, gc, 0, 0, 0, 0, width, height);
 ```
 
+`CopyArea` is a server-side blit: no pixel data crosses the connection, which
+makes "draw once into a pixmap, then move it" the cheapest animation the core
+protocol offers. The demo below scrolls a 960×200 pixmap drawn a single time,
+at two requests per frame:
+
+<LiveDemo demo="copy-area" compact />
+
 The complete list of drawing requests — `PolyPoint`, `PolySegment`,
 `PolyArc`, `FillPoly`, `PutImage`, `GetImage`, `CopyPlane` and friends — is
 in the [core requests reference](../reference/core-requests.md).
@@ -89,35 +121,37 @@ in the [core requests reference](../reference/core-requests.md).
 
 The core protocol only does flat 1-bit-coverage drawing. For anti-aliasing,
 alpha blending and gradients, load the [RENDER](../reference/ext/render.md)
-extension. Abridged from `examples/simple/gradients.js`:
+extension. Its unit of work is the *Picture*: a drawable wrapped in a pixel
+format, or — for gradients and solid fills — no drawable at all.
 
-```js
-X.require('render', (err, Render) => {
-  const win = X.AllocID();
-  X.CreateWindow(win, display.screen[0].root, 0, 0, 500, 500, 0, 0, 0, 0, {
-    backgroundPixel: display.screen[0].white_pixel,
-    eventMask: x11.eventMask.Exposure,
-  });
-  X.MapWindow(win);
+:::note Colour components are floats
 
-  // a Picture wraps a drawable for use with RENDER
-  const picture = X.AllocID();
-  Render.CreatePicture(picture, win, Render.rgb24, { polyEdge: 1, polyMode: 0 });
+Everywhere in the RENDER binding, colour components are **0..1 and clamped**,
+not the 16-bit values the protocol carries on the wire; the client scales them
+for you. Passing `0xffff` gets you 1.0, and passing `0x3000` for alpha gets you
+1.0 as well, silently — so a stop list written in 16-bit values comes out fully
+opaque rather than translucent.
 
-  // gradients are Pictures too
-  const gradient = X.AllocID();
-  Render.LinearGradient(gradient, [0, 0], [1000, 100], [
-    [0,    [0, 0, 0, 0x3000]],           // stop, [r, g, b, a] as 16-bit
-    [0.25, [0xffff, 0, 0x0fff, 0x3000]],
-    [1,    [0xffff, 0xffff, 0, 0x8000]],
-  ]);
+:::
 
-  X.on('event', () => {
-    // composite the gradient onto the window (3 = PictOp Over)
-    Render.Composite(3, gradient, 0, picture, 0, 0, 0, 0, 0, 0, 500, 500);
-  });
-});
-```
+Gradients are Pictures with nothing behind them: the client sends a few hundred
+bytes describing the ramp, and the server evaluates it for every sample the
+composite needs.
+
+<LiveDemo demo="render-gradients" compact />
+
+Because a Picture's source can be transformed, a small pixmap goes a long way.
+`SetPictureTransform` takes a 3×3 matrix mapping *destination* coordinates back
+to source coordinates — the inverse of how you would write it for a canvas —
+and `SetPictureFilter` chooses the resampling:
+
+<LiveDemo demo="render-transform" compact />
+
+Compositing itself is Porter-Duff, and the operator is an argument to every
+RENDER drawing request. The fourteen operators only differ from one another
+where both sides carry alpha, which is what this grid is arranged to show:
+
+<LiveDemo demo="render-operators" compact />
 
 `Render` also provides `RadialGradient`, `ConicalGradient`, `Triangles`,
 `FillRectangles` and glyph rendering — see the

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -33,7 +33,15 @@ x11.createClient((err, display) => {
 });
 ```
 
-A more typical program creates a window, selects events and draws into it:
+A more typical program creates a window, selects events and draws into it.
+This one is running below — not a recording, and not a screenshot: the X
+server it is talking to is the pure-JavaScript one from this repository,
+compiled to run in your browser and compositing to a canvas. Edit the code
+and press Run.
+
+<LiveDemo demo="hello-window" compact />
+
+The same program, as a listing:
 
 ```js
 const x11 = require('x11');
@@ -76,12 +84,12 @@ x11.createClient((err, display) => {
 
 ## Where to go next
 
-- [Getting started](guides/getting-started.md) — connecting, the display
+- [Getting started](guides/getting-started.mdx) — connecting, the display
   object, screens and resource ids
-- [Windows & drawing](guides/windows-and-drawing.md) — `CreateWindow`,
+- [Windows & drawing](guides/windows-and-drawing.mdx) — `CreateWindow`,
   graphics contexts and drawing requests
-- [Events](guides/events.md) — event masks and event delivery
-- [Extensions](guides/extensions.md) — loading protocol extensions with
+- [Events](guides/events.mdx) — event masks and event delivery
+- [Extensions](guides/extensions.mdx) — loading protocol extensions with
   `X.require()`
 - [Custom transports & DISPLAY protocols](guides/custom-transports.md) —
   plugging your own connection layer into `createClient`

--- a/website/package.json
+++ b/website/package.json
@@ -8,11 +8,12 @@
     "build-demo-bundles": "node scripts/build-demo-bundles.mjs",
     "check-demos": "node scripts/check-demos.mjs",
     "check-bundle": "node scripts/check-bundle.mjs",
+    "check-share": "node scripts/check-share.mjs",
     "start": "npm run sync-docs && npm run build-demo-bundles && docusaurus start",
     "prebuild": "npm run sync-docs && npm run build-demo-bundles",
     "build": "docusaurus build",
     "pretest": "npm run check-demos",
-    "test": "npm run build-demo-bundles && npm run check-bundle",
+    "test": "npm run build-demo-bundles && npm run check-bundle && npm run check-share",
     "serve": "docusaurus serve",
     "clear": "docusaurus clear"
   },

--- a/website/scripts/check-demos.mjs
+++ b/website/scripts/check-demos.mjs
@@ -38,6 +38,59 @@ function loadDemo(file) {
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
+// The server's built-in font covers ASCII 0-127 and nothing else, so a stray
+// em-dash or "×" in a drawn string comes out as a filled box. A checksum
+// cannot see that, so every text request is inspected as it is made.
+//
+// This has to happen at call time rather than by reading the source: demos
+// route text through their own label() helpers and build strings by
+// concatenation, and a scan of the literal `ImageText8(...)` span misses both.
+const TEXT_REQUESTS = ['ImageText8', 'ImageText16', 'PolyText8', 'PolyText16'];
+
+function watchDrawnText(X, problems) {
+  for (const name of TEXT_REQUESTS) {
+    const original = X[name];
+    if (typeof original !== 'function') continue;
+    X[name] = function (...args) {
+      for (const arg of args) {
+        const strings =
+          typeof arg === 'string' ? [arg]
+            : Array.isArray(arg) ? arg.filter(a => typeof a === 'string')
+              : [];
+        for (const s of strings) {
+          const bad = s.match(/[^\x00-\x7F]/);
+          if (bad)
+            problems.push(new Error(
+              `${name} would draw non-ASCII ${JSON.stringify(bad[0])} as a filled box, in ${JSON.stringify(s)}`));
+        }
+      }
+      return original.apply(this, args);
+    };
+  }
+}
+
+// x11 as the demo sees it, except that every client it opens has its text
+// requests watched. A demo may connect more than once (the window manager
+// does), so this wraps createClient rather than a single client.
+function watchedX11(problems) {
+  return new Proxy(x11, {
+    get(target, prop) {
+      if (prop !== 'createClient') return target[prop];
+      return (...args) => {
+        const last = args.length - 1;
+        if (typeof args[last] === 'function') {
+          const cb = args[last];
+          args[last] = (err, display) => {
+            if (display && display.client) watchDrawnText(display.client, problems);
+            return cb(err, display);
+          };
+        }
+        return target.createClient(...args);
+      };
+    },
+  });
+}
+
 function checksum(server) {
   server.compose();
   const data = server.root.raster.data;
@@ -69,10 +122,39 @@ const exercises = {
     server.injectButton(1, true);
     server.injectButton(1, false);
   },
+  'raster-ops'(server) {
+    // drag out a rubber band, then release to commit it
+    server.injectPointerMove(120, 140);
+    server.injectButton(1, true);
+    for (let i = 1; i <= 12; i++)
+      server.injectPointerMove(120 + i * 20, 140 + i * 12);
+    server.injectButton(1, false);
+  },
+  'window-manager'(server) {
+    // grab a frame by its title bar and move it
+    server.injectPointerMove(120, 78);
+    server.injectButton(1, true);
+    for (let i = 1; i <= 8; i++)
+      server.injectPointerMove(120 + i * 10, 78 + i * 6);
+    server.injectButton(1, false);
+  },
 };
 
+// Demos whose whole point is that injected input changes the picture: a
+// green run that never moved a pixel here would mean the handler silently
+// stopped being wired up.
+const mustReactToInput = new Set([
+  'pointer-paint', 'keyboard', 'raster-ops', 'window-manager',
+]);
+
+// Demos driven by a timer rather than by input.
+const mustAnimate = new Set(['bouncing-ball', 'copy-area', 'render-transform', 'clip-rects']);
+
 async function runDemo(demo) {
-  const server = new XServer({ width: 640, height: 480 });
+  const server = new XServer({
+    width: demo.screenWidth || 640,
+    height: demo.screenHeight || 480,
+  });
   current = { server, streams: [] };
   const problems = [];
   const timers = { intervals: [], timeouts: [] };
@@ -86,8 +168,9 @@ async function runDemo(demo) {
   };
   const trackInterval = (fn, ms) => { const id = setInterval(fn, ms); timers.intervals.push(id); return id; };
   const trackTimeout = (fn, ms) => { const id = setTimeout(fn, ms); timers.timeouts.push(id); return id; };
+  const watched = watchedX11(problems);
   const demoRequire = name => {
-    if (name === 'x11') return x11;
+    if (name === 'x11') return watched;
     throw new Error(`module not available in the playground: ${name}`);
   };
   const onUncaught = err => problems.push(err);
@@ -111,15 +194,13 @@ async function runDemo(demo) {
 
     if (after === before && afterSetup === before)
       problems.push(new Error('no pixels changed on the server raster'));
-    if (demo.id === 'pointer-paint' && after === afterSetup)
-      problems.push(new Error('painting via injected pointer input changed nothing'));
-    if (demo.id === 'keyboard' && after === afterSetup)
-      problems.push(new Error('typing via injected key input changed nothing'));
+    if (mustReactToInput.has(demo.id) && after === afterSetup)
+      problems.push(new Error('injected input changed nothing on screen'));
     if (demo.id === 'event-log' && logCount === 0)
       problems.push(new Error('no events were logged'));
-    if (demo.id === 'bouncing-ball') {
+    if (mustAnimate.has(demo.id)) {
       const mid = checksum(server);
-      await sleep(120);
+      await sleep(150);
       if (checksum(server) === mid)
         problems.push(new Error('animation is not animating'));
     }

--- a/website/scripts/check-share.mjs
+++ b/website/scripts/check-share.mjs
@@ -1,0 +1,110 @@
+// Gate for shareable playground links (src/lib/share.mjs). A share link has
+// no server behind it — the snippet *is* the URL — so the codec is the whole
+// feature, and a link that stops decoding breaks silently and permanently
+// for anyone who already pasted it somewhere.
+//
+// Checks: every demo round-trips byte for byte; the resulting URLs stay short
+// enough to paste; a guide-embedded demo shares to the playground rather than
+// to the page it sits on; malformed input is rejected rather than
+// half-decoded; and the plain fallback (browsers without CompressionStream)
+// round-trips too.
+//
+//   node scripts/check-share.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+
+import { encodeShare, decodeShare, shareUrl } from '../src/lib/share.mjs';
+
+const websiteDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const demosDir = path.join(websiteDir, 'src', 'demos');
+
+// Demo modules are browser ESM ({ export default {...} }, no imports).
+function loadDemo(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  return new Function(`${src.replace(/^export default/m, 'return')}`)();
+}
+
+// A URL people paste into chat clients and issue trackers. Browsers take far
+// more than this, but an HTTP request line has to fit the front-end server's
+// header buffer (8 KB is the usual default), so half of that is the point
+// where a demo has grown too big to share rather than too big to load.
+const MAX_URL = 4096;
+
+const files = fs
+  .readdirSync(demosDir)
+  .filter((f) => f.endsWith('.js') && f !== 'index.js')
+  .sort();
+assert.ok(files.length > 0, 'no demos found');
+
+const PLAYGROUND = '/node-x11/playground';
+const location = {
+  origin: 'https://sidorares.github.io',
+  pathname: PLAYGROUND,
+};
+
+let longest = 0;
+let longestId = null;
+for (const file of files) {
+  const demo = loadDemo(path.join(demosDir, file));
+  const encoded = await encodeShare(demo.code);
+  assert.strictEqual(
+    await decodeShare(encoded),
+    demo.code,
+    `${demo.id} did not round-trip`,
+  );
+  assert.match(encoded, /^[dp][A-Za-z0-9_-]+$/, `${demo.id} is not URL-safe`);
+
+  const url = await shareUrl(demo.code, location, PLAYGROUND);
+  if (url.length > longest) {
+    longest = url.length;
+    longestId = demo.id;
+  }
+  assert.ok(
+    url.length <= MAX_URL,
+    `${demo.id}: share URL is ${url.length} chars, over ${MAX_URL}`,
+  );
+}
+
+// A demo embedded in a guide shares to the playground, not to the docs page
+// it happens to sit on — a docs page cannot host someone else's snippet.
+{
+  const onAGuidePage = {
+    origin: 'https://sidorares.github.io',
+    pathname: '/node-x11/docs/guides/windows-and-drawing',
+  };
+  const url = await shareUrl('const x = 1;\n', onAGuidePage, PLAYGROUND);
+  assert.ok(
+    url.startsWith(`https://sidorares.github.io${PLAYGROUND}?code=`),
+    `a guide demo must share to the playground, got ${url}`,
+  );
+}
+
+// The fallback path: browsers without CompressionStream get scheme 'p'.
+{
+  const source = "const x11 = require('x11');\n";
+  const plain = 'p' + Buffer.from(source, 'utf8').toString('base64url');
+  assert.strictEqual(await decodeShare(plain), source, 'plain scheme');
+}
+
+// Hostile or stale input must throw, not produce garbage: the caller falls
+// back to the built-in demos and says the link was unreadable.
+for (const bad of ['', 'd', 'x' + 'AAAA', 'dnot-valid-deflate', 'z123']) {
+  await assert.rejects(
+    () => decodeShare(bad),
+    `decodeShare(${JSON.stringify(bad)}) should reject`,
+  );
+}
+await assert.rejects(
+  () => encodeShare('x'.repeat(70 * 1024)),
+  /over the .* byte limit/,
+  'oversized snippets are refused up front',
+);
+
+console.log(
+  `share links ok (${files.length} demos round-trip, longest URL ${longest} chars — ${longestId})`,
+);

--- a/website/src/components/LiveDemo/impl.js
+++ b/website/src/components/LiveDemo/impl.js
@@ -3,9 +3,42 @@ import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { useColorMode } from '@docusaurus/theme-common';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import { shareUrl } from '../../lib/share.mjs';
 import styles from './styles.module.css';
 
 const MAX_CONSOLE_LINES = 200;
+
+/**
+ * Hold off mounting the runner until the demo is near the viewport.
+ *
+ * On the playground that changes nothing — the only demo is on screen at
+ * once — but a guide page carries several, and each runner is a whole X
+ * server compositing to a canvas on a rAF loop. Booting them all on page
+ * load would spend the reader's CPU on demos they may never scroll to.
+ */
+function useNearViewport(ref, { rootMargin = '300px' } = {}) {
+  const [near, setNear] = useState(false);
+
+  useEffect(() => {
+    if (near) return undefined; // one-way: never unmount a running demo
+    const node = ref.current;
+    if (!node) return undefined;
+    if (typeof IntersectionObserver !== 'function') {
+      setNear(true); // no observer: fall back to eager, which is the old behaviour
+      return undefined;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) setNear(true);
+      },
+      { rootMargin },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [near, ref, rootMargin]);
+
+  return near;
+}
 
 // Code editor next to a live X session: the iframe hosts a JS X server
 // rendered to a canvas (static/demo/runner.html); Run sends the editor
@@ -16,17 +49,29 @@ export default function LiveDemoImpl({
   height = 420,
   screenWidth = 640,
   screenHeight = 480,
+  autoRun = true,
+  // `compact` stacks the editor under the screen and trims the chrome, for
+  // demos sitting inside prose rather than on the playground.
+  compact = false,
+  // Where Share points. Guides share to the playground, which is the only
+  // page that can host an arbitrary snippet.
+  sharePath = '/playground',
 }) {
   const { colorMode } = useColorMode();
   const runnerBase = useBaseUrl('/demo/runner.html');
   const runnerSrc = `${runnerBase}?width=${screenWidth}&height=${screenHeight}`;
+  const playgroundPath = useBaseUrl(sharePath);
 
+  const containerRef = useRef(null);
   const iframeRef = useRef(null);
   const codeRef = useRef(code);
   const consoleRef = useRef(null);
   const [editorCode, setEditorCode] = useState(code);
   const [lines, setLines] = useState([]);
   const [ready, setReady] = useState(false);
+  const [shared, setShared] = useState(null);
+
+  const live = useNearViewport(containerRef);
 
   const run = useCallback(() => {
     const frame = iframeRef.current;
@@ -43,7 +88,7 @@ export default function LiveDemoImpl({
       if (!msg || typeof msg !== 'object') return;
       if (msg.type === 'ready') {
         setReady(true);
-        run(); // auto-run on mount, once the runner has booted
+        if (autoRun) run();
       } else if (msg.type === 'console') {
         setLines((prev) => [
           ...prev.slice(-(MAX_CONSOLE_LINES - 1)),
@@ -53,7 +98,7 @@ export default function LiveDemoImpl({
     };
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [run]);
+  }, [autoRun, run]);
 
   useEffect(() => {
     // keep the console scrolled to the latest line
@@ -64,16 +109,42 @@ export default function LiveDemoImpl({
   const onChange = useCallback((value) => {
     codeRef.current = value;
     setEditorCode(value);
+    setShared(null); // the link no longer describes what is in the editor
   }, []);
 
   const onReset = useCallback(() => {
     codeRef.current = code;
     setEditorCode(code);
+    setShared(null);
     run();
   }, [code, run]);
 
+  const onShare = useCallback(async () => {
+    try {
+      const url = await shareUrl(codeRef.current, window.location, playgroundPath);
+      // Writing the address bar only makes sense when we are already on the
+      // page the link points at; from a guide it would rewrite the doc URL.
+      if (window.location.pathname === playgroundPath)
+        window.history.replaceState(null, '', url);
+      let copied = false;
+      try {
+        await navigator.clipboard.writeText(url);
+        copied = true;
+      } catch {
+        // clipboard blocked (no permission, or a non-secure origin) — the
+        // link is still shown below, selectable by hand
+      }
+      setShared({ url, copied });
+    } catch (err) {
+      setShared({ error: err.message });
+    }
+  }, [playgroundPath]);
+
   return (
-    <div className={styles.container}>
+    <div
+      className={compact ? `${styles.container} ${styles.compact}` : styles.container}
+      ref={containerRef}
+    >
       <div className={styles.editorPane}>
         <div className={styles.toolbar}>
           <button
@@ -90,10 +161,39 @@ export default function LiveDemoImpl({
             onClick={onReset}>
             Reset
           </button>
+          <button
+            type="button"
+            className="button button--secondary button--sm"
+            onClick={onShare}>
+            Share 🔗
+          </button>
           <span className={styles.hint}>
-            {ready ? 'runs in your browser — no X server needed' : 'starting X server…'}
+            {!live
+              ? 'scroll into view to start'
+              : ready
+                ? 'runs in your browser — no X server needed'
+                : 'starting X server…'}
           </span>
         </div>
+        {shared && (
+          <div className={shared.error ? styles.shareError : styles.shareOk}>
+            {shared.error ? (
+              `That snippet could not be turned into a link: ${shared.error}`
+            ) : (
+              <>
+                {shared.copied
+                  ? 'Link copied — it carries the whole snippet, there is no server storing it.'
+                  : 'Copy this link — it carries the whole snippet, there is no server storing it.'}
+                <input
+                  className={styles.shareInput}
+                  readOnly
+                  value={shared.url}
+                  onFocus={(e) => e.target.select()}
+                />
+              </>
+            )}
+          </div>
+        )}
         <div className={styles.editor}>
           <CodeMirror
             value={editorCode}
@@ -117,13 +217,20 @@ export default function LiveDemoImpl({
         </div>
       </div>
       <div className={styles.screenPane}>
-        <iframe
-          ref={iframeRef}
-          src={runnerSrc}
-          className={styles.frame}
-          style={{ aspectRatio: `${screenWidth} / ${screenHeight}` }}
-          title="node-x11 live X session"
-        />
+        {live ? (
+          <iframe
+            ref={iframeRef}
+            src={runnerSrc}
+            className={styles.frame}
+            style={{ aspectRatio: `${screenWidth} / ${screenHeight}` }}
+            title="node-x11 live X session"
+          />
+        ) : (
+          <div
+            className={styles.framePlaceholder}
+            style={{ aspectRatio: `${screenWidth} / ${screenHeight}` }}
+          />
+        )}
         <div className={styles.screenCaption}>
           {screenWidth}×{screenHeight} X screen — click it to give it focus,
           then interact with the pointer and keyboard

--- a/website/src/components/LiveDemo/index.js
+++ b/website/src/components/LiveDemo/index.js
@@ -1,14 +1,45 @@
 import React from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import { byId } from '../../demos';
 import styles from './styles.module.css';
 
-// SSR-safe wrapper: the editor + iframe runner only exist in the browser.
-export default function LiveDemo(props) {
+/**
+ * A live X session with an editor beside it.
+ *
+ * Pass `code` directly, or `demo="hello-window"` to pull one of the demos in
+ * `src/demos`. Referencing by id is what keeps a guide honest: the same
+ * string runs on the playground and is checked in CI by
+ * `scripts/check-demos.mjs`, so a snippet in the prose cannot quietly rot
+ * while the API moves under it.
+ */
+export default function LiveDemo({ demo, code, ...rest }) {
+  const source = demo ? byId[demo] : null;
+
+  if (demo && !source) {
+    // A typo'd id must be loud at build time rather than rendering an empty
+    // editor that nobody notices.
+    throw new Error(
+      `<LiveDemo demo="${demo}"> — no such demo in src/demos (have: ${Object.keys(byId).join(', ')})`,
+    );
+  }
+
+  const props = source
+    ? {
+        code: source.code,
+        screenWidth: source.screenWidth,
+        screenHeight: source.screenHeight,
+        height: source.height,
+        ...rest,
+      }
+    : { code, ...rest };
+
+  // Undefined props would clobber the impl's own defaults.
+  for (const key of Object.keys(props))
+    if (props[key] === undefined) delete props[key];
+
   return (
     <BrowserOnly
-      fallback={
-        <div className={styles.fallback}>Loading live demo…</div>
-      }>
+      fallback={<div className={styles.fallback}>Loading live demo…</div>}>
       {() => {
         const Impl = require('./impl').default;
         return <Impl {...props} />;

--- a/website/src/components/LiveDemo/styles.module.css
+++ b/website/src/components/LiveDemo/styles.module.css
@@ -83,6 +83,50 @@
   background: #14161a;
 }
 
+/* Reserves the screen's box until the demo scrolls into view, so arriving at
+   a guide anchor does not shift the text under the reader. */
+.framePlaceholder {
+  display: block;
+  width: 100%;
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  background: var(--ifm-color-emphasis-100);
+}
+
+.shareOk,
+.shareError {
+  margin-bottom: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.shareOk {
+  border: 1px solid var(--ifm-color-success-dark);
+  background: var(--ifm-color-success-contrast-background);
+  color: var(--ifm-color-success-contrast-foreground);
+}
+
+.shareError {
+  border: 1px solid var(--ifm-color-danger-dark);
+  background: var(--ifm-color-danger-contrast-background);
+  color: var(--ifm-color-danger-contrast-foreground);
+}
+
+.shareInput {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 4px 6px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+}
+
 .screenCaption {
   margin-top: 6px;
   font-size: 0.8rem;
@@ -95,6 +139,30 @@
   padding: 3rem 1rem;
   text-align: center;
   color: var(--ifm-color-emphasis-600);
+}
+
+/* In prose the screen leads and the editor follows: a reader scrolling a
+   guide wants to see the result first and only then the code that made it.
+   The docs column is also far narrower than the playground's, so side by
+   side would squeeze both panes. */
+.compact {
+  flex-direction: column-reverse;
+  padding: 12px;
+  margin-bottom: var(--ifm-leading);
+}
+
+.compact .editorPane,
+.compact .screenPane {
+  width: 100%;
+  flex: none;
+}
+
+.compact .screenPane {
+  margin-bottom: 12px;
+}
+
+.compact .console {
+  height: 72px;
 }
 
 @media (max-width: 996px) {

--- a/website/src/demos/clip-rects.js
+++ b/website/src/demos/clip-rects.js
@@ -1,0 +1,123 @@
+export default {
+  id: 'clip-rects',
+  title: 'Clipping',
+  description:
+    'SetClipRectangles turns a GC into a stencil: the same fill request, sent twice, produces completely different ink.',
+  screenWidth: 640,
+  screenHeight: 340,
+  code: `const x11 = require('x11');
+
+// The clip list lives on the GC, not on the request. So a "shape" in core X11
+// is often not a shape at all — it is a rectangle list installed as a clip,
+// with something ordinary drawn through it.
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  const W = 640, H = 340;
+
+  const wid = X.AllocID();
+  X.CreateWindow(wid, screen.root, 0, 0, W, H, 0, 0, 0, 0, {
+    backgroundPixel: 0x0f1216,
+    eventMask: x11.eventMask.Exposure
+  });
+  X.MapWindow(wid);
+
+  const gc = X.AllocID();
+  X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x0f1216 });
+
+  // A second GC carrying the clip, so the unclipped one stays available.
+  const clipped = X.AllocID();
+  X.CreateGC(clipped, wid, { foreground: 0x4fc3f7 });
+
+  let phase = 0;
+
+  // A ring of rectangles approximating a circle — the clip list is unsorted
+  // (ordering 0), which is the only ordering that needs no care about
+  // overlap.
+  function discClip(cx, cy, r) {
+    const rects = [];
+    for (let y = -r; y < r; y += 2) {
+      const half = Math.round(Math.sqrt(r * r - y * y));
+      if (half > 0) rects.push(cx - half, cy + y, half * 2, 2);
+    }
+    return rects;
+  }
+
+  // "CLIP", built out of bars rather than drawn as text: the letters are the
+  // clip list, and the fill below is what makes them visible.
+  function textClip(x, y) {
+    const letters = {
+      C: [[0, 0, 10, 64], [0, 0, 30, 10], [0, 54, 30, 10]],
+      L: [[0, 0, 10, 64], [0, 54, 30, 10]],
+      I: [[10, 0, 10, 64], [0, 0, 30, 10], [0, 54, 30, 10]],
+      P: [[0, 0, 10, 64], [0, 0, 30, 10], [20, 0, 10, 37], [0, 27, 30, 10]]
+    };
+    const rects = [];
+    'CLIP'.split('').forEach((ch, i) => {
+      for (const [bx, by, bw, bh] of letters[ch])
+        rects.push(x + i * 42 + bx, y + by, bw, bh);
+    });
+    return rects;
+  }
+
+  function paint() {
+    X.ChangeGC(gc, { foreground: 0x0f1216 });
+    X.PolyFillRectangle(wid, gc, [0, 0, W, H]);
+
+    X.ChangeGC(gc, { foreground: 0xdfe4ea });
+    X.ImageText8(wid, gc, 20, 28,
+      'one PolyFillRectangle covering the whole panel, three different clips');
+
+    const panels = [
+      { x: 20, label: 'no clip', rects: null },
+      { x: 230, label: 'disc clip', rects: discClip(100, 105, 78) },
+      { x: 440, label: 'glyph clip', rects: textClip(18, 68) }
+    ];
+
+    for (const panel of panels) {
+      X.ChangeGC(gc, { foreground: 0x1a2028 });
+      X.PolyFillRectangle(wid, gc, [panel.x, 50, 180, 190]);
+
+      if (panel.rects) {
+        // clip origins are relative to the drawable, so shift the list into
+        // the panel by setting the origin rather than by moving every rect
+        X.SetClipRectangles(clipped, 0, panel.x, 50, panel.rects);
+      } else {
+        // an empty list would clip everything away; None restores "no clip"
+        X.ChangeGC(clipped, { clipMask: 0 });
+      }
+
+      // the identical request every time — only the GC changed
+      const hue = (phase + panels.indexOf(panel) * 40) % 360;
+      X.ChangeGC(clipped, { foreground: hsv(hue) });
+      X.PolyFillRectangle(wid, clipped, [panel.x, 50, 180, 190]);
+
+      X.ChangeGC(gc, { foreground: 0x8892a0 });
+      X.ImageText8(wid, gc, panel.x, 262, panel.label);
+    }
+  }
+
+  function hsv(h) {
+    const f = (n) => {
+      const k = (n + h / 60) % 6;
+      const v = 0.55 + 0.45 * Math.max(0, Math.min(1, Math.min(k, 4 - k, 1)));
+      return Math.round(v * 255);
+    };
+    return (f(5) << 16) | (f(3) << 8) | f(1);
+  }
+
+  X.on('event', ev => {
+    if (ev.name !== 'Expose') return;
+    paint();
+    console.log('clip lists are GC state — ' + discClip(100, 105, 78).length / 4 +
+      ' rects in the disc');
+  });
+
+  setInterval(() => { phase = (phase + 6) % 360; paint(); }, 90);
+  X.on('error', e => console.error(e));
+});
+`,
+};

--- a/website/src/demos/copy-area.js
+++ b/website/src/demos/copy-area.js
@@ -1,0 +1,91 @@
+export default {
+  id: 'copy-area',
+  title: 'Pixmaps and CopyArea',
+  description:
+    'Draw once into an off-screen pixmap, then scroll it across the window with CopyArea — the classic way to animate without redrawing.',
+  screenWidth: 640,
+  screenHeight: 340,
+  code: `const x11 = require('x11');
+
+// A pixmap is a drawable with no window: same drawing requests, nothing on
+// screen. Render the expensive thing into it once, then move pixels around
+// with CopyArea, which is a server-side blit — no pixel data on the wire.
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  const W = 640, H = 340;
+  const STRIP_W = 960, STRIP_H = 200;
+
+  const wid = X.AllocID();
+  X.CreateWindow(wid, screen.root, 0, 0, W, H, 0, 0, 0, 0, {
+    backgroundPixel: 0x0f1317,
+    eventMask: x11.eventMask.Exposure
+  });
+  X.MapWindow(wid);
+
+  const gc = X.AllocID();
+  X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x0f1317 });
+
+  // ---- the off-screen strip, drawn exactly once
+  const strip = X.AllocID();
+  X.CreatePixmap(strip, wid, 24, STRIP_W, STRIP_H);
+
+  X.ChangeGC(gc, { foreground: 0x161c22 });
+  X.PolyFillRectangle(strip, gc, [0, 0, STRIP_W, STRIP_H]);
+
+  // a skyline: cheap to look at, tedious enough that you would not want to
+  // redraw it 25 times a second
+  let seed = 7;
+  const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+  for (let layer = 0; layer < 3; layer++) {
+    const shade = [0x1f2a36, 0x2c3b4a, 0x3d5061][layer];
+    X.ChangeGC(gc, { foreground: shade });
+    const boxes = [];
+    for (let x = 0; x < STRIP_W; x += 24 + Math.floor(rand() * 20)) {
+      const h = 40 + Math.floor(rand() * (60 + layer * 40));
+      boxes.push(x, STRIP_H - h, 18 + Math.floor(rand() * 26), h);
+    }
+    X.PolyFillRectangle(strip, gc, boxes);
+  }
+  X.ChangeGC(gc, { foreground: 0xffe082 });
+  const windows = [];
+  for (let i = 0; i < 260; i++)
+    windows.push(
+      Math.floor(rand() * STRIP_W),
+      STRIP_H - 10 - Math.floor(rand() * 120), 3, 4);
+  X.PolyFillRectangle(strip, gc, windows);
+
+  let offset = 0;
+  let running = false;
+
+  function frame() {
+    if (!running) return;
+    // Two copies so the strip wraps seamlessly: the tail, then the head.
+    const first = Math.min(W, STRIP_W - offset);
+    X.CopyArea(strip, wid, gc, offset, 0, 0, 90, first, STRIP_H);
+    if (first < W)
+      X.CopyArea(strip, wid, gc, 0, 0, first, 90, W - first, STRIP_H);
+    offset = (offset + 2) % STRIP_W;
+  }
+
+  X.on('event', ev => {
+    if (ev.name !== 'Expose') return;
+    X.ChangeGC(gc, { foreground: 0xdfe4ea });
+    X.ImageText8(wid, gc, 20, 30,
+      'drawn once into a ' + STRIP_W + 'x' + STRIP_H + ' pixmap, then blitted');
+    X.ImageText8(wid, gc, 20, 50,
+      'CopyArea moves pixels inside the server: nothing crosses the wire');
+    X.ImageText8(wid, gc, 20, 320,
+      'two CopyArea requests per frame, 40 bytes total');
+    running = true;
+    console.log('skyline cached in pixmap ' + strip);
+  });
+
+  setInterval(frame, 40);
+  X.on('error', e => console.error(e));
+});
+`,
+};

--- a/website/src/demos/guide-create-window.js
+++ b/website/src/demos/guide-create-window.js
@@ -1,0 +1,28 @@
+export default {
+  id: 'guide-create-window',
+  title: 'Create and map a window',
+  description: 'The smallest thing that puts something on screen.',
+  // Guide-scoped: small enough to read inside prose, so it stays out of the
+  // playground picker where the fuller demos live.
+  playground: false,
+  screenWidth: 420,
+  screenHeight: 260,
+  height: 260,
+  code: `const x11 = require('x11');
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  const wid = X.AllocID();
+  X.CreateWindow(wid, screen.root, 40, 30, 340, 200, 2, 0, 0, 0, {
+    backgroundPixel: 0x3498db,
+    borderPixel: 0x1b4f72
+  });
+  X.MapWindow(wid);
+
+  console.log('window ' + wid + ' is on screen');
+});
+`,
+};

--- a/website/src/demos/guide-extension.js
+++ b/website/src/demos/guide-extension.js
@@ -1,0 +1,64 @@
+export default {
+  id: 'guide-extension',
+  title: 'Loading an extension',
+  description:
+    'X.require negotiates an extension and hands back an object whose requests you call like core ones.',
+  playground: false,
+  screenWidth: 420,
+  screenHeight: 260,
+  height: 320,
+  code: `const x11 = require('x11');
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  // X.require does QueryExtension, learns the major opcode, and returns an
+  // object whose methods pack requests against it. Nothing is loaded until
+  // you ask, and an absent extension gives you an error rather than a throw.
+  X.require('render', (err2, render) => {
+    if (err2) {
+      console.error('no RENDER on this display: ' + err2);
+      return;
+    }
+
+    render.QueryVersion(0, 11, (err3, version) => {
+      if (err3) throw err3;
+      console.log('RENDER ' + version.majorVersion + '.' + version.minorVersion);
+    });
+
+    const wid = X.AllocID();
+    X.CreateWindow(wid, screen.root, 0, 0, 420, 260, 0, 0, 0, 0, {
+      backgroundPixel: 0x11151a,
+      eventMask: x11.eventMask.Exposure
+    });
+    X.MapWindow(wid);
+
+    const gc = X.AllocID();
+    X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x1f2933 });
+
+    // A Picture wraps a drawable in a pixel format RENDER understands.
+    const picture = X.AllocID();
+    render.CreatePicture(picture, wid, render.rgb24);
+
+    X.on('event', ev => {
+      if (ev.name !== 'Expose') return;
+
+      // colours here are floats, and alpha actually blends — unlike the core
+      // protocol, where a pixel value simply replaces what was there
+      render.FillRectangles(render.PictOp.Src, picture,
+        [0.12, 0.16, 0.20, 1], [0, 0, 420, 260]);
+      render.FillRectangles(render.PictOp.Over, picture,
+        [0.91, 0.30, 0.24, 0.85], [40, 60, 160, 120]);
+      render.FillRectangles(render.PictOp.Over, picture,
+        [0.20, 0.60, 0.86, 0.55], [120, 100, 160, 120]);
+
+      X.ImageText8(wid, gc, 40, 220, 'two Over fills, 55% and 85% alpha');
+    });
+
+    X.on('error', e => console.error(e));
+  });
+});
+`,
+};

--- a/website/src/demos/guide-gc.js
+++ b/website/src/demos/guide-gc.js
@@ -1,0 +1,51 @@
+export default {
+  id: 'guide-gc',
+  title: 'A graphics context is pen state',
+  description:
+    'The same PolyFillRectangle four times — only the GC changed between them.',
+  playground: false,
+  screenWidth: 420,
+  screenHeight: 260,
+  height: 300,
+  code: `const x11 = require('x11');
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  const wid = X.AllocID();
+  X.CreateWindow(wid, screen.root, 0, 0, 420, 260, 0, 0, 0, 0, {
+    backgroundPixel: 0x11151a,
+    eventMask: x11.eventMask.Exposure
+  });
+  X.MapWindow(wid);
+
+  const gc = X.AllocID();
+  X.CreateGC(gc, wid, { foreground: 0xe74c3c, background: 0x11151a });
+
+  X.on('event', ev => {
+    if (ev.name !== 'Expose') return;
+
+    // Nothing about the shape changes below — ChangeGC does all the work.
+    X.PolyFillRectangle(wid, gc, [30, 40, 80, 80]);
+
+    X.ChangeGC(gc, { foreground: 0xf1c40f });
+    X.PolyFillRectangle(wid, gc, [130, 40, 80, 80]);
+
+    X.ChangeGC(gc, { foreground: 0x2ecc71 });
+    X.PolyFillRectangle(wid, gc, [230, 40, 80, 80]);
+
+    // GXxor combines with what is already there rather than replacing it
+    X.ChangeGC(gc, { foreground: 0xffffff, function: x11.gcFunction.GXxor });
+    X.PolyFillRectangle(wid, gc, [70, 90, 200, 40]);
+
+    X.ChangeGC(gc, { foreground: 0x8892a0, function: x11.gcFunction.GXcopy });
+    X.ImageText8(wid, gc, 30, 180, 'one request, four GC states');
+    X.ImageText8(wid, gc, 30, 200, 'the white band is GXxor over the squares');
+  });
+
+  X.on('error', e => console.error(e));
+});
+`,
+};

--- a/website/src/demos/index.js
+++ b/website/src/demos/index.js
@@ -1,25 +1,63 @@
 import helloWindow from './hello-window.js';
 import gradientRects from './gradient-rects.js';
 import text from './text.js';
+import shapes from './shapes.js';
+import clipRects from './clip-rects.js';
+import copyArea from './copy-area.js';
 import pointerPaint from './pointer-paint.js';
+import rasterOps from './raster-ops.js';
 import eventLog from './event-log.js';
 import bouncingBall from './bouncing-ball.js';
 import keyboard from './keyboard.js';
+import renderOperators from './render-operators.js';
+import renderGradients from './render-gradients.js';
+import renderTransform from './render-transform.js';
+import windowManager from './window-manager.js';
 import glxTriangle from './glx-triangle.js';
 import glxCube from './glx-cube.js';
+import guideCreateWindow from './guide-create-window.js';
+import guideGc from './guide-gc.js';
+import guideExtension from './guide-extension.js';
 
-// Ordered list shown in the playground picker. Each entry:
-// { id, title, description, code } (+ optional screenWidth/screenHeight).
-const demos = [
+// Every demo, in the order the playground picker shows them. Each entry:
+// { id, title, description, code } plus optional screenWidth/screenHeight/
+// height, `playground: false` to keep it out of the picker, and
+// `requiresWebGL: true` for the GLX ones that scripts/check-demos.mjs skips.
+//
+// Guide-scoped entries are here rather than inline in the .mdx so that
+// scripts/check-demos.mjs runs them too — a snippet in the prose is exactly
+// the kind that rots silently otherwise.
+const all = [
+  // core protocol
   helloWindow,
   gradientRects,
   text,
+  shapes,
+  clipRects,
+  copyArea,
+  // input
   pointerPaint,
+  rasterOps,
   eventLog,
   bouncingBall,
   keyboard,
+  // RENDER
+  renderOperators,
+  renderGradients,
+  renderTransform,
+  // putting it together
+  windowManager,
+  // GLX
   glxTriangle,
   glxCube,
+  // guide-scoped, not in the picker
+  guideCreateWindow,
+  guideGc,
+  guideExtension,
 ];
+
+export const byId = Object.fromEntries(all.map((d) => [d.id, d]));
+
+const demos = all.filter((d) => d.playground !== false);
 
 export default demos;

--- a/website/src/demos/raster-ops.js
+++ b/website/src/demos/raster-ops.js
@@ -1,0 +1,120 @@
+export default {
+  id: 'raster-ops',
+  title: 'Raster ops: XOR rubber band',
+  description:
+    'Drag inside the window. The selection box is drawn with GXxor, so drawing it a second time erases it — how X did interactive feedback before compositing.',
+  screenWidth: 640,
+  screenHeight: 400,
+  code: `const x11 = require('x11');
+
+// GC "function" is a bitwise operation between the pixel being drawn and the
+// pixel already there. GXxor is the useful one: drawing the same shape twice
+// restores the original, so you can drag a rubber band over arbitrary
+// content without saving and restoring what was underneath.
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+  const GX = x11.gcFunction;
+
+  const W = 640, H = 400;
+
+  const wid = X.AllocID();
+  X.CreateWindow(wid, screen.root, 0, 0, W, H, 0, 0, 0, 0, {
+    backgroundPixel: 0x101418,
+    eventMask: x11.eventMask.Exposure |
+               x11.eventMask.ButtonPress |
+               x11.eventMask.ButtonRelease |
+               x11.eventMask.PointerMotion
+  });
+  X.MapWindow(wid);
+
+  const gc = X.AllocID();
+  X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x1b2530 });
+
+  // the rubber band GC: xor, and a foreground chosen so the band is legible
+  // against everything below it
+  const bandGc = X.AllocID();
+  X.CreateGC(bandGc, wid, {
+    foreground: 0xffffff,
+    function: GX.GXxor,
+    lineWidth: 1
+  });
+
+  let anchor = null;   // { x, y }
+  let band = null;     // last drawn rect, still on screen
+
+  function bandRect(a, b) {
+    return [
+      Math.min(a.x, b.x), Math.min(a.y, b.y),
+      Math.abs(a.x - b.x), Math.abs(a.y - b.y)
+    ];
+  }
+
+  function toggleBand(rect) {
+    // one request, and it is its own undo
+    if (rect[2] > 0 && rect[3] > 0)
+      X.PolyRectangle(wid, bandGc, rect);
+  }
+
+  // A busy backdrop, so that erasing the band by redrawing it is visibly
+  // exact rather than just plausible against a flat colour.
+  function backdrop() {
+    X.ChangeGC(gc, { foreground: 0x1b2530 });
+    X.PolyFillRectangle(wid, gc, [0, 0, W, H]);
+
+    const stripes = [];
+    for (let i = 0; i < 26; i++) stripes.push(i * 26, 70, 14, H - 90);
+    X.ChangeGC(gc, { foreground: 0x27384a });
+    X.PolyFillRectangle(wid, gc, stripes);
+
+    // PolyFillArc takes [x, y, w, h, angle1, angle2] per arc
+    const dots = [];
+    for (let i = 0; i < 40; i++)
+      dots.push(30 + (i % 10) * 62, 110 + Math.floor(i / 10) * 66, 26, 26,
+        0, 360 * 64);
+    X.ChangeGC(gc, { foreground: 0x4fc3f7 });
+    X.PolyFillArc(wid, gc, dots);
+
+    X.ChangeGC(gc, { foreground: 0xdfe4ea });
+    X.ImageText8(wid, gc, 20, 30, 'drag to draw a selection box');
+    X.ImageText8(wid, gc, 20, 50,
+      'GXxor: the same PolyRectangle both draws and erases it');
+  }
+
+  X.on('event', ev => {
+    if (ev.name === 'Expose') {
+      backdrop();
+      band = null;
+      return;
+    }
+    if (ev.name === 'ButtonPress') {
+      anchor = { x: ev.x, y: ev.y };
+      band = null;
+      return;
+    }
+    if (ev.name === 'MotionNotify' && anchor) {
+      if (band) toggleBand(band);            // erase the previous box
+      band = bandRect(anchor, { x: ev.x, y: ev.y });
+      toggleBand(band);                      // draw the new one
+      return;
+    }
+    if (ev.name === 'ButtonRelease' && anchor) {
+      if (band) toggleBand(band);            // erase, then commit for real
+      const rect = bandRect(anchor, { x: ev.x, y: ev.y });
+      anchor = null;
+      band = null;
+      if (rect[2] > 2 && rect[3] > 2) {
+        X.ChangeGC(gc, { foreground: 0xf06292, lineWidth: 2 });
+        X.PolyRectangle(wid, gc, rect);
+        X.ChangeGC(gc, { lineWidth: 1 });
+        console.log('selected ' + rect[2] + 'x' + rect[3] + ' at ' + rect[0] + ',' + rect[1]);
+      }
+    }
+  });
+
+  X.on('error', e => console.error(e));
+});
+`,
+};

--- a/website/src/demos/render-gradients.js
+++ b/website/src/demos/render-gradients.js
@@ -1,0 +1,87 @@
+export default {
+  id: 'render-gradients',
+  title: 'RENDER: gradients',
+  description:
+    'Linear, radial and conical gradient pictures — sources with no pixels behind them, evaluated per sample by the server.',
+  screenWidth: 640,
+  screenHeight: 380,
+  code: `const x11 = require('x11');
+
+// A gradient is a Picture with no drawable: nothing is stored, the server
+// evaluates the ramp for each sample it is asked for. So the client sends a
+// few hundred bytes describing the ramp once, and the server produces as
+// many pixels as the composite needs.
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  X.require('render', (err2, render) => {
+    if (err2) throw err2;
+
+    const wid = X.AllocID();
+    X.CreateWindow(wid, screen.root, 0, 0, 640, 380, 0, 0, 0, 0, {
+      backgroundPixel: 0x101418,
+      eventMask: x11.eventMask.Exposure
+    });
+    X.MapWindow(wid);
+
+    const gc = X.AllocID();
+    X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x101418 });
+
+    const dst = X.AllocID();
+    render.CreatePicture(dst, wid, render.rgb24);
+
+    // stops are [offset, [r, g, b, a]] with everything in 0..1
+    const sunset = [
+      [0.0, [0.98, 0.79, 0.19, 1]],
+      [0.5, [0.91, 0.30, 0.24, 1]],
+      [1.0, [0.31, 0.16, 0.51, 1]]
+    ];
+    const ocean = [
+      [0.0, [0.05, 0.62, 0.86, 1]],
+      [1.0, [0.06, 0.20, 0.35, 1]]
+    ];
+    const wheel = [
+      [0.00, [0.95, 0.26, 0.21, 1]],
+      [0.25, [0.99, 0.85, 0.21, 1]],
+      [0.50, [0.30, 0.76, 0.35, 1]],
+      [0.75, [0.13, 0.59, 0.95, 1]],
+      [1.00, [0.95, 0.26, 0.21, 1]]
+    ];
+
+    const linear = X.AllocID();
+    render.CreateLinearGradient(linear, [0, 0], [180, 180], sunset);
+
+    const radial = X.AllocID();
+    // two circles: the ramp runs from the inner one to the outer one
+    render.CreateRadialGradient(radial, [90, 80], [90, 90], 8, 95, ocean);
+
+    const conical = X.AllocID();
+    render.CreateConicalGradient(conical, [90, 90], 0, wheel);
+
+    function panel(picture, x, y, label) {
+      render.Composite(render.PictOp.Src, picture, 0, dst,
+        0, 0, 0, 0, x, y, 180, 180);
+      X.ImageText8(wid, gc, x, y + 198, label);
+    }
+
+    X.on('event', ev => {
+      if (ev.name !== 'Expose') return;
+      X.ChangeGC(gc, { foreground: 0xdfe4ea });
+      // ImageText8 draws through the server's built-in 8x8 font, which only
+      // covers ASCII 0-127 — anything else comes out as a filled box.
+      X.ImageText8(wid, gc, 20, 26,
+        'gradient pictures have no backing pixmap: the server samples the ramp');
+      panel(linear, 20, 50, 'CreateLinearGradient');
+      panel(radial, 228, 50, 'CreateRadialGradient');
+      panel(conical, 436, 50, 'CreateConicalGradient');
+      console.log('three gradient sources, 0 pixels uploaded');
+    });
+
+    X.on('error', e => console.error(e));
+  });
+});
+`,
+};

--- a/website/src/demos/render-operators.js
+++ b/website/src/demos/render-operators.js
@@ -1,0 +1,100 @@
+export default {
+  id: 'render-operators',
+  title: 'RENDER: Porter-Duff operators',
+  description:
+    'All fourteen compositing operators side by side. Each cell composites the same translucent source over the same translucent destination, changing only the operator.',
+  screenWidth: 640,
+  screenHeight: 460,
+  code: `const x11 = require('x11');
+
+// The compositing operators only differ from one another when BOTH sides
+// carry alpha, so each cell is built up in its own depth-32 pixmap and then
+// laid over a checkerboard — the checks are what make the transparency the
+// operators produce visible at all.
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  X.require('render', (err2, render) => {
+    if (err2) throw err2;
+
+    const wid = X.AllocID();
+    X.CreateWindow(wid, screen.root, 0, 0, 640, 460, 0, 0, 0, 0, {
+      backgroundPixel: 0x1b1f24,
+      eventMask: x11.eventMask.Exposure
+    });
+    X.MapWindow(wid);
+
+    const gc = X.AllocID();
+    X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x1b1f24 });
+
+    const dstPicture = X.AllocID();
+    render.CreatePicture(dstPicture, wid, render.rgb24);
+
+    // one scratch pixmap reused for every cell
+    const CELL_W = 112, CELL_H = 86;
+    const pixmap = X.AllocID();
+    X.CreatePixmap(pixmap, wid, 32, CELL_W, CELL_H);
+    const cell = X.AllocID();
+    render.CreatePicture(cell, pixmap, render.rgba32);
+
+    const ops = [
+      'Clear', 'Src', 'Dst', 'Over', 'OverReverse',
+      'In', 'InReverse', 'Out', 'OutReverse', 'Atop',
+      'AtopReverse', 'Xor', 'Add', 'Saturate'
+    ];
+
+    // destination shape: a cyan square on the left
+    // source shape:      a magenta square on the right, overlapping
+    const DST_RECT = [8, 14, 58, 58];
+    const SRC_RECT = [40, 30, 58, 58];
+    const DST_COLOR = [0.15, 0.68, 0.78, 0.75];
+    const SRC_COLOR = [0.85, 0.24, 0.55, 0.6];
+
+    function checkerboard(x, y, w, h) {
+      // 8px checks, drawn with the core protocol rather than RENDER
+      X.ChangeGC(gc, { foreground: 0x2c333c });
+      X.PolyFillRectangle(wid, gc, [x, y, w, h]);
+      X.ChangeGC(gc, { foreground: 0x394450 });
+      const squares = [];
+      for (let cy = 0; cy < h; cy += 8)
+        for (let cx = ((cy / 8) % 2) * 8; cx < w; cx += 16)
+          squares.push(x + cx, y + cy, Math.min(8, w - cx), Math.min(8, h - cy));
+      X.PolyFillRectangle(wid, gc, squares);
+    }
+
+    function drawCell(name, col, row) {
+      const x = 12 + col * (CELL_W + 12);
+      const y = 30 + row * (CELL_H + 34);
+
+      // Build the composite off-screen: clear to fully transparent, lay down
+      // the destination, then apply the operator with the source.
+      render.FillRectangles(render.PictOp.Clear, cell, [0, 0, 0, 0],
+        [0, 0, CELL_W, CELL_H]);
+      render.FillRectangles(render.PictOp.Src, cell, DST_COLOR, DST_RECT);
+      render.FillRectangles(render.PictOp[name], cell, SRC_COLOR, SRC_RECT);
+
+      checkerboard(x, y, CELL_W, CELL_H);
+      render.Composite(render.PictOp.Over, cell, 0, dstPicture,
+        0, 0, 0, 0, x, y, CELL_W, CELL_H);
+
+      X.ChangeGC(gc, { foreground: 0xdfe4ea });
+      X.ImageText8(wid, gc, x + 2, y + CELL_H + 14, name);
+    }
+
+    X.on('event', ev => {
+      if (ev.name !== 'Expose') return;
+      X.ChangeGC(gc, { foreground: 0xdfe4ea });
+      X.ImageText8(wid, gc, 12, 18,
+        'cyan = destination, magenta = source, checks = transparent');
+      ops.forEach((name, i) => drawCell(name, i % 5, Math.floor(i / 5)));
+      console.log(ops.length + ' operators composited');
+    });
+
+    X.on('error', e => console.error(e));
+  });
+});
+`,
+};

--- a/website/src/demos/render-transform.js
+++ b/website/src/demos/render-transform.js
@@ -1,0 +1,107 @@
+export default {
+  id: 'render-transform',
+  title: 'RENDER: transforms & filters',
+  description:
+    'SetPictureTransform rotating and scaling a source picture, with nearest-neighbour beside bilinear so the filter difference is visible.',
+  screenWidth: 640,
+  screenHeight: 360,
+  code: `const x11 = require('x11');
+
+// A picture transform is a 3x3 matrix mapping DESTINATION coordinates back
+// to source coordinates — the inverse of the way you would write it for a
+// canvas. Nothing is re-uploaded per frame: the client sends nine numbers
+// and the server resamples.
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  X.require('render', (err2, render) => {
+    if (err2) throw err2;
+
+    const wid = X.AllocID();
+    X.CreateWindow(wid, screen.root, 0, 0, 640, 360, 0, 0, 0, 0, {
+      backgroundPixel: 0x0e1116,
+      eventMask: x11.eventMask.Exposure
+    });
+    X.MapWindow(wid);
+
+    const gc = X.AllocID();
+    X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x0e1116 });
+
+    const dst = X.AllocID();
+    render.CreatePicture(dst, wid, render.rgb24);
+
+    // A small, deliberately chunky source so resampling is easy to see.
+    const SRC = 32;
+    const pixmap = X.AllocID();
+    X.CreatePixmap(pixmap, wid, 32, SRC, SRC);
+    const src = X.AllocID();
+    render.CreatePicture(src, pixmap, render.rgba32);
+
+    render.FillRectangles(render.PictOp.Src, src, [0.10, 0.13, 0.17, 1],
+      [0, 0, SRC, SRC]);
+    // four quadrants plus a diagonal, so rotation and filtering both show
+    render.FillRectangles(render.PictOp.Src, src, [0.95, 0.35, 0.21, 1], [0, 0, 16, 16]);
+    render.FillRectangles(render.PictOp.Src, src, [0.18, 0.72, 0.85, 1], [16, 16, 16, 16]);
+    render.FillRectangles(render.PictOp.Src, src, [0.99, 0.85, 0.25, 1], [16, 0, 16, 16]);
+    render.FillRectangles(render.PictOp.Src, src, [0.35, 0.78, 0.45, 1], [0, 16, 16, 16]);
+    const diagonal = [];
+    for (let i = 0; i < SRC; i++) diagonal.push(i, i, 2, 2);
+    render.FillRectangles(render.PictOp.Src, src, [1, 1, 1, 1], diagonal);
+
+    // Two copies of the same pixmap, differing only in resampling filter.
+    const nearest = X.AllocID();
+    render.CreatePicture(nearest, pixmap, render.rgba32);
+    render.SetPictureFilter(nearest, 'nearest', []);
+    const bilinear = X.AllocID();
+    render.CreatePicture(bilinear, pixmap, render.rgba32);
+    render.SetPictureFilter(bilinear, 'bilinear', []);
+
+    const SIZE = 160;
+    const SCALE = SRC / SIZE;   // dest → src, so >1 shrinks the source
+
+    function rotationAbout(angle, cx, cy) {
+      const c = Math.cos(angle), s = Math.sin(angle);
+      // translate to centre, rotate, scale, translate back — expressed in
+      // destination space because that is the direction RENDER samples in
+      return [
+        c * SCALE, -s * SCALE, (cx - c * cx + s * cy) * SCALE,
+        s * SCALE, c * SCALE, (cy - s * cx - c * cy) * SCALE,
+        0, 0, 1
+      ];
+    }
+
+    let angle = 0;
+    let painted = false;
+
+    function frame() {
+      if (!painted) return;
+      const m = rotationAbout(angle, SIZE / 2, SIZE / 2);
+      render.SetPictureTransform(nearest, m);
+      render.SetPictureTransform(bilinear, m);
+      render.Composite(render.PictOp.Src, nearest, 0, dst,
+        0, 0, 0, 0, 90, 70, SIZE, SIZE);
+      render.Composite(render.PictOp.Src, bilinear, 0, dst,
+        0, 0, 0, 0, 390, 70, SIZE, SIZE);
+      angle += 0.03;
+    }
+
+    X.on('event', ev => {
+      if (ev.name !== 'Expose') return;
+      X.ChangeGC(gc, { foreground: 0xdfe4ea });
+      X.ImageText8(wid, gc, 20, 30,
+        'the same 32x32 pixmap, scaled 5x and rotating: 9 numbers per frame');
+      X.ImageText8(wid, gc, 90, 260, "filter 'nearest'");
+      X.ImageText8(wid, gc, 390, 260, "filter 'bilinear'");
+      painted = true;
+      console.log('source is ' + SRC + 'x' + SRC + ', drawn at ' + SIZE + 'x' + SIZE);
+    });
+
+    setInterval(frame, 40);
+    X.on('error', e => console.error(e));
+  });
+});
+`,
+};

--- a/website/src/demos/shapes.js
+++ b/website/src/demos/shapes.js
@@ -1,0 +1,104 @@
+export default {
+  id: 'shapes',
+  title: 'Arcs, polygons and lines',
+  description:
+    'The core geometry requests: PolyArc, PolyFillArc, FillPoly, PolySegment, PolyLine and PolyRectangle, with line width and arc mode.',
+  screenWidth: 640,
+  screenHeight: 400,
+  code: `const x11 = require('x11');
+
+// Core X11 has no paths and no curves beyond the ellipse: every shape here
+// is one request carrying a flat list of 16-bit coordinates. Angles are in
+// 1/64 of a degree, counter-clockwise from 3 o'clock.
+
+x11.createClient((err, display) => {
+  if (err) throw err;
+  const X = display.client;
+  const screen = display.screen[0];
+
+  const wid = X.AllocID();
+  X.CreateWindow(wid, screen.root, 0, 0, 640, 400, 0, 0, 0, 0, {
+    backgroundPixel: 0x11151a,
+    eventMask: x11.eventMask.Exposure
+  });
+  X.MapWindow(wid);
+
+  const gc = X.AllocID();
+  X.CreateGC(gc, wid, { foreground: 0xdfe4ea, background: 0x11151a, lineWidth: 1 });
+
+  const DEG = 64; // 1/64 degree units
+
+  function label(x, y, text) {
+    X.ChangeGC(gc, { foreground: 0x8892a0, lineWidth: 1 });
+    X.ImageText8(wid, gc, x, y, text);
+  }
+
+  X.on('event', ev => {
+    if (ev.name !== 'Expose') return;
+
+    // ---- outlined ellipse arcs: [x, y, w, h, angle1, angle2] each
+    label(30, 30, 'PolyArc');
+    X.ChangeGC(gc, { foreground: 0x4fc3f7, lineWidth: 2 });
+    X.PolyArc(wid, gc, [
+      30, 44, 120, 90, 0, 360 * DEG,
+      50, 60, 80, 58, 45 * DEG, 180 * DEG
+    ]);
+
+    // ---- filled arcs, and the difference arcMode makes
+    label(200, 30, 'PolyFillArc (chord vs pie)');
+    X.ChangeGC(gc, { foreground: 0xf06292, arcMode: 0 }); // 0 = Chord
+    X.PolyFillArc(wid, gc, [200, 44, 100, 90, 30 * DEG, 220 * DEG]);
+    X.ChangeGC(gc, { foreground: 0xba68c8, arcMode: 1 }); // 1 = PieSlice
+    X.PolyFillArc(wid, gc, [320, 44, 100, 90, 30 * DEG, 220 * DEG]);
+
+    // ---- a filled polygon: shape 0 Complex, coordMode 0 Origin
+    label(450, 30, 'FillPoly');
+    X.ChangeGC(gc, { foreground: 0x81c784 });
+    const star = [];
+    for (let i = 0; i < 10; i++) {
+      const r = i % 2 ? 26 : 58;
+      const a = (i / 10) * Math.PI * 2 - Math.PI / 2;
+      star.push(Math.round(520 + r * Math.cos(a)), Math.round(90 + r * Math.sin(a)));
+    }
+    X.FillPoly(wid, gc, 0, 0, star);
+
+    // ---- disconnected segments: [x1, y1, x2, y2] each
+    label(30, 190, 'PolySegment');
+    X.ChangeGC(gc, { foreground: 0xffb74d, lineWidth: 3 });
+    const segments = [];
+    for (let i = 0; i < 12; i++)
+      segments.push(30 + i * 14, 205, 30 + i * 14 + 10, 275);
+    X.PolySegment(wid, gc, segments);
+
+    // ---- a connected polyline through the same kind of list
+    label(230, 190, 'PolyLine');
+    X.ChangeGC(gc, { foreground: 0x4dd0e1, lineWidth: 2 });
+    const wave = [];
+    for (let i = 0; i <= 40; i++)
+      wave.push(230 + i * 4, Math.round(240 + Math.sin(i / 3) * 32));
+    // note the argument order: PolyLine and PolyPoint take coordMode first,
+    // unlike every other drawing request
+    X.PolyLine(0, wid, gc, wave); // 0 = Origin
+
+    // ---- outlined rectangles
+    label(450, 190, 'PolyRectangle');
+    X.ChangeGC(gc, { foreground: 0xe57373, lineWidth: 2 });
+    const boxes = [];
+    for (let i = 0; i < 5; i++)
+      boxes.push(455 + i * 6, 205 + i * 6, 120 - i * 12, 70 - i * 12);
+    X.PolyRectangle(wid, gc, boxes);
+
+    // ---- line width is GC state, not a per-request argument
+    label(30, 320, 'lineWidth 1, 3, 6, 10: GC state, not a request argument');
+    [1, 3, 6, 10].forEach((w, i) => {
+      X.ChangeGC(gc, { foreground: 0xdfe4ea, lineWidth: w });
+      X.PolySegment(wid, gc, [30 + i * 150, 340, 150 + i * 150, 375]);
+    });
+
+    console.log('six geometry requests, all coordinates 16-bit');
+  });
+
+  X.on('error', e => console.error(e));
+});
+`,
+};

--- a/website/src/demos/window-manager.js
+++ b/website/src/demos/window-manager.js
@@ -1,0 +1,158 @@
+export default {
+  id: 'window-manager',
+  title: 'A window manager',
+  description:
+    'SubstructureRedirect: intercept MapRequest, reparent each client into a frame with a title bar, and drag it by that bar. Two toy clients connect separately so there is something to manage.',
+  screenWidth: 640,
+  screenHeight: 440,
+  code: `const x11 = require('x11');
+
+// Selecting SubstructureRedirect on the root means map and configure
+// requests from OTHER clients are delivered to us as events instead of
+// taking effect. That one event mask is the whole mechanism a window manager
+// is built on — there is no privileged API.
+//
+// Note the two connections. A client's own requests are never redirected to
+// itself, so the toy applications have to be a separate connection or the
+// window manager would simply never hear about them.
+
+x11.createClient((err, wmDisplay) => {
+  if (err) throw err;
+  const WM = wmDisplay.client;
+  const screen = wmDisplay.screen[0];
+  const root = screen.root;
+
+  const TITLE_H = 22;
+  const frames = [];   // { client, frame, x, y, width, height }
+
+  WM.ChangeWindowAttributes(root, {
+    eventMask: x11.eventMask.SubstructureRedirect |
+               x11.eventMask.SubstructureNotify
+  });
+
+  // ImageText8 fills each glyph cell with the GC's BACKGROUND before drawing
+  // the glyph, so both colours have to be set or the text lands on a black
+  // box (or vanishes into one).
+  const gc = WM.AllocID();
+  WM.CreateGC(gc, root, { foreground: 0xecf0f1, background: 0x34495e });
+
+  // a desktop, so the managed windows have something to sit on
+  const desktopGc = WM.AllocID();
+  WM.CreateGC(desktopGc, root, { foreground: 0x1d2b38 });
+  WM.PolyFillRectangle(root, desktopGc, [0, 0, screen.pixel_width, screen.pixel_height]);
+  WM.ChangeGC(desktopGc, { foreground: 0x24374a });
+  const grid = [];
+  for (let x = 0; x < screen.pixel_width; x += 32) grid.push(x, 0, 1, screen.pixel_height);
+  for (let y = 0; y < screen.pixel_height; y += 32) grid.push(0, y, screen.pixel_width, 1);
+  WM.PolyFillRectangle(root, desktopGc, grid);
+
+  function frameFor(client, geom) {
+    const frame = WM.AllocID();
+    WM.CreateWindow(frame, root,
+      geom.xPos, geom.yPos, geom.width, geom.height + TITLE_H, 1, 0, 0, 0, {
+        backgroundPixel: 0x2c3e50,
+        borderPixel: 0x1a252f,
+        eventMask: x11.eventMask.Exposure |
+                   x11.eventMask.ButtonPress |
+                   x11.eventMask.ButtonRelease |
+                   x11.eventMask.PointerMotion
+      });
+    // the client keeps its own size — it just gets a new parent
+    WM.ReparentWindow(client, frame, 0, TITLE_H);
+    WM.MapWindow(frame);
+    WM.MapWindow(client);
+    frames.push({
+      client, frame,
+      x: geom.xPos, y: geom.yPos, width: geom.width, height: geom.height
+    });
+    console.log('framed client ' + client);
+  }
+
+  function paintTitle(frame) {
+    const entry = frames.find(f => f.frame === frame);
+    if (!entry) return;
+    WM.ChangeGC(gc, { foreground: 0x34495e });
+    WM.PolyFillRectangle(frame, gc, [0, 0, entry.width, TITLE_H]);
+    WM.ChangeGC(gc, { foreground: 0xecf0f1 });
+    WM.ImageText8(frame, gc, 8, 15, 'drag this bar');
+    WM.ChangeGC(gc, { foreground: 0xe74c3c });
+    WM.PolyFillRectangle(frame, gc, [entry.width - 18, 6, 10, 10]);
+  }
+
+  let drag = null;
+
+  WM.on('event', ev => {
+    switch (ev.name) {
+      case 'MapRequest':
+        // the client asked to be shown; we decide how
+        if (!frames.some(f => f.client === ev.wid))
+          WM.GetGeometry(ev.wid, (err2, geom) => {
+            if (!err2) frameFor(ev.wid, geom);
+          });
+        break;
+
+      case 'ConfigureRequest':
+        // honour it verbatim — a real WM would apply policy here
+        WM.ConfigureWindow(ev.wid, {
+          x: ev.x, y: ev.y, width: ev.width, height: ev.height
+        });
+        break;
+
+      case 'Expose':
+        paintTitle(ev.wid);
+        break;
+
+      case 'ButtonPress': {
+        const entry = frames.find(f => f.frame === ev.wid);
+        if (entry && ev.y < TITLE_H)
+          drag = { entry, dx: ev.x, dy: ev.y };
+        break;
+      }
+
+      case 'MotionNotify':
+        if (drag) {
+          drag.entry.x = ev.rootx - drag.dx;
+          drag.entry.y = ev.rooty - drag.dy;
+          WM.ConfigureWindow(drag.entry.frame,
+            { x: drag.entry.x, y: drag.entry.y });
+        }
+        break;
+
+      case 'ButtonRelease':
+        drag = null;
+        break;
+    }
+  });
+
+  WM.on('error', e => console.error('wm: ' + e.error));
+
+  // ---- a second connection: two ordinary clients with no idea they are managed
+  x11.createClient((err2, appDisplay) => {
+    if (err2) throw err2;
+    const A = appDisplay.client;
+
+    [
+      { x: 60, y: 70, w: 250, h: 140, bg: 0xf39c12, text: 'client one' },
+      { x: 330, y: 190, w: 240, h: 150, bg: 0x16a085, text: 'client two' }
+    ].forEach(spec => {
+      const wid = A.AllocID();
+      A.CreateWindow(wid, root, spec.x, spec.y, spec.w, spec.h, 0, 0, 0, 0, {
+        backgroundPixel: spec.bg,
+        eventMask: x11.eventMask.Exposure
+      });
+      const cgc = A.AllocID();
+      A.CreateGC(cgc, wid, { foreground: 0x11151a, background: spec.bg });
+      A.on('event', ev => {
+        if (ev.name === 'Expose' && ev.wid === wid) {
+          A.ImageText8(wid, cgc, 12, 28, spec.text);
+          A.ImageText8(wid, cgc, 12, 48, 'I did not draw my own frame');
+        }
+      });
+      A.MapWindow(wid);   // arrives at the WM as a MapRequest
+    });
+
+    A.on('error', e => console.error('app: ' + e.error));
+  });
+});
+`,
+};

--- a/website/src/lib/share.mjs
+++ b/website/src/lib/share.mjs
@@ -1,0 +1,96 @@
+// Shareable playground links: the whole snippet travels in the query
+// string, so there is nothing to store and nothing to expire. A link is
+// self-contained — paste it anywhere and it still works in a year.
+//
+// The payload is `?code=<scheme><base64url>`, where the leading byte says
+// how the rest was packed:
+//   d — raw DEFLATE (CompressionStream), which is what every current
+//       browser and node >= 18 takes; a 2.5 KB demo comes out near 900
+//       characters
+//   p — plain UTF-8, the fallback when CompressionStream is missing
+//
+// base64url (`-` and `_`, no padding) keeps the value legal in a URL
+// without percent-encoding, which is what makes these links survive being
+// pasted into chat clients and issue trackers.
+
+const SCHEME_DEFLATE = 'd';
+const SCHEME_PLAIN = 'p';
+
+/** Refuse to build or accept absurd links rather than hanging the tab. */
+export const MAX_SHARE_BYTES = 64 * 1024;
+
+function toBase64Url(bytes) {
+  // chunked: String.fromCharCode.apply blows the argument limit on big arrays
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 0x8000)
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000));
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function fromBase64Url(text) {
+  const padded = text.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+const hasCompression =
+  typeof CompressionStream === 'function' &&
+  typeof DecompressionStream === 'function';
+
+async function through(bytes, stream) {
+  const response = new Response(new Blob([bytes]).stream().pipeThrough(stream));
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/** Source → the value for the `code` query parameter. */
+export async function encodeShare(source) {
+  const bytes = new TextEncoder().encode(source);
+  if (bytes.length > MAX_SHARE_BYTES)
+    throw new Error(
+      `snippet is ${bytes.length} bytes, over the ${MAX_SHARE_BYTES} byte limit for a link`,
+    );
+  if (!hasCompression) return SCHEME_PLAIN + toBase64Url(bytes);
+  const packed = await through(bytes, new CompressionStream('deflate-raw'));
+  return SCHEME_DEFLATE + toBase64Url(packed);
+}
+
+/**
+ * The `code` query parameter → source. Throws on anything malformed; the
+ * caller is expected to fall back to a built-in demo and say so, since this
+ * input arrives from a stranger's URL.
+ */
+export async function decodeShare(param) {
+  if (typeof param !== 'string' || param.length < 2)
+    throw new Error('empty shared snippet');
+  const scheme = param[0];
+  const bytes = fromBase64Url(param.slice(1));
+  if (scheme === SCHEME_PLAIN) {
+    if (bytes.length > MAX_SHARE_BYTES)
+      throw new Error('shared snippet too large');
+    return new TextDecoder().decode(bytes);
+  }
+  if (scheme !== SCHEME_DEFLATE)
+    throw new Error(`unknown share format "${scheme}"`);
+  if (!hasCompression)
+    throw new Error('this browser cannot read compressed shared snippets');
+  const raw = await through(bytes, new DecompressionStream('deflate-raw'));
+  if (raw.length > MAX_SHARE_BYTES) throw new Error('shared snippet too large');
+  return new TextDecoder().decode(raw);
+}
+
+/**
+ * Absolute URL carrying `source`. A demo embedded in a guide shares to the
+ * playground rather than to the page it sits on — a docs page renders fixed
+ * prose and cannot host someone else's snippet — so the caller passes the
+ * playground's path and we keep only the origin from `location`.
+ */
+export async function shareUrl(source, location, playgroundPath) {
+  const code = await encodeShare(source);
+  const path = playgroundPath || location.pathname;
+  return `${location.origin}${path}?code=${code}`;
+}

--- a/website/src/pages/playground.js
+++ b/website/src/pages/playground.js
@@ -1,14 +1,63 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import clsx from 'clsx';
 import demos from '../demos';
 import LiveDemo from '../components/LiveDemo';
+import { decodeShare } from '../lib/share.mjs';
 import styles from './playground.module.css';
 
+const SHARED_ID = '__shared__';
+
+/**
+ * A snippet that arrived in the URL. Decoding is asynchronous (the payload
+ * is DEFLATE), and the query is read exactly once — pressing Share rewrites
+ * the address bar, and re-reading it then would throw away whatever the
+ * reader had since typed.
+ */
+function useSharedSnippet() {
+  const [shared, setShared] = useState(null);
+  const done = useRef(false);
+
+  useEffect(() => {
+    if (done.current) return undefined;
+    done.current = true;
+    const param = new URLSearchParams(window.location.search).get('code');
+    if (!param) return undefined;
+
+    let live = true;
+    decodeShare(param).then(
+      (code) => live && setShared({ code }),
+      (err) => live && setShared({ error: err.message }),
+    );
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  return shared;
+}
+
 export default function Playground() {
-  const [selectedId, setSelectedId] = useState(demos[0].id);
-  const demo = demos.find((d) => d.id === selectedId) || demos[0];
+  const shared = useSharedSnippet();
+  const [selectedId, setSelectedId] = useState(null);
+
+  // A decoded link selects itself, unless the reader has already clicked
+  // something else.
+  useEffect(() => {
+    if (shared?.code) setSelectedId((current) => current ?? SHARED_ID);
+  }, [shared]);
+
+  const sharedDemo = shared?.code && {
+    id: SHARED_ID,
+    title: 'Shared snippet',
+    description: 'This code came from a link rather than from this site.',
+    code: shared.code,
+  };
+
+  const items = sharedDemo ? [sharedDemo, ...demos] : demos;
+  const demo = items.find((d) => d.id === selectedId) || items[0];
+  const isShared = demo.id === SHARED_ID;
 
   return (
     <Layout
@@ -23,18 +72,36 @@ export default function Playground() {
           ordinary node-x11 client code — the same code you would run in node
           against a real display — connected through a custom{' '}
           <code>DISPLAY</code> transport (<code>demo/local:0</code>). Edit it
-          and press Run.
+          and press Run, or press <strong>Share</strong> for a link that carries
+          the whole snippet in its query string — there is no server storing any
+          of this.
         </p>
+        <div className={styles.perfNote}>
+          <strong>This is the slow way to run an X server.</strong> Everything
+          here is emulation: the server is JavaScript, rasterizing into a canvas
+          on the same main thread as the editor, and input reaches it by{' '}
+          <code>postMessage</code> across an iframe boundary. On a desktop your
+          client talks over a unix socket to a real X server — C, usually
+          GPU-accelerated — which does the compositing and glyph drawing itself.
+          Judge the protocol here; judge the performance there.
+        </div>
+        {shared?.error && (
+          <div className={styles.shareError}>
+            That shared link could not be read ({shared.error}), so here are the
+            built-in demos instead.
+          </div>
+        )}
         <div className={styles.layout}>
           <aside className={styles.sidebar}>
             <ul className={styles.demoList}>
-              {demos.map((d) => (
+              {items.map((d) => (
                 <li key={d.id}>
                   <button
                     type="button"
                     className={clsx(
                       styles.demoButton,
-                      d.id === demo.id && styles.demoButtonActive
+                      d.id === demo.id && styles.demoButtonActive,
+                      d.id === SHARED_ID && styles.demoButtonShared,
                     )}
                     onClick={() => setSelectedId(d.id)}>
                     {d.title}
@@ -48,12 +115,21 @@ export default function Playground() {
               {demo.title}
             </Heading>
             <p className={styles.demoDescription}>{demo.description}</p>
+            {isShared && (
+              <div className={styles.sharedNote}>
+                <strong>This snippet came from a link.</strong> It is ordinary
+                JavaScript and it will run in this page, so read it before you
+                press Run — which is why, unlike the built-in demos, it has not
+                started on its own.
+              </div>
+            )}
             <LiveDemo
               key={demo.id}
               code={demo.code}
               height={demo.height}
               screenWidth={demo.screenWidth}
               screenHeight={demo.screenHeight}
+              autoRun={!isShared}
             />
           </div>
         </div>

--- a/website/src/pages/playground.module.css
+++ b/website/src/pages/playground.module.css
@@ -53,6 +53,40 @@
   font-weight: 600;
 }
 
+.demoButtonShared,
+.demoButtonShared:hover {
+  font-style: italic;
+}
+
+.perfNote,
+.sharedNote,
+.shareError {
+  max-width: 62rem;
+  margin-bottom: var(--ifm-leading);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.perfNote {
+  border-left: 4px solid var(--ifm-color-warning-dark);
+  background: var(--ifm-color-warning-contrast-background);
+  color: var(--ifm-color-warning-contrast-foreground);
+}
+
+.sharedNote {
+  border-left: 4px solid var(--ifm-color-info-dark);
+  background: var(--ifm-color-info-contrast-background);
+  color: var(--ifm-color-info-contrast-foreground);
+}
+
+.shareError {
+  border-left: 4px solid var(--ifm-color-danger-dark);
+  background: var(--ifm-color-danger-contrast-background);
+  color: var(--ifm-color-danger-contrast-foreground);
+}
+
 .demoTitle {
   margin-bottom: 0.25rem;
 }

--- a/website/src/theme/MDXComponents.js
+++ b/website/src/theme/MDXComponents.js
@@ -1,0 +1,10 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import LiveDemo from '@site/src/components/LiveDemo';
+
+// Making LiveDemo global means a guide can drop `<LiveDemo demo="..." />`
+// into the prose without an import line at the top of the file — the import
+// is the kind of boilerplate that discourages adding a demo at all.
+export default {
+  ...MDXComponents,
+  LiveDemo,
+};


### PR DESCRIPTION
The docs site already had a playground with nine live demos behind its own tab. The guides beside it were static listings — which is the wrong way round, because the place a reader wants to try `SetClipRectangles` is the paragraph explaining it, not a separate page they have to carry the idea to.

## Demos in the prose

Guides now embed live demos where the explanation happens:

```mdx
<LiveDemo demo="shapes" compact />
```

`demo="id"` resolves out of `src/demos`, which is the part that matters: a snippet in a guide is now **the same string the playground runs and the same string `check-demos.mjs` executes against a real X server**. A demo in the prose can no longer rot silently while the API moves under it — the previous alternative, pasting code into the page, is unchecked by construction. `LiveDemo` is registered globally via `src/theme/MDXComponents.js`, so embedding one costs a single line and no import.

Mounting is lazy, via IntersectionObserver. Each runner is an X server compositing on a rAF loop, and `windows-and-drawing` now carries eight demos; without this, arriving at that page would boot eight servers. It boots two.

Pages touched: `intro`, `getting-started`, `windows-and-drawing`, `events`, `extensions` (renamed to `.mdx` — `format: 'detect'` means a `.md` file renders `<LiveDemo …>` as literal text).

![pages-demo-crop](https://github.com/user-attachments/assets/ab624d0c-72bb-48fc-a32d-4556136d3c65)

## Nine new demos

Scoped to what the in-browser server actually implements — core protocol, RENDER and GLX. There is no SHAPE or RANDR to demo against, which is now stated on the extensions page rather than left for a reader to discover by trying.

| demo | what it shows |
|---|---|
| `shapes` | `PolyArc`, `PolyFillArc` chord vs pie, `FillPoly`, `PolySegment`, `PolyLine`, `PolyRectangle`; lineWidth as GC state |
| `clip-rects` | a clip list as a stencil — spells CLIP with an ordinary fill |
| `copy-area` | a 960×200 pixmap drawn once, scrolled at two requests per frame |
| `raster-ops` | a `GXxor` rubber band that erases itself by being redrawn |
| `render-operators` | all fourteen Porter-Duff operators |
| `render-gradients` | linear, radial and conical sources with no backing pixmap |
| `render-transform` | `SetPictureTransform` rotating a 32×32 source at 5×, nearest beside bilinear |
| `window-manager` | `SubstructureRedirect`, reparenting, drag by title bar |
| 3 guide-scoped | small enough to read inside prose; kept out of the playground picker |

The operator grid needed some care to be worth looking at: the fourteen operators only differ where **both** sides carry alpha, so each cell is composited in its own depth-32 pixmap and laid over a checkerboard.

![render-operators](https://github.com/user-attachments/assets/6cece661-5bfc-43d9-a82a-aa60cb511c42)

`window-manager` is the one with a protocol subtlety. A client's own requests are never redirected back to itself, so a single connection would never see its own `MapRequest` — it opens two, one managing the screen and one for the toy applications. Neither application drew its title bar or knows it has one.

![window-manager](https://github.com/user-attachments/assets/303d6f96-a0cb-4b2c-bbd4-224ab6357c15)

![shapes](https://github.com/user-attachments/assets/9f9e5eea-6948-40b8-a826-71d97bcfecf3)

![clip-rects](https://github.com/user-attachments/assets/d9aef9fd-0417-4f59-8d83-f02c30304e8c)

## Share links

Ported from react-x11: the snippet travels in the query string (`deflate-raw` + base64url, 64 KB cap), so there is nothing stored and nothing to expire. A demo embedded in a guide shares to the **playground** rather than to the docs page it sits on, since a docs page cannot host someone else's snippet. Code arriving from a link does not auto-run, and says so.

## A documentation bug this surfaced

The gradient example in `windows-and-drawing` passed stops as 16-bit values (`0xffff`, `0x3000`) and commented them as such. But the RENDER binding clamps colour components to 0..1 (`colorToFix`, lib/ext/render.js:274), so **every stop it documented came out fully opaque** — the translucent ramp it described was not what the code produced. The values look like they predate the conversion. Fixed here, with an admonition stating the constraint.

`examples/simple/gradients.js` has the same problem and is deliberately left out of this PR — it is a behaviour change to an example, not documentation.

## Testing

- **18 demos green** (`check-demos`), 2 WebGL-only skipped
- `check-bundle` and the new `check-share` green; both wired into `npm test`
- Site builds clean
- Library suite unchanged: 288 passing / 12 failing, identical on `master` (pre-existing, needs a real XKB server)

Two things went into `check-demos` worth flagging for review. It now sizes the server from the demo instead of assuming 640×480. And it wraps every client's text requests to reject non-ASCII: the server's built-in font is ASCII-only, so an em-dash in an `ImageText8` string draws a **filled box**, which no checksum can detect. That found four real cases in this PR. It runs at call time rather than by scanning source, because demos route text through their own `label()` helpers — a static scan of `ImageText8(...)` spans finds nothing there, which I confirmed by planting a fault and watching the static version pass.

One trap now written down in `AGENTS.md`: `npx docusaurus serve` 301-redirects `/demo/runner.html` to a path without the baseUrl, so every demo iframe shows the site's own homepage. It is a preview-only artifact — `npm start` and GitHub Pages both serve it correctly — but it cost me a while, so the guidance is to verify a build with a plain static server instead.

All screenshots above were rendered by this branch's own demo code driving `lib/xserver` headlessly.