### PR TITLE
fix(render): examples wrote 16-bit colours that silently clamped to opaque

### DIFF
--- a/docs/ext/render.md
+++ b/docs/ext/render.md
@@ -36,6 +36,22 @@ Colors are given as `[r, g, b, a]` arrays of floats in 0..1 (clamped, scaled
 to 16 bits per channel). Coordinates and matrix/filter values are JS numbers
 converted to 16.16 FIXED (truncated to 1/65536 units) on the wire.
 
+Two things about colors are easy to get wrong, and both fail quietly:
+
+- **The range is 0..1, not 0..0xffff.** The client scales to 16 bits for you.
+  A value above 1 is clamped, so a stop list written in 16-bit values
+  (`[0xffff, 0, 0x3000, 0x8000]`) does not come out translucent — every
+  component saturates and the stop is opaque. The client warns once per
+  connection when this happens; set `Render.strictColors = true` to throw
+  instead.
+- **Colors are premultiplied by alpha**, as everywhere in RENDER. Each of
+  `r`, `g`, `b` must be `<= a`. White at half alpha is `[0.5, 0.5, 0.5, 0.5]`,
+  not `[1, 1, 1, 0.5]`, and a fully transparent stop is `[0, 0, 0, 0]`
+  whatever color you were fading from. Out-of-gamut values are not rejected —
+  they composite to something brighter than the alpha allows. Writing
+  `const rgba = (r, g, b, a) => [r * a, g * a, b * a, a]` and calling that is
+  the readable way to keep it straight; the examples do.
+
 ## Requests
 
 ### QueryVersion(clientMajor, clientMinor, cb)
@@ -182,7 +198,20 @@ values (6 per trap: top `l, r, y` then bottom `l, r, y`), offset by
 `offX`,`offY`. No reply.
 
 ### CreateSolidFill(pid, r, g, b, a)
-Creates a solid-fill source picture; channels are floats 0..1. No reply.
+Creates a solid-fill source picture; channels are floats 0..1, premultiplied
+by `a`. No reply.
+
+### strictColors
+Not a request — a flag on the extension object, default `false`. While false,
+a colour component outside 0..1 (or `NaN`) is clamped and warned about once per
+connection. Set it to `true` and the same component throws instead, which is
+useful in tests and when porting code written against a client that took raw
+16-bit values.
+
+```js
+Render.strictColors = true;
+Render.FillRectangles(op, pic, [0xffff, 0, 0, 0xffff], rects); // throws
+```
 
 ### LinearGradient(pid, p1, p2, stops) / CreateLinearGradient(...)
 Creates a linear gradient source from point `p1` to `p2` (`[x, y]` arrays).

--- a/examples/kbdheatmap/kbdheatmap.js
+++ b/examples/kbdheatmap/kbdheatmap.js
@@ -81,11 +81,14 @@ function main(X)
     const gc = X.AllocID();
     X.CreateGC(gc, win);
 
+            // Colours are floats 0..1, premultiplied by alpha. The centre stop
+            // used to read 0x15000, which is past even 16-bit full scale and
+            // silently clamped to opaque — 1 is what it always drew.
             const picGrad = X.AllocID();
             Render.RadialGradient(picGrad, [150/2,150/2], [150/2,150/2], 0, 150/2,
                 [
-                  [0,   [0,0,0,0x15000 ] ],
-                  [1,   [0, 0, 0, 0x0] ]
+                  [0,   [0, 0, 0, 1] ],
+                  [1,   [0, 0, 0, 0] ]
                 ]);
             const pixmapHeatPush = X.AllocID();
             X.CreatePixmap(pixmapHeatPush, win, 32, 150, 150);

--- a/examples/paint.js
+++ b/examples/paint.js
@@ -21,16 +21,22 @@ const xclient = x11.createClient((err, display) => {
 
         const pict = X.AllocID();
         Render.CreatePicture(pict, wid, Render.rgb24);
+        // RENDER colours are floats 0..1, premultiplied by alpha (each of
+        // r,g,b must end up <= a). Multiplying here keeps the stops readable.
+        const rgba = (r, g, b, a) => [r * a, g * a, b * a, a];
+
+        // ten brushes, softest to hardest: flat 6% alpha out to a widening
+        // radius, then fading to nothing at the edge
         const pictGrad = [];
         for (let i=0; i < 10; ++i)
         {
             pictGrad[i] = X.AllocID();
             Render.RadialGradient(pictGrad[i], [50,56], [50,50], 0, 50,
             [
-                [0,   [0,0,0,0x0fff ] ],
-                [0.1 + 0.8*i/10,   [0,0,0,0x0fff ] ],
-                [0.997,   [0xffff, 0xf, 0, 0x1] ],
-                [1,   [0xffff, 0xffff, 0, 0x0] ]
+                [0,   rgba(0, 0, 0, 0.0625) ],
+                [0.1 + 0.8*i/10,   rgba(0, 0, 0, 0.0625) ],
+                [0.997,   rgba(1, 0, 0, 0) ],
+                [1,   rgba(1, 1, 0, 0) ]
             ]);
         }
 

--- a/examples/simple/gradients.js
+++ b/examples/simple/gradients.js
@@ -29,35 +29,41 @@ x11.createClient(
             const pix_pict = X.AllocID();
             Render.CreatePicture(pix_pict, pixmap, Render.rgba32, { polyEdge: 1, polyMode: 0 });
 
+            // RENDER colours are floats 0..1 and PREMULTIPLIED by alpha, so
+            // each of r,g,b must end up <= a. Writing the colour you mean and
+            // letting this helper multiply is clearer, and harder to get
+            // wrong, than premultiplying the constants by hand.
+            const rgba = (r, g, b, a) => [r * a, g * a, b * a, a];
+
             const pic_grad = X.AllocID();
             Render.LinearGradient(pic_grad, [0,0], [1000,100],
             //RenderRadialGradient(pic_grad, [0,0], [1000,100], 10, 1000,
             //RenderConicalGradient(pic_grad, [250,250], 360,
                 [
-                  [0,   [0,0,0,0x3000 ] ],
-                  [0.1, [0xfff, 0, 0xffff, 0x1000] ] ,
-                  [0.25, [0xffff, 0, 0xfff, 0x3000] ] ,
-                  [0.5, [0xffff, 0, 0xffff, 0x4000] ] ,
-                  [1,   [0xffff, 0xffff, 0, 0x8000] ]
+                  [0,   rgba(0, 0, 0, 0.1875) ],
+                  [0.1, rgba(0.0625, 0, 1, 0.0625) ] ,
+                  [0.25, rgba(1, 0, 0.0625, 0.1875) ] ,
+                  [0.5, rgba(1, 0, 1, 0.25) ] ,
+                  [1,   rgba(1, 1, 0, 0.5) ]
                 ]);
 
             const pic_grad1 = X.AllocID();
 
             Render.ConicalGradient(pic_grad1, [250,250], 10,
                 [
-                  [0,   [0,0,0,0x5000 ] ],
-                  [0.1, [0xfff, 0, 0xffff, 0x3000] ] ,
-                  [0.25, [0xffff, 0, 0xfff, 0x2000] ] ,
-                  [0.5, [0xffff, 0, 0xffff, 0x1000] ] ,
-                  [1,   [0xffff, 0xffff, 0, 0x8000] ]
+                  [0,   rgba(0, 0, 0, 0.3125) ],
+                  [0.1, rgba(0.0625, 0, 1, 0.1875) ] ,
+                  [0.25, rgba(1, 0, 0.0625, 0.125) ] ,
+                  [0.5, rgba(1, 0, 1, 0.0625) ] ,
+                  [1,   rgba(1, 1, 0, 0.5) ]
                 ]);
 
             const pic_grad2 = X.AllocID();
             Render.RadialGradient(pic_grad2, [250,250], [250,250], 0, 250,
                 [
-                  [0,   [0,0,0,0x5000 ] ],
-                  [0.99,   [0xffff, 0xffff, 0, 0xffff] ],
-                  [1,   [0xffff, 0xffff, 0, 0x0] ]
+                  [0,   rgba(0, 0, 0, 0.3125) ],
+                  [0.99,   rgba(1, 1, 0, 1) ],
+                  [1,   rgba(1, 1, 0, 0) ]
                 ]);
 
             const pixmap1 = X.AllocID();
@@ -80,7 +86,7 @@ x11.createClient(
 
             function update()
             {
-                Render.FillRectangles(1, pix_pict, [0xffff, 0xffff, 0xffff, 0xffff], [0, 0, 2500, 2500]);
+                Render.FillRectangles(1, pix_pict, [1, 1, 1, 1], [0, 0, 2500, 2500]);
                 Render.Composite(3, pix_pict2, 0, pix_pict, 0, 0, 0, 0, X.x1, X.y1, 2500, 2500);
                 //Render.Composite(3, pic_grad, 0, pix_pict, 0, 0, 0, 0, 0, 0, 500, 500);
                 Render.Composite(3, pix_pict1, 0, pix_pict, 0, 0, 0, 0, X.x2, X.y2, 2500, 2500);

--- a/examples/simple/render.js
+++ b/examples/simple/render.js
@@ -13,13 +13,18 @@ const xclient = x11.createClient((err, display) => {
 
         const pict = X.AllocID();
         Render.CreatePicture(pict, wid, Render.rgb24);
+        // RENDER colours are floats 0..1, premultiplied by alpha (each of
+        // r,g,b must end up <= a). Multiplying here keeps the stops readable.
+        const rgba = (r, g, b, a) => [r * a, g * a, b * a, a];
+
+        // a soft dark disc: flat 6% alpha out to 0.3, then fading to nothing
         const pictGrad = X.AllocID();
         Render.RadialGradient(pictGrad, [26,26], [26,26], 0, 26,
             [
-                [0,   [0,0,0,0x0fff ] ],
-                [0.3,   [0,0,0,0x0fff ] ],
-                [0.997,   [0xffff, 0xf, 0, 0x1] ],
-                [1,   [0xffff, 0xffff, 0, 0x0] ]
+                [0,   rgba(0, 0, 0, 0.0625) ],
+                [0.3,   rgba(0, 0, 0, 0.0625) ],
+                [0.997,   rgba(1, 0, 0, 0) ],
+                [1,   rgba(1, 1, 0, 0) ]
             ]);
 
         function draw(x, y) {

--- a/examples/simple/text/render-glyph.js
+++ b/examples/simple/text/render-glyph.js
@@ -56,27 +56,32 @@ const xclient = x11.createClient({ debug: true }, (err, display) => {
         X.CreatePixmap(pix, root, 32, 1, 1);
         const pictSolidPix = X.AllocID();
         Render.CreatePicture(pictSolidPix, pix, Render.rgba32, {repeat: 1});
-        Render.FillRectangles(1, pictSolidPix, [0x0, 0x0, 0x0, 0xffff], [0, 0, 100, 100]);
+        // colours are floats 0..1 (opaque black here, so [r,g,b,a] directly)
+        Render.FillRectangles(1, pictSolidPix, [0, 0, 0, 1], [0, 0, 100, 100]);
         //X.FreePixmap(pix);
+
+        // RENDER colours are premultiplied by alpha (each of r,g,b must end up
+        // <= a); multiplying here keeps the stops readable.
+        const rgba = (r, g, b, a) => [r * a, g * a, b * a, a];
 
         const pictGrad = X.AllocID();
         Render.RadialGradient(pictGrad, [260,260], [260,260], 0, 260,
             [
-                [0,     [0x0000, 0x0, 0, 0xffff ] ],
-                [0.3,   [0xffff, 0x0, 0, 0xffff ] ],
-                [0.997, [0xffff, 0xf, 0, 0x1] ],
-                [1,     [0x0000, 0x0, 0, 0xffff ] ],
+                [0,     rgba(0, 0, 0, 1) ],
+                [0.3,   rgba(1, 0, 0, 1) ],
+                [0.997, rgba(1, 0, 0, 0) ],
+                [1,     rgba(0, 0, 0, 1) ],
             ]
         );
 
         const pictLinearGrad = X.AllocID();
         Render.LinearGradient(pictLinearGrad, [0,0], [1000,100],
                 [
-                  [0,   [0,0,0,0xffff ] ],
-                 // [0.1, [0xfff, 0, 0xffff, 0x1000] ] ,
-                 // [0.25, [0xffff, 0, 0xfff, 0x3000] ] ,
-                 // [0.5, [0xffff, 0, 0xffff, 0x4000] ] ,
-                  [1,   [0xffff, 0xffff, 0, 0xffff] ]
+                  [0,   rgba(0, 0, 0, 1) ],
+                 // [0.1, rgba(0.0625, 0, 1, 0.0625) ] ,
+                 // [0.25, rgba(1, 0, 0.0625, 0.1875) ] ,
+                 // [0.5, rgba(1, 0, 1, 0.25) ] ,
+                  [1,   rgba(1, 1, 0, 1) ]
                 ]);
 
 
@@ -129,7 +134,7 @@ const xclient = x11.createClient({ debug: true }, (err, display) => {
           if (!x)
             x = 0;
           // TODO: example with multiple glyphsets in one CompositeGlyphs call
-          Render.FillRectangles(1, pict, [0xffff, 0xffff, 0xffff, 0xffff], [0, 0, 3000, 3000]);
+          Render.FillRectangles(1, pict, [1, 1, 1, 1], [0, 0, 3000, 3000]);
           //Render.Composite(3, pictLinearGrad, 0, pict, 0, 0, 0, 0, 0, 0, 2500, 2500);
           // op, src, dst, maskFormat, gsid, srcX, srcY, dstX, dstY, glyphs
           //Render.CompositeGlyphs8(3, pictSolidPix, pict, 0, glyphSet, 0, 0, [[10, 60, process.argv[4]]]);

--- a/examples/smoketest/transpwindow.js
+++ b/examples/smoketest/transpwindow.js
@@ -42,13 +42,18 @@ x11.createClient((err, display) => {
             for (let i=0; i<3; ++i)
                 stops.push(Math.random());
             stops.sort();
+            // Colours are floats 0..1, premultiplied by alpha. These used to be
+            // random 16-bit values, every one of which clamped to 1 — so the
+            // "random" gradient was always opaque white.
             const colors = [];
-            for (let i=0; i<stops.length; ++i)
+            for (let i=0; i<stops.length; ++i) {
+                const a = Math.random();
                 colors.push([stops[i], [
-                    parseInt(Math.random()*65535),
-                    parseInt(Math.random()*65535),
-                    parseInt(Math.random()*65535),
-                    parseInt(Math.random()*65535)]]);
+                    Math.random()*a,
+                    Math.random()*a,
+                    Math.random()*a,
+                    a]]);
+            }
 
             console.log(colors);
 

--- a/examples/smoketest/trapezoids.js
+++ b/examples/smoketest/trapezoids.js
@@ -78,8 +78,9 @@ x11.createClient({ debug: true}, (err, display) => {
       let g;
       let b;
 
-      // fill window
-      r = 1;g = 1;b = 1;a = 0.5;
+      // fill window: white at half alpha. Colours are premultiplied, so each
+      // channel is scaled by the alpha rather than left at full scale.
+      a = 0.5; r = a; g = a; b = a;
       Render.FillRectangles(1, pictBuff, [r, g, b, a], [0, 0, 1000, 1000])
 
       // fill traps

--- a/examples/windowmanager/wm.js
+++ b/examples/windowmanager/wm.js
@@ -37,11 +37,14 @@ function ManageWindow(wid)
             eventMask: events
         });
 
+         // RENDER colours are floats 0..1, premultiplied by alpha. These stops
+         // are opaque, so [r, g, b, 1] needs no premultiplying: blue to green
+         // down the 24px title bar.
          const bggrad = X.AllocID();
          X.Render.LinearGradient(bggrad, [0,0], [0,24],
                 [
-                  [0,   [0,0,0xffff,0xffffff ] ],
-                  [1,   [0x00ff, 0xff00, 0, 0xffffff] ]
+                  [0,   [0, 0, 1, 1] ],
+                  [1,   [0, 1, 0, 1] ]
                 ]);
 
         const framepic = X.AllocID();
@@ -96,16 +99,19 @@ x11.createClient((err, display) => {
         tree.children.forEach(ManageWindow);
     });
 
+    // premultiplied floats 0..1; both live stops are opaque, so [r,g,b,1]
+    // needs no multiplying. The commented-out stops are translucent, so their
+    // colours are already multiplied by their alpha.
     X.bggrad = X.AllocID();
     Render.LinearGradient(X.bggrad, [-10,0], [0,1000],
             //RenderRadialGradient(pic_grad, [0,0], [1000,100], 10, 1000,
             //RenderConicalGradient(pic_grad, [250,250], 360,
                 [
-                  [0,   [0,0,0,0xffffff ] ],
-                  //[0.1, [0xfff, 0, 0xffff, 0x1000] ] ,
-                  //[0.25, [0xffff, 0, 0xfff, 0x3000] ] ,
-                  //[0.5, [0xffff, 0, 0xffff, 0x4000] ] ,
-                  [1,   [0xffff, 0xffff, 0, 0xffffff] ]
+                  [0,   [0, 0, 0, 1] ],
+                  //[0.1, [0.0039, 0, 0.0625, 0.0625] ] ,   // blue  @  6% alpha
+                  //[0.25, [0.1875, 0, 0.0117, 0.1875] ] ,  // red   @ 19% alpha
+                  //[0.5, [0.25, 0, 0.25, 0.25] ] ,         // pink  @ 25% alpha
+                  [1,   [1, 1, 0, 1] ]
                 ]);
 
     X.rootpic = X.AllocID();

--- a/lib/ext/render.js
+++ b/lib/ext/render.js
@@ -271,8 +271,33 @@ exports.requireExt = (display, callback) => {
       return parseInt(f * 65536);
     }
 
+    // Set `Render.strictColors = true` to turn an out-of-range colour
+    // component into a throw instead of a clamp.
+    ext.strictColors = false;
+
+    // Warned at most once per connection: a caller passing 16-bit colours
+    // usually does it in every request, and one warning per gradient stop
+    // would be unreadable.
+    let warnedColorRange = false;
+
     function colorToFix(f) {
-      if (f < 0) f = 0;
+      // Catches NaN as well as out-of-range. A component above 1 is nearly
+      // always a 16-bit value written against a client that did not scale —
+      // clamping it is silent, and the result reads as a rendering bug rather
+      // than a caller bug, which is how such values survive in code for years.
+      if (!(f >= 0 && f <= 1)) {
+        const msg = `Render: color component ${f} is outside 0..1. Components ` +
+          'are floats 0..1, premultiplied by alpha (so r, g and b must each be ' +
+          '<= a); a 16-bit value such as 0xffff saturates to 1.';
+        if (ext.strictColors)
+          throw new Error(msg);
+        if (!warnedColorRange) {
+          warnedColorRange = true;
+          console.warn(`${msg} Set Render.strictColors = true to throw instead ` +
+            'of clamping. Further occurrences are not reported.');
+        }
+      }
+      if (!(f > 0)) f = 0;   // also maps NaN to 0 rather than writing garbage
       if (f > 1) f = 1;
       return parseInt(f * 65535);
     }

--- a/test/xserver/render-fastpath.js
+++ b/test/xserver/render-fastpath.js
@@ -134,7 +134,7 @@ describe('xserver: RENDER fast paths', () => {
             for (let op = 0; op < OPS.length; op++) {
                 it(`${OPS[op]} on depth ${depth}`, done => {
                     bothAgree(depth, pic => {
-                        render.FillRectangles(op, pic, [0x8000, 0x4000, 0xc000, 0xa000],
+                        render.FillRectangles(op, pic, [0.3, 0.15, 0.45, 0.6],
                             [2, 1, 9, 7, 12, 5, 8, 9]);
                     }, `FillRectangles ${OPS[op]} depth ${depth}`, done);
                 });
@@ -143,7 +143,7 @@ describe('xserver: RENDER fast paths', () => {
 
         it('opaque fill covers exactly the rect and nothing else', done => {
             bothAgree(24, pic => {
-                render.FillRectangles(render.PictOp.Src, pic, [0xffff, 0, 0, 0xffff],
+                render.FillRectangles(render.PictOp.Src, pic, [1, 0, 0, 1],
                     [3, 2, 5, 4]);
             }, 'partial opaque fill', done);
         });
@@ -151,7 +151,7 @@ describe('xserver: RENDER fast paths', () => {
         it('a clip list still matches', done => {
             bothAgree(24, pic => {
                 render.SetPictureClipRectangles(pic, 0, 0, [1, 1, 8, 6, 10, 4, 6, 8]);
-                render.FillRectangles(render.PictOp.Src, pic, [0, 0xffff, 0, 0xffff],
+                render.FillRectangles(render.PictOp.Src, pic, [0, 1, 0, 1],
                     [0, 0, W, H]);
             }, 'clipped fill', done);
         });
@@ -162,7 +162,7 @@ describe('xserver: RENDER fast paths', () => {
         it('overlapping clip rectangles composite each pixel once', done => {
             bothAgree(24, pic => {
                 render.SetPictureClipRectangles(pic, 0, 0, [2, 2, 10, 10, 6, 4, 10, 6]);
-                render.FillRectangles(render.PictOp.Over, pic, [0x8000, 0, 0x4000, 0x8000],
+                render.FillRectangles(render.PictOp.Over, pic, [0.5, 0, 0.25, 0.5],
                     [0, 0, W, H]);
             }, 'overlapping clip, Over', done);
         });
@@ -170,7 +170,7 @@ describe('xserver: RENDER fast paths', () => {
         it('clip rectangles given out of x order still match', done => {
             bothAgree(24, pic => {
                 render.SetPictureClipRectangles(pic, 0, 0, [14, 1, 6, 12, 2, 3, 5, 9]);
-                render.FillRectangles(render.PictOp.Over, pic, [0, 0x9000, 0x3000, 0xa000],
+                render.FillRectangles(render.PictOp.Over, pic, [0, 0.5, 0.2, 0.625],
                     [0, 0, W, H]);
             }, 'unsorted clip', done);
         });
@@ -178,7 +178,7 @@ describe('xserver: RENDER fast paths', () => {
         it('a clip origin offset still matches', done => {
             bothAgree(24, pic => {
                 render.SetPictureClipRectangles(pic, 3, 2, [0, 0, 8, 8]);
-                render.FillRectangles(render.PictOp.Src, pic, [0xffff, 0xffff, 0, 0xffff],
+                render.FillRectangles(render.PictOp.Src, pic, [1, 1, 0, 1],
                     [0, 0, W, H]);
             }, 'clip origin', done);
         });
@@ -223,7 +223,7 @@ describe('xserver: RENDER fast paths', () => {
                     const dotPic = X.AllocID();
                     render.CreatePicture(dotPic, dot, render.rgba32);
                     render.FillRectangles(render.PictOp.Src, dotPic,
-                        [0x6000, 0x2000, 0xa000, 0xc000], [0, 0, 1, 1]);
+                        [0.375, 0.125, 0.625, 0.75], [0, 0, 1, 1]);
                     render.ChangePicture(dotPic, { repeat });
                     render.Composite(render.PictOp.Over, dotPic, 0, pic,
                         0, 0, 0, 0, 0, 0, W, H);
@@ -238,7 +238,7 @@ describe('xserver: RENDER fast paths', () => {
                 const dotPic = X.AllocID();
                 render.CreatePicture(dotPic, dot, render.rgba32);
                 render.FillRectangles(render.PictOp.Src, dotPic,
-                    [0x6000, 0x2000, 0xa000, 0xc000], [0, 0, 1, 1]);
+                    [0.375, 0.125, 0.625, 0.75], [0, 0, 1, 1]);
                 render.Composite(render.PictOp.Over, dotPic, 0, pic,
                     0, 0, 0, 0, 0, 0, W, H);
             }, '1x1 repeat None', done);
@@ -251,7 +251,7 @@ describe('xserver: RENDER fast paths', () => {
                 const dotPic = X.AllocID();
                 render.CreatePicture(dotPic, dot, render.rgb24);
                 render.FillRectangles(render.PictOp.Src, dotPic,
-                    [0, 0xffff, 0x4000, 0xffff], [0, 0, 1, 1]);
+                    [0, 1, 0.25, 1], [0, 0, 1, 1]);
                 render.ChangePicture(dotPic, { repeat: 1 });
                 render.SetPictureTransform(dotPic, [3, 0, 0, 0, 3, 0, 0, 0, 1]);
                 render.Composite(render.PictOp.Src, dotPic, 0, pic,
@@ -265,7 +265,7 @@ describe('xserver: RENDER fast paths', () => {
                 X.CreatePixmap(small, root, 24, 4, 4);
                 const smallPic = X.AllocID();
                 render.CreatePicture(smallPic, small, render.rgb24);
-                render.FillRectangles(render.PictOp.Src, smallPic, [0xffff, 0, 0xffff, 0xffff],
+                render.FillRectangles(render.PictOp.Src, smallPic, [1, 0, 1, 1],
                     [0, 0, 4, 4]);
                 render.ChangePicture(smallPic, { repeat: 1 });
                 render.Composite(render.PictOp.Src, smallPic, 0, pic, 0, 0, 0, 0, 0, 0, W, H);
@@ -321,7 +321,7 @@ describe('xserver: RENDER fast paths', () => {
                 X.CreatePixmap(maskPixmap, root, 8, W, H);
                 const mask = X.AllocID();
                 render.CreatePicture(mask, maskPixmap, render.a8);
-                render.FillRectangles(render.PictOp.Src, mask, [0, 0, 0, 0x8000], [0, 0, W, H]);
+                render.FillRectangles(render.PictOp.Src, mask, [0, 0, 0, 0.5], [0, 0, W, H]);
                 render.Composite(render.PictOp.Over, src.pic, mask, pic, 0, 0, 0, 0, 0, 0, W, H);
             }, 'flat mask', done);
         });
@@ -352,7 +352,7 @@ describe('xserver: RENDER fast paths', () => {
                 const dotPic = X.AllocID();
                 render.CreatePicture(dotPic, dot, render.rgba32);
                 render.FillRectangles(render.PictOp.Src, dotPic,
-                    [0x9000, 0x3000, 0x5000, 0xd000], [0, 0, 1, 1]);
+                    [0.5, 0.2, 0.3, 0.8], [0, 0, 1, 1]);
                 render.ChangePicture(dotPic, { repeat: 1 });
                 const mask = mkAlphaPixmap(5);
                 render.Composite(render.PictOp.Over, dotPic, mask.pic, pic,
@@ -396,7 +396,7 @@ describe('xserver: RENDER fast paths', () => {
                 X.CreatePixmap(small, root, 8, 4, 4);
                 const mask = X.AllocID();
                 render.CreatePicture(mask, small, render.a8);
-                render.FillRectangles(render.PictOp.Src, mask, [0, 0, 0, 0x8000], [0, 0, 4, 4]);
+                render.FillRectangles(render.PictOp.Src, mask, [0, 0, 0, 0.5], [0, 0, 4, 4]);
                 render.ChangePicture(mask, { repeat: 1 });
                 render.Composite(render.PictOp.Over, src.pic, mask, pic,
                     0, 0, 0, 0, 0, 0, W, H);

--- a/test/xserver/render.js
+++ b/test/xserver/render.js
@@ -580,6 +580,75 @@ describe('xserver: RENDER', () => {
         });
     });
 
+    describe('colour range', () => {
+
+        // Components are floats 0..1, premultiplied. A 16-bit value like
+        // 0xffff clamps, which used to be silent — every example in this repo
+        // that wrote stops that way rendered fully opaque instead of
+        // translucent, for years, with nothing to notice it by.
+        it('clamps out-of-range components and warns once', done => {
+            const warnings = [];
+            const realWarn = console.warn;
+            console.warn = msg => warnings.push(String(msg));
+
+            const { pic, pixmap } = mkCanvas();
+            // 0x8000 as "half" is the classic mistake: it saturates to full.
+            render.FillRectangles(render.PictOp.Src, pic, [0x8000, 0, 0, 0xffff],
+                [0, 0, W, H]);
+            render.FillRectangles(render.PictOp.Src, pic, [0xffff, 0, 0, 0xffff],
+                [0, 0, 1, 1]);
+
+            readBack(pixmap, data => {
+                console.warn = realWarn;
+                // clamped to full red, not half
+                assert.strictEqual(px(data, 5, 5), 0xff0000);
+                // two offending requests, one warning: the flag lives on the
+                // extension instance, and beforeEach gives each test a fresh
+                // connection, so this is exact rather than order-dependent
+                assert.strictEqual(warnings.length, 1,
+                    `expected exactly one warning, got ${warnings.length}`);
+                assert.match(warnings[0], /outside 0\.\.1/);
+                assert.match(warnings[0], /premultiplied/);
+                done();
+            });
+        });
+
+        it('strictColors turns an out-of-range component into a throw', () => {
+            const { pic } = mkCanvas();
+            render.strictColors = true;
+            try {
+                assert.throws(
+                    () => render.FillRectangles(render.PictOp.Src, pic,
+                        [0xffff, 0, 0, 0xffff], [0, 0, W, H]),
+                    /outside 0\.\.1/);
+                // NaN is caught by the same guard rather than writing garbage
+                assert.throws(
+                    () => render.FillRectangles(render.PictOp.Src, pic,
+                        [NaN, 0, 0, 1], [0, 0, W, H]),
+                    /outside 0\.\.1/);
+                // and valid values still go through untouched
+                assert.doesNotThrow(
+                    () => render.FillRectangles(render.PictOp.Src, pic,
+                        [0.5, 0.25, 0.5, 0.5], [0, 0, W, H]));
+            } finally {
+                render.strictColors = false;
+            }
+        });
+
+        it('CreateSolidFill and gradient stops use the same guard', () => {
+            render.strictColors = true;
+            try {
+                assert.throws(() => render.CreateSolidFill(X.AllocID(), 0xffff, 0, 0, 0xffff),
+                    /outside 0\.\.1/);
+                assert.throws(() => render.CreateLinearGradient(X.AllocID(), [0, 0], [W, 0],
+                    [[0, [0xffff, 0, 0, 0xffff]], [1, [0, 0, 0xffff, 0xffff]]]),
+                    /outside 0\.\.1/);
+            } finally {
+                render.strictColors = false;
+            }
+        });
+    });
+
     describe('errors', () => {
 
         it('bad picture ids raise the Picture error', done => {


### PR DESCRIPTION
`colorToFix` ([lib/ext/render.js:274](https://github.com/sidorares/node-x11/blob/master/lib/ext/render.js#L274)) clamps colour components to 0..1 and scales to 16 bits. The examples were written against a client that passed raw 16-bit values straight through, so every component above 1 saturates — the translucent gradients they describe have not been translucent for years, and nothing said so.

## What it looked like

`examples/paint.js` is the clearest case. Its brush is a radial gradient fading from 6% black to a fully transparent outer stop. With clamping, the 6% became opaque, and the transparent stop — written `[0xffff, 0xffff, 0, 0x0]` — became opaque **yellow**, because alpha `0x0` was the only component small enough to survive. A soft grey brush was painting a hard yellow ribbon:

![paint-before](https://github.com/user-attachments/assets/53bfc870-c26f-4a3e-97cc-6aa05247ee67)

![paint-after](https://github.com/user-attachments/assets/8a733db7-ee5c-4863-ab23-c165d678feda)

`examples/simple/gradients.js`, before and after. Distinct colours on screen go from **511** to **12509**:

![gradients-before](https://github.com/user-attachments/assets/b416d50b-f325-4991-a437-3dd54cda2b41)

![gradients-after](https://github.com/user-attachments/assets/9120e5bf-afbf-499e-8df5-091fb6f5ab6d)

## Why a plain divide by 65535 is not the fix

RENDER colours are **premultiplied by alpha** — each of `r`, `g`, `b` must be `<= a`. That is the fact the docs never stated, and it is what made these values look plausible.

Dividing by 65535 would leave **21 of the 47** colour quads out of gamut (`[0xfff, 0, 0xffff, 0x1000]` becomes blue 1.0 at alpha 0.06), where they clip instead of blending. So the conversion treats the old numbers as straight colour and multiplies by alpha. That agrees with a plain divide wherever alpha is 1 or the colour is 0 — which covers every quad that was already valid.

Examples now write the constraint at the call site instead of baking it into constants:

```js
const rgba = (r, g, b, a) => [r * a, g * a, b * a, a];
```

## Two examples had their own variant of the bug

- **`smoketest/transpwindow.js`** built "random" stops from `Math.random() * 65535` on all four components. Every one clamped to 1, so the random *translucent* gradient was always opaque white.
- **`smoketest/trapezoids.js`** was already using floats, but wrote white-at-half-alpha as `[1, 1, 1, 0.5]`. Premultiplied, that is out of gamut; it is `[0.5, 0.5, 0.5, 0.5]`.

## New: an out-of-range component is no longer silent

Clamping quietly is how this survived, so:

- a component outside 0..1, or `NaN`, warns **once per connection** and names the likely cause
- `Render.strictColors = true` turns it into a throw — useful in tests and when porting code written against the old passthrough behaviour
- `NaN` maps to 0 rather than being written into the buffer as-is

Nothing about the default rendering path changes: valid colours are untouched and still silent.

## Fast-path tests were weaker than they looked

Thirteen scenarios in `test/xserver/render-fastpath.js` passed 16-bit colours, so they were comparing the fast and general paths at **opaque white** rather than at the partial alpha they appear to specify. The equivalence claim held — both paths got the same input — but the coverage did not match the intent. Converted to real premultiplied values; both paths still agree, so nothing was hidden behind the clamp.

## Testing

- `npm run test:xserver` — **284 passing**, including three new tests covering clamp-and-warn-once, `strictColors`, and `NaN`
- `npm run test:glx-emu` — 52 passing
- `npm test` — 288 passing / 12 failing, identical to `master` (pre-existing, needs a fuller XKB server)
- lint clean

Verified by running the examples headlessly against `lib/xserver` using the `check-demos.mjs` harness pattern, and diffing the composited screen before and after. The warn-once test was checked by planting a fault and confirming it fails.

## Scope

Four RENDER examples do not run at all: `kbdheatmap` and `transpwindow` have data bugs, `trapezoids` needs `underscore`, `render-glyph` needs the native `freetype2_render` module. All four fail identically on `master`, so their colours are converted here but the failures are untouched and want a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
