### PR TITLE
feat(events): build events from objects instead of hand-packing 32-byte buffers

### DIFF
--- a/autogen/generate-events.js
+++ b/autogen/generate-events.js
@@ -1,11 +1,15 @@
 'use strict';
 
 /**
- * Generate core X11 event parsers from autogen/proto/xproto.xml.
+ * Generate core X11 event parsers and packers from autogen/proto/xproto.xml.
  * Output: lib/generated/core-events.js
  *
  * Wire layout (32 bytes): type(1), detail/pad(1), seq(2), extra(4), body(24).
  * Parsers receive (type, seq, extra, code, raw) where raw is the 24-byte body.
+ * Packers take the parsed object back to the 32 bytes it came from.
+ *
+ * Both emitters read the same field descriptor (`describeEvent`), so a
+ * parser and its packer can never disagree about an offset.
  */
 
 const fs = require('fs');
@@ -94,6 +98,57 @@ const TYPE_READ = {
   FONT: 'readUInt32LE',
   GCONTEXT: 'readUInt32LE',
   VISUALID: 'readUInt32LE'
+};
+
+/**
+ * Inverse of TYPE_READ. Each entry writes into the full 32-byte packet at an
+ * absolute offset and normalises the value first, so packing a field is total:
+ * out-of-range and negative numbers wrap the way the wire does instead of
+ * throwing ERR_OUT_OF_RANGE from Buffer.write*.
+ */
+const TYPE_WRITE = {
+  BOOL: v => `buf[%d] = ${v} ? 1 : 0;`,
+  BYTE: v => `buf[%d] = ${v} & 0xff;`,
+  CARD8: v => `buf[%d] = ${v} & 0xff;`,
+  INT8: v => `buf[%d] = ${v} & 0xff;`,
+  KEYCODE: v => `buf[%d] = ${v} & 0xff;`,
+  BUTTON: v => `buf[%d] = ${v} & 0xff;`,
+  // signed fields go out through the unsigned writers so that a negative
+  // coordinate wraps to its two's complement instead of throwing
+  CARD16: v => `buf.writeUInt16LE(${v} & 0xffff, %d);`,
+  INT16: v => `buf.writeUInt16LE(${v} & 0xffff, %d);`,
+  CARD32: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  INT32: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  TIMESTAMP: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  WINDOW: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  DRAWABLE: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  ATOM: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  COLORMAP: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  PIXMAP: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  CURSOR: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  FONT: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  GCONTEXT: v => `buf.writeUInt32LE(${v} >>> 0, %d);`,
+  VISUALID: v => `buf.writeUInt32LE(${v} >>> 0, %d);`
+};
+
+/**
+ * ClientMessage bodies are one of three views over the same 20 bytes; the
+ * parser and the packer both branch off this table so they cannot diverge.
+ */
+const CLIENT_MESSAGE_DATA = [
+  { format: 32, count: 5, size: 4, read: 'readUInt32LE', write: 'writeUInt32LE' },
+  { format: 16, count: 10, size: 2, read: 'readUInt16LE', write: 'writeUInt16LE' },
+  { format: 8, count: 20, size: 1, read: 'readUInt8', write: 'writeUInt8' }
+];
+
+/** Keys the parser puts on every event object; no wire field may claim them. */
+const RESERVED_PROPS = new Set(['type', 'seq', 'name', 'values', 'rawData']);
+
+/** Property names of the three hand-written events, for the same uniqueness check. */
+const SPECIAL_PROPS = {
+  KeymapNotify: ['keys'],
+  ClientMessage: ['format', 'wid', 'message_type', 'data'],
+  MappingNotify: ['request', 'firstKeyCode', 'count']
 };
 
 function resolveTypes(typedefs, name) {
@@ -226,26 +281,34 @@ function readExpr(typedefs, f, bufExpr, offset) {
 }
 
 /**
- * Emit a parser function body for one event.
- * Returns { lines, usesHeaderBuf } or null if unsupported (KeymapNotify lists, etc.).
+ * Walk one event's wire layout once and describe where every field lives.
+ * Both emitters below read this, so the parser and the packer cannot end up
+ * disagreeing about an offset.
+ *
+ * Returns { name, number, detail, extra, body[], derived[] } where
+ * `detail` is the byte at absolute offset 1, `extra` the 32-bit slot at 4..7
+ * and each `body` entry carries both the absolute offset and the offset
+ * relative to `raw` (the 24-byte body the parsers are handed).
  */
-function genEventParser(typedefs, ev) {
-  // Special-case ClientMessage (format-dependent data) and MappingNotify / KeymapNotify
-  if (ev.name === 'KeymapNotify')
-    return genKeymapNotify();
-  if (ev.name === 'ClientMessage')
-    return genClientMessage();
-  if (ev.name === 'MappingNotify')
-    return genMappingNotify();
+function describeEvent(typedefs, ev) {
+  if (ev.noSeq) {
+    // The header's sequence number slot is payload for these; both emitters
+    // assume bytes 2-3 are the sequence number. KeymapNotify is the only one
+    // in xproto.xml and is hand-written below.
+    throw new Error(`${ev.name}: no-sequence-number events need a hand-written parser/packer pair`);
+  }
 
-  const lines = [];
-  lines.push(`function parse${ev.name}(type, seq, extra, code, raw, headerBuf) {`);
-  lines.push('  const event = { type: type & 0x7F, seq, name: \'' + ev.name + '\' };');
+  const desc = {
+    name: ev.name,
+    number: ev.number,
+    detail: null,
+    extra: null,
+    body: [],
+    derived: []
+  };
 
   // Walk wire offsets: after type byte at 0. seq at 2..3. Body fields relative to full packet.
   let wire = 1;
-  let assignedDetail = false;
-  let assignedExtra = false;
 
   for (const f of ev.fields) {
     if (f.kind === 'pad') {
@@ -268,67 +331,130 @@ function genEventParser(typedefs, ev) {
       continue;
     }
 
-    if (f.kind === 'list') {
-      lines.push(`  // list ${f.name} not auto-generated`);
-      continue;
-    }
+    if (f.kind === 'list')
+      throw new Error(`${ev.name}: list field ${f.name} needs a hand-written parser/packer pair`);
 
     const sz = fieldSize(typedefs, f);
     const prop = jsName(ev.name, f.name);
+    const type = resolveTypes(typedefs, f.type);
 
     // Align past sequence number if we're about to write into 2..3
-    if (wire === 2) {
+    if (wire === 2)
       wire = 4;
-    }
-    if (wire > 2 && wire < 4) {
-      wire = 4;
-    }
 
     if (wire === 1 && sz === 1) {
-      // detail / first byte → code
-      if (prop !== 'keycode' && prop !== 'detail' && prop !== 'stackMode') {
-        lines.push(`  event.${prop} = code;`);
-      } else {
-        lines.push(`  event.${prop} = code;`);
-      }
-      assignedDetail = true;
+      desc.detail = { prop, type, size: sz };
       wire = 2;
       continue;
     }
 
     if (wire === 4 && sz === 4) {
-      lines.push(`  event.${prop} = extra;`);
-      assignedExtra = true;
+      desc.extra = { prop, type, size: sz };
       wire = 8;
       continue;
     }
 
-    if (wire < 8) {
-      // shouldn't happen for well-formed core events
-      lines.push(`  // unexpected wire offset ${wire} for ${f.name}`);
-      wire += sz;
-      continue;
-    }
+    if (wire < 8)
+      throw new Error(`${ev.name}: field ${f.name} (${sz}b) lands at offset ${wire}, inside the header; it needs a hand-written parser/packer pair`);
 
-    const rawOff = wire - 8;
-    let expr = readExpr(typedefs, f, 'raw', rawOff);
-    if (f.type === 'BOOL' || prop === 'overrideRedirect' || prop === 'fromConfigure') {
-      // ConfigureNotify historically left overrideRedirect as 0/1 number
-      if (ev.name !== 'ConfigureNotify' && (prop === 'overrideRedirect' || prop === 'fromConfigure'))
-        expr = `!!${expr}`;
-    }
-    lines.push(`  event.${prop} = ${expr};`);
+    desc.body.push({
+      prop,
+      type,
+      size: sz,
+      absOff: wire,
+      rawOff: wire - 8,
+      // ConfigureNotify historically left overrideRedirect as a 0/1 number
+      parserCoerces: (prop === 'overrideRedirect' || prop === 'fromConfigure') && ev.name !== 'ConfigureNotify'
+    });
     wire += sz;
   }
 
-  // EnterNotify legacy values[] array
-  if (ev.name === 'EnterNotify' || ev.name === 'LeaveNotify') {
-    lines.push('  event.values = [event.root, event.wid, event.child, event.rootx, event.rooty, event.x, event.y, event.buttons, event.mode];');
+  // EnterNotify/LeaveNotify carry a legacy values[] copy of nine fields it
+  // already reported individually — synthesised on parse, never packed.
+  if (ev.name === 'EnterNotify' || ev.name === 'LeaveNotify')
+    desc.derived.push('values');
+
+  const seen = new Set();
+  for (const prop of propsOf(desc)) {
+    if (RESERVED_PROPS.has(prop))
+      throw new Error(`${ev.name}: field maps to reserved property '${prop}' — add an EVENT_FIELD_ALIAS entry`);
+    if (seen.has(prop))
+      throw new Error(`${ev.name}: two wire fields both map to '${prop}' — add an EVENT_FIELD_ALIAS entry`);
+    seen.add(prop);
   }
+
+  return desc;
+}
+
+function propsOf(desc) {
+  const props = desc.body.map(f => f.prop);
+  if (desc.detail)
+    props.unshift(desc.detail.prop);
+  if (desc.extra)
+    props.push(desc.extra.prop);
+  return props;
+}
+
+/** Emit the parser function for one described event. */
+function emitParser(desc) {
+  const lines = [];
+  lines.push(`function parse${desc.name}(type, seq, extra, code, raw, headerBuf) {`);
+  lines.push(`  const event = { type: type & 0x7F, seq, name: '${desc.name}' };`);
+
+  if (desc.detail)
+    lines.push(`  event.${desc.detail.prop} = code;`);
+  if (desc.extra)
+    lines.push(`  event.${desc.extra.prop} = extra;`);
+
+  for (const f of desc.body) {
+    const method = TYPE_READ[f.type];
+    if (!method)
+      throw new Error(`no reader for ${f.type}`);
+    const expr = `raw.${method}(${f.rawOff})`;
+    lines.push(`  event.${f.prop} = ${f.parserCoerces ? `!!${expr}` : expr};`);
+  }
+
+  if (desc.derived.includes('values'))
+    lines.push('  event.values = [event.root, event.wid, event.child, event.rootx, event.rooty, event.x, event.y, event.buttons, event.mode];');
 
   lines.push('  return event;');
   lines.push('}');
-  return { name: ev.name, number: ev.number, code: lines.join('\n'), assignedDetail, assignedExtra };
+  return lines.join('\n');
+}
+
+/**
+ * Emit the packer function for one described event: the same field map, run
+ * backwards into a zero-filled 32-byte buffer. Offsets are absolute, so no
+ * raw/headerBuf split is needed on this side.
+ */
+function emitPacker(desc) {
+  const lines = [];
+  lines.push(`function pack${desc.name}(ev, buf) {`);
+  lines.push(`  buf[0] = ${desc.number};`);
+  if (desc.detail)
+    lines.push('  ' + writeExpr(desc.detail.type, `ev.${desc.detail.prop}`, 1));
+  else
+    lines.push('  buf[1] = 0;');
+  lines.push('  buf.writeUInt16LE(ev.seq & 0xffff, 2);');
+  if (desc.extra)
+    lines.push('  ' + writeExpr(desc.extra.type, `ev.${desc.extra.prop}`, 4));
+
+  for (const f of desc.body)
+    lines.push('  ' + writeExpr(f.type, `ev.${f.prop}`, f.absOff));
+
+  if (desc.derived.includes('values'))
+    lines.push('  // values[] duplicates fields already written above; derived on parse, not packed');
+
+  lines.push('  return buf;');
+  lines.push('}');
+  return lines.join('\n');
+}
+
+function writeExpr(type, valueExpr, absOff) {
+  const write = TYPE_WRITE[type];
+  if (!write)
+    throw new Error(`no writer for ${type}`);
+  return write(valueExpr).replace('%d', absOff);
 }
 
 function genClientMessage() {
@@ -339,17 +465,41 @@ function genClientMessage() {
   lines.push('  event.wid = extra;');
   lines.push('  event.message_type = raw.readUInt32LE(0);');
   lines.push('  const data = [];');
-  lines.push('  if (code === 32) {');
-  lines.push('    for (let i = 0; i < 5; i++) data.push(raw.readUInt32LE(4 + i * 4));');
-  lines.push('  } else if (code === 16) {');
-  lines.push('    for (let i = 0; i < 10; i++) data.push(raw.readUInt16LE(4 + i * 2));');
-  lines.push('  } else {');
-  lines.push('    for (let i = 0; i < 20; i++) data.push(raw.readUInt8(4 + i));');
+  CLIENT_MESSAGE_DATA.forEach((v, i) => {
+    const head = i === 0 ? `  if (code === ${v.format}) {`
+      : i === CLIENT_MESSAGE_DATA.length - 1 ? '  } else {'
+        : `  } else if (code === ${v.format}) {`;
+    lines.push(head);
+    lines.push(`    for (let i = 0; i < ${v.count}; i++) data.push(raw.${v.read}(4 + i${v.size === 1 ? '' : ` * ${v.size}`}));`);
+  });
   lines.push('  }');
   lines.push('  event.data = data;');
   lines.push('  return event;');
   lines.push('}');
-  return { name: 'ClientMessage', number: 33, code: lines.join('\n') };
+
+  const p = [];
+  p.push('function packClientMessage(ev, buf) {');
+  p.push('  buf[0] = 33;');
+  p.push('  buf[1] = ev.format & 0xff;');
+  p.push('  buf.writeUInt16LE(ev.seq & 0xffff, 2);');
+  p.push('  buf.writeUInt32LE(ev.wid >>> 0, 4);');
+  p.push('  buf.writeUInt32LE(ev.message_type >>> 0, 8);');
+  p.push('  const data = ev.data || [];');
+  CLIENT_MESSAGE_DATA.forEach((v, i) => {
+    const head = i === 0 ? `  if (ev.format === ${v.format}) {`
+      : i === CLIENT_MESSAGE_DATA.length - 1 ? '  } else {'
+        : `  } else if (ev.format === ${v.format}) {`;
+    // masked, not range-checked: XDND and friends compose data words like
+    // (x << 16) | y, which is a negative number in JS
+    const norm = v.size === 4 ? 'data[i] >>> 0' : `data[i] & 0x${'ff'.repeat(v.size)}`;
+    p.push(head);
+    p.push(`    for (let i = 0; i < ${v.count}; i++) buf.${v.write}(${norm}, 12 + i${v.size === 1 ? '' : ` * ${v.size}`});`);
+  });
+  p.push('  }');
+  p.push('  return buf;');
+  p.push('}');
+
+  return { name: 'ClientMessage', number: 33, code: lines.join('\n'), packCode: p.join('\n') };
 }
 
 function genMappingNotify() {
@@ -361,7 +511,21 @@ function genMappingNotify() {
   lines.push('  event.count = headerBuf[6];');
   lines.push('  return event;');
   lines.push('}');
-  return { name: 'MappingNotify', number: 34, code: lines.join('\n') };
+
+  // Three byte-granular fields inside the 32-bit "extra" slot, so they are
+  // written at absolute offsets rather than through the generic body walk.
+  const p = [];
+  p.push('function packMappingNotify(ev, buf) {');
+  p.push('  buf[0] = 34;');
+  p.push('  buf[1] = 0;');
+  p.push('  buf.writeUInt16LE(ev.seq & 0xffff, 2);');
+  p.push('  buf[4] = ev.request & 0xff;');
+  p.push('  buf[5] = ev.firstKeyCode & 0xff;');
+  p.push('  buf[6] = ev.count & 0xff;');
+  p.push('  return buf;');
+  p.push('}');
+
+  return { name: 'MappingNotify', number: 34, code: lines.join('\n'), packCode: p.join('\n') };
 }
 
 function genKeymapNotify() {
@@ -373,8 +537,92 @@ function genKeymapNotify() {
   lines.push('  event.keys = Buffer.concat([headerBuf.slice(1, 8), raw]);');
   lines.push('  return event;');
   lines.push('}');
-  return { name: 'KeymapNotify', number: 11, code: lines.join('\n') };
+
+  // The only event with no sequence number: bytes 2-3 are key bits, so this
+  // packer must not stamp them. `keys` is the 31 bytes from offset 1 on,
+  // matching what the parser hands back (keys[i] is wire byte i + 1).
+  const p = [];
+  p.push('function packKeymapNotify(ev, buf) {');
+  p.push('  buf[0] = 11;');
+  p.push('  if (ev.keys) Buffer.from(ev.keys).copy(buf, 1, 0, 31);');
+  p.push('  return buf;');
+  p.push('}');
+
+  return { name: 'KeymapNotify', number: 11, code: lines.join('\n'), packCode: p.join('\n') };
 }
+
+/** Emitted verbatim: the packer counterpart of unpackEvent. */
+const PACK_EVENT = `
+/**
+ * Build the 32-byte wire form of an event, ready to hand to SendEvent.
+ *
+ * \`ev\` is shaped like the objects unpackEvent produces: \`name\` (or \`type\`)
+ * selects the layout and the remaining properties are the fields; anything
+ * left out packs as zero. The sequence number at bytes 2-3 and the 0x80
+ * "came from SendEvent" bit are filled in by the server, so callers do not
+ * need to supply them. Pass \`buf\` to pack into an existing 32-byte buffer
+ * (it is zeroed first) instead of allocating a new one.
+ */
+function packEvent(ev, buf) {
+  if (!ev || typeof ev !== 'object')
+    throw new TypeError('packEvent: expected an event object, got ' + typeof ev);
+
+  let type;
+  const named = ev.name === undefined ? undefined : eventTypes[ev.name];
+  if (ev.name !== undefined && named === undefined)
+    throw new TypeError('packEvent: unknown event name ' + JSON.stringify(ev.name));
+
+  if (typeof ev.type === 'number') {
+    type = ev.type & 0x7f;
+    // Extension events reuse core event names (XFixes has its own
+    // SelectionNotify); trusting the name alone would pack one as the other.
+    if (named !== undefined && named !== type) {
+      throw new TypeError('packEvent: ' + JSON.stringify(ev.name) + ' is core event ' +
+        named + ' but this event has type ' + type +
+        ' — extension events are not packed by name');
+    }
+  } else if (named !== undefined) {
+    type = named;
+  } else {
+    throw new TypeError('packEvent: event needs a name or a numeric type');
+  }
+
+  const fn = packers[type];
+  if (!fn) {
+    throw new TypeError(type === 35
+      ? 'packEvent: GenericEvent (35) has no fixed 32-byte form and cannot be sent with SendEvent'
+      : 'packEvent: no packer for event type ' + type);
+  }
+
+  if (type === 33) {
+    // The server rejects any other format with BadValue, and the format
+    // decides how it byte-swaps the 20 data bytes for the recipient.
+    if (ev.format !== 8 && ev.format !== 16 && ev.format !== 32)
+      throw new TypeError('packEvent: ClientMessage format must be 8, 16 or 32, got ' + ev.format);
+    const room = ev.format === 32 ? 5 : ev.format === 16 ? 10 : 20;
+    if (ev.data && ev.data.length > room) {
+      throw new TypeError('packEvent: ClientMessage data holds ' + room + ' values at format ' +
+        ev.format + ', got ' + ev.data.length);
+    }
+  }
+
+  if (buf === undefined) {
+    buf = Buffer.alloc(32);
+  } else {
+    if (!Buffer.isBuffer(buf))
+      throw new TypeError('packEvent: target must be a Buffer');
+    if (buf.length < 32)
+      throw new TypeError('packEvent: target buffer must be at least 32 bytes, got ' + buf.length);
+    // Return exactly the event's 32 bytes even when packing into a larger
+    // slot, so the result can go straight to SendEvent. Unused bytes must be
+    // zero: every convention built on ClientMessage (EWMH, XEmbed, XDND)
+    // requires that of the sender.
+    buf = buf.length === 32 ? buf : buf.subarray(0, 32);
+    buf.fill(0);
+  }
+  return fn(ev, buf);
+}
+`;
 
 function main() {
   parseProto((err, { typedefs, events }) => {
@@ -393,15 +641,37 @@ function main() {
       'ColormapNotify', 'ClientMessage', 'MappingNotify'
     ];
 
+    // Hand-written pairs: format-dependent body, byte fields inside the
+    // header, and the one event with no sequence number.
+    const SPECIAL = {
+      ClientMessage: genClientMessage,
+      MappingNotify: genMappingNotify,
+      KeymapNotify: genKeymapNotify
+    };
+
     const parsers = [];
     for (const name of wanted) {
       const ev = events[name];
       if (!ev)
         throw new Error(`missing event ${name}`);
-      const p = genEventParser(typedefs, ev);
-      if (!p)
+
+      if (SPECIAL[name]) {
+        const p = SPECIAL[name]();
+        for (const prop of SPECIAL_PROPS[name]) {
+          if (RESERVED_PROPS.has(prop))
+            throw new Error(`${name}: field maps to reserved property '${prop}'`);
+        }
+        parsers.push(p);
         continue;
-      parsers.push(p);
+      }
+
+      const desc = describeEvent(typedefs, ev);
+      parsers.push({
+        name: desc.name,
+        number: desc.number,
+        code: emitParser(desc),
+        packCode: emitPacker(desc)
+      });
     }
 
     const out = [];
@@ -413,10 +683,24 @@ function main() {
       out.push(p.code);
       out.push('');
     }
+    for (const p of parsers) {
+      out.push(p.packCode);
+      out.push('');
+    }
 
     out.push('const parsers = {');
     for (const p of parsers)
       out.push(`  ${p.number}: parse${p.name},`);
+    out.push('};');
+    out.push('');
+    out.push('const packers = {');
+    for (const p of parsers)
+      out.push(`  ${p.number}: pack${p.name},`);
+    out.push('};');
+    out.push('');
+    out.push('const eventTypes = {');
+    for (const p of parsers)
+      out.push(`  ${p.name}: ${p.number},`);
     out.push('};');
     out.push('');
     out.push('function unpackEvent(type, seq, extra, code, raw, headerBuf) {');
@@ -426,12 +710,14 @@ function main() {
     out.push('  return { type: t, seq };');
     out.push('}');
     out.push('');
-    out.push('module.exports = { unpackEvent, parsers };');
+    out.push(PACK_EVENT.trim());
+    out.push('');
+    out.push('module.exports = { unpackEvent, parsers, packEvent, packers, eventTypes };');
     out.push('');
 
     fs.mkdirSync(path.dirname(OUT), { recursive: true });
     fs.writeFileSync(OUT, out.join('\n'));
-    console.log(`wrote ${OUT} (${parsers.length} event parsers)`);
+    console.log(`wrote ${OUT} (${parsers.length} event parsers + packers)`);
   });
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -215,6 +215,10 @@ extension name. Requiring an extension twice returns the cached instance.
 ## Other exports
 
 - `x11.eventMask` — event mask bit names
+- `x11.packEvent` — build the 32 wire bytes of an event for `SendEvent`, also
+  available on the client as `X.packEvent`
+  (see [core-events.md](core-events.md#building-events-to-send))
+- `x11.eventTypes` — event name → protocol event number
 - `x11.keySyms` — keysym tables (lazy-loaded)
 - `x11.gcFunction` — GC raster operation constants (lazy-loaded)
 - `x11.createServer` — experimental X server implementation

--- a/docs/core-events.md
+++ b/docs/core-events.md
@@ -38,8 +38,54 @@ SelectionClear/SelectionRequest arrive at selection owners.
 Every parsed event carries `type` (numeric event code), `name`, `seq`
 (sequence number of the last request processed before the event; absent on
 KeymapNotify) and the fields listed below. The client additionally attaches
-`rawData`, the raw 32-byte wire packet, which can be passed to `SendEvent`
-unchanged. Field lists below name only the event-specific fields.
+`rawData`, the raw wire packet — 32 bytes for a core event, which can be
+passed to `SendEvent` unchanged; longer for a GenericEvent, which cannot be
+sent at all. Field lists below name only the event-specific fields.
+
+## Building events to send
+
+`x11.packEvent(event[, buffer])` is the inverse of the parsers: it turns an
+event object — the same shape the events below describe — into the 32-byte
+wire form [`SendEvent`](core-requests.md#sendeventdestination-propagate-eventmask-event)
+expects. `SendEvent` calls it for you, so an object can be passed directly:
+
+```js
+X.SendEvent(wid, 0, 0, {
+    name: 'ClientMessage',
+    format: 32,
+    wid: wid,
+    message_type: WM_PROTOCOLS,
+    data: [WM_DELETE_WINDOW, 0]
+});
+```
+
+Every event on this page except GenericEvent can be packed — GenericEvent has
+no fixed 32-byte form — and `x11.eventTypes` maps those 33 names to their
+protocol numbers. The same function is on the client as `X.packEvent`. Notes
+that apply to all of them:
+
+- Fields left out are packed as zero, and unused bytes are always zero — what
+  EWMH, XEmbed and XDND require of a sender.
+- `seq` (bytes 2-3) and the `0x80` "synthetic" bit are the server's to fill
+  in, so callers do not supply them; the server rewrites both for each
+  recipient, so not even forwarding `rawData` verbatim delivers them intact.
+  KeymapNotify is the exception that has no sequence number at all: its bytes
+  1-31 are entirely payload.
+- Out-of-range and negative values wrap to the width of their field rather
+  than throwing, so a negative coordinate — or an XDND data word composed as
+  `(x << 16) | y` — packs the way the wire encodes it.
+- Passing a `buffer` packs into its first 32 bytes instead of allocating (they
+  are zeroed first; the rest is untouched) and returns just those 32 bytes.
+  It must be a Buffer of at least 32 bytes.
+- Invalid input throws a `TypeError` rather than producing a packet the server
+  rejects asynchronously: an unknown event name, a GenericEvent, an extension
+  event that reuses a core event's name (the numeric `type` wins, and there is
+  no packer for it), a ClientMessage `format` other than 8, 16 or 32, or more
+  `data` values than the format holds.
+
+ClientMessage has a shortcut, since it carries nearly every window-manager
+conversation — see
+[`SendClientMessage`](core-requests.md#sendclientmessagedestination-wid-message_type-format-data-eventmask-cb).
 
 ## Keyboard and pointer
 

--- a/docs/core-requests.md
+++ b/docs/core-requests.md
@@ -2,7 +2,8 @@
 
 Reference for all 120 requests of the X11 core protocol as implemented on the
 client object (`X = display.client`, see [README.md](README.md) for connecting
-and the general calling convention). Requests with a reply take a trailing
+and the general calling convention), plus one convenience wrapper built on top
+of them (`SendClientMessage`). Requests with a reply take a trailing
 `cb(err, result)`; requests without one state "No reply." — they can be fired
 and forgotten, or given a trailing `cb(err)` invoked exactly once: `null` on
 success (confirmed via a sync round trip when necessary) or the X error the
@@ -155,11 +156,68 @@ Opcode 24. No reply. Asks the selection owner to convert `selection` to
 `target` and store it in `property` on `requestor`; results arrive as a
 SelectionNotify event. `time` optional.
 
-### SendEvent(destination, propagate, eventMask, eventRawData)
+### SendEvent(destination, propagate, eventMask, event)
 Opcode 25. No reply. Sends a synthetic event. `destination` is a window id
-or `x11.PointerWindow` (0) / `x11.InputFocus` (1); `eventRawData` must be a
-32-byte Buffer in wire format — the `rawData` property of a received event
-works directly.
+or `x11.PointerWindow` (0) / `x11.InputFocus` (1).
+
+`event` is either an event object — see
+[Building events to send](core-events.md#building-events-to-send) — or a
+32-byte Buffer already in wire format, such as the `rawData` property of a
+received event. Anything that is not exactly 32 bytes throws.
+
+`eventMask` selects who receives it: the event goes to every client that
+selected one of those bits on `destination`. An **empty mask (0) is not "no
+delivery"** — it sends the event to the client that created `destination`,
+which is how ICCCM WM_PROTOCOLS, XEmbed and XDND messages reach their target
+regardless of what it selected. EWMH messages addressed to the root window
+use `SubstructureRedirect|SubstructureNotify` instead. `propagate` is false
+for every one of those conventions.
+
+```js
+// answer a SelectionRequest, ICCCM 2.2 (property 0 = refused)
+X.SendEvent(ev.requestor, 0, 0, {
+    name: 'SelectionNotify',
+    time: ev.time,
+    requestor: ev.requestor,
+    selection: ev.selection,
+    target: ev.target,
+    property: ev.property
+});
+```
+
+### SendClientMessage(destination, wid, message_type, format, data, eventMask, cb)
+Convenience wrapper over `SendEvent` (opcode 25) for the event that carries
+most window-manager traffic. No reply; `cb(err)` may be passed in place of
+`eventMask` or after it, and fires once the server has processed the request.
+
+`destination` is the window the message is *delivered* to and `wid` the window
+it is *about*; for EWMH root-window messages those differ. `format` is 8, 16
+or 32 and decides how the server byte-swaps `data` for the recipient — it must
+match how the values were composed. `data` holds up to 20/10/5 values
+respectively and is zero-padded.
+
+`eventMask` defaults to `SubstructureRedirect|SubstructureNotify`, what EWMH
+requires for messages sent to the root. Messages aimed at another client's own
+window need an explicit `0` — including when a callback is passed in the
+`eventMask` position, which leaves the root-window default in place.
+
+None of the atoms below are predefined (`X.atoms` holds only the 68 that are),
+so intern them first:
+
+```js
+X.InternAtom(false, '_NET_WM_STATE', (err, _NET_WM_STATE) => {
+    X.InternAtom(false, '_NET_WM_STATE_FULLSCREEN', (err, fullscreen) => {
+        // ask the window manager to fullscreen us (EWMH _NET_WM_STATE)
+        X.SendClientMessage(root, wid, _NET_WM_STATE, 32,
+            [1 /* add */, fullscreen, 0, 1 /* normal application */]);
+    });
+});
+
+// tell a client to close (ICCCM WM_DELETE_WINDOW). `time` is the timestamp of
+// the event that prompted this, and the empty mask is what routes the message
+// to the window's own client
+X.SendClientMessage(wid, wid, WM_PROTOCOLS, 32, [WM_DELETE_WINDOW, time], 0);
+```
 
 ## Grabs & input control
 

--- a/examples/smoketest/sendevent.js
+++ b/examples/smoketest/sendevent.js
@@ -41,16 +41,8 @@ xclient.on('connect', function(display) {
             // send copy of event to the second window
             if (ev.wid == wid) // don't send it from second window
             {
-                // set window in the event we are sending
-                const n = wid1;
-                let offset = 12;
-                const buf = ev.rawData;
-                buf[offset++] = n & 0xff;
-                buf[offset++] = (n >> 8) & 0xff;
-                buf[offset++] = (n >> 16) & 0xff;
-                buf[offset++] = (n >> 24) & 0xff;
-
-                X.SendEvent(wid1, 1, PointerMotion, ev.rawData);
+                // same event, re-addressed to the second window
+                X.SendEvent(wid1, 1, PointerMotion, Object.assign({}, ev, { wid: wid1 }));
             } else {
                 console.log('GotData!');
             }

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -3,6 +3,7 @@
 
 const xutil = require('./xutil');
 const coreReplies = require('./generated/core-replies');
+const coreEvents = require('./generated/core-events');
 
 const valueMask = {
     CreateWindow: {
@@ -739,8 +740,16 @@ const templates = {
 
    SendEvent: [
 
-       (destination, propagate, eventMask, eventRawData) => {
-           const b = Buffer.alloc(12 + eventRawData.length);
+       (destination, propagate, eventMask, event) => {
+           // Either the raw 32 wire bytes (a received event's rawData) or an
+           // event object in the shape the parsers produce.
+           const eventRawData = Buffer.isBuffer(event) ? event : coreEvents.packEvent(event);
+           if (eventRawData.length !== 32) {
+               throw new TypeError(
+                   `SendEvent: event must be exactly 32 bytes, got ${eventRawData.length}` +
+                   ' (GenericEvent bodies cannot be sent)');
+           }
+           const b = Buffer.alloc(44);
            b[0] = 25;
            b[1] = propagate;
            b.writeUInt16LE(11, 2);

--- a/lib/generated/core-events.js
+++ b/lib/generated/core-events.js
@@ -367,6 +367,423 @@ function parseMappingNotify(type, seq, extra, code, raw, headerBuf) {
   return event;
 }
 
+function packKeyPress(ev, buf) {
+  buf[0] = 2;
+  buf[1] = ev.keycode & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.root >>> 0, 8);
+  buf.writeUInt32LE(ev.wid >>> 0, 12);
+  buf.writeUInt32LE(ev.child >>> 0, 16);
+  buf.writeUInt16LE(ev.rootx & 0xffff, 20);
+  buf.writeUInt16LE(ev.rooty & 0xffff, 22);
+  buf.writeUInt16LE(ev.x & 0xffff, 24);
+  buf.writeUInt16LE(ev.y & 0xffff, 26);
+  buf.writeUInt16LE(ev.buttons & 0xffff, 28);
+  buf[30] = ev.sameScreen ? 1 : 0;
+  return buf;
+}
+
+function packKeyRelease(ev, buf) {
+  buf[0] = 3;
+  buf[1] = ev.keycode & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.root >>> 0, 8);
+  buf.writeUInt32LE(ev.wid >>> 0, 12);
+  buf.writeUInt32LE(ev.child >>> 0, 16);
+  buf.writeUInt16LE(ev.rootx & 0xffff, 20);
+  buf.writeUInt16LE(ev.rooty & 0xffff, 22);
+  buf.writeUInt16LE(ev.x & 0xffff, 24);
+  buf.writeUInt16LE(ev.y & 0xffff, 26);
+  buf.writeUInt16LE(ev.buttons & 0xffff, 28);
+  buf[30] = ev.sameScreen ? 1 : 0;
+  return buf;
+}
+
+function packButtonPress(ev, buf) {
+  buf[0] = 4;
+  buf[1] = ev.keycode & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.root >>> 0, 8);
+  buf.writeUInt32LE(ev.wid >>> 0, 12);
+  buf.writeUInt32LE(ev.child >>> 0, 16);
+  buf.writeUInt16LE(ev.rootx & 0xffff, 20);
+  buf.writeUInt16LE(ev.rooty & 0xffff, 22);
+  buf.writeUInt16LE(ev.x & 0xffff, 24);
+  buf.writeUInt16LE(ev.y & 0xffff, 26);
+  buf.writeUInt16LE(ev.buttons & 0xffff, 28);
+  buf[30] = ev.sameScreen ? 1 : 0;
+  return buf;
+}
+
+function packButtonRelease(ev, buf) {
+  buf[0] = 5;
+  buf[1] = ev.keycode & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.root >>> 0, 8);
+  buf.writeUInt32LE(ev.wid >>> 0, 12);
+  buf.writeUInt32LE(ev.child >>> 0, 16);
+  buf.writeUInt16LE(ev.rootx & 0xffff, 20);
+  buf.writeUInt16LE(ev.rooty & 0xffff, 22);
+  buf.writeUInt16LE(ev.x & 0xffff, 24);
+  buf.writeUInt16LE(ev.y & 0xffff, 26);
+  buf.writeUInt16LE(ev.buttons & 0xffff, 28);
+  buf[30] = ev.sameScreen ? 1 : 0;
+  return buf;
+}
+
+function packMotionNotify(ev, buf) {
+  buf[0] = 6;
+  buf[1] = ev.keycode & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.root >>> 0, 8);
+  buf.writeUInt32LE(ev.wid >>> 0, 12);
+  buf.writeUInt32LE(ev.child >>> 0, 16);
+  buf.writeUInt16LE(ev.rootx & 0xffff, 20);
+  buf.writeUInt16LE(ev.rooty & 0xffff, 22);
+  buf.writeUInt16LE(ev.x & 0xffff, 24);
+  buf.writeUInt16LE(ev.y & 0xffff, 26);
+  buf.writeUInt16LE(ev.buttons & 0xffff, 28);
+  buf[30] = ev.sameScreen ? 1 : 0;
+  return buf;
+}
+
+function packEnterNotify(ev, buf) {
+  buf[0] = 7;
+  buf[1] = ev.detail & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.root >>> 0, 8);
+  buf.writeUInt32LE(ev.wid >>> 0, 12);
+  buf.writeUInt32LE(ev.child >>> 0, 16);
+  buf.writeUInt16LE(ev.rootx & 0xffff, 20);
+  buf.writeUInt16LE(ev.rooty & 0xffff, 22);
+  buf.writeUInt16LE(ev.x & 0xffff, 24);
+  buf.writeUInt16LE(ev.y & 0xffff, 26);
+  buf.writeUInt16LE(ev.buttons & 0xffff, 28);
+  buf[30] = ev.mode & 0xff;
+  buf[31] = ev.sameScreenFocus & 0xff;
+  // values[] duplicates fields already written above; derived on parse, not packed
+  return buf;
+}
+
+function packLeaveNotify(ev, buf) {
+  buf[0] = 8;
+  buf[1] = ev.detail & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.root >>> 0, 8);
+  buf.writeUInt32LE(ev.wid >>> 0, 12);
+  buf.writeUInt32LE(ev.child >>> 0, 16);
+  buf.writeUInt16LE(ev.rootx & 0xffff, 20);
+  buf.writeUInt16LE(ev.rooty & 0xffff, 22);
+  buf.writeUInt16LE(ev.x & 0xffff, 24);
+  buf.writeUInt16LE(ev.y & 0xffff, 26);
+  buf.writeUInt16LE(ev.buttons & 0xffff, 28);
+  buf[30] = ev.mode & 0xff;
+  buf[31] = ev.sameScreenFocus & 0xff;
+  // values[] duplicates fields already written above; derived on parse, not packed
+  return buf;
+}
+
+function packFocusIn(ev, buf) {
+  buf[0] = 9;
+  buf[1] = ev.detail & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf[8] = ev.mode & 0xff;
+  return buf;
+}
+
+function packFocusOut(ev, buf) {
+  buf[0] = 10;
+  buf[1] = ev.detail & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf[8] = ev.mode & 0xff;
+  return buf;
+}
+
+function packKeymapNotify(ev, buf) {
+  buf[0] = 11;
+  if (ev.keys) Buffer.from(ev.keys).copy(buf, 1, 0, 31);
+  return buf;
+}
+
+function packExpose(ev, buf) {
+  buf[0] = 12;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf.writeUInt16LE(ev.x & 0xffff, 8);
+  buf.writeUInt16LE(ev.y & 0xffff, 10);
+  buf.writeUInt16LE(ev.width & 0xffff, 12);
+  buf.writeUInt16LE(ev.height & 0xffff, 14);
+  buf.writeUInt16LE(ev.count & 0xffff, 16);
+  return buf;
+}
+
+function packGraphicsExposure(ev, buf) {
+  buf[0] = 13;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.drawable >>> 0, 4);
+  buf.writeUInt16LE(ev.x & 0xffff, 8);
+  buf.writeUInt16LE(ev.y & 0xffff, 10);
+  buf.writeUInt16LE(ev.width & 0xffff, 12);
+  buf.writeUInt16LE(ev.height & 0xffff, 14);
+  buf.writeUInt16LE(ev.minorOpcode & 0xffff, 16);
+  buf.writeUInt16LE(ev.count & 0xffff, 18);
+  buf[20] = ev.majorOpcode & 0xff;
+  return buf;
+}
+
+function packNoExposure(ev, buf) {
+  buf[0] = 14;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.drawable >>> 0, 4);
+  buf.writeUInt16LE(ev.minorOpcode & 0xffff, 8);
+  buf[10] = ev.majorOpcode & 0xff;
+  return buf;
+}
+
+function packVisibilityNotify(ev, buf) {
+  buf[0] = 15;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf[8] = ev.state & 0xff;
+  return buf;
+}
+
+function packCreateNotify(ev, buf) {
+  buf[0] = 16;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.parent >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf.writeUInt16LE(ev.x & 0xffff, 12);
+  buf.writeUInt16LE(ev.y & 0xffff, 14);
+  buf.writeUInt16LE(ev.width & 0xffff, 16);
+  buf.writeUInt16LE(ev.height & 0xffff, 18);
+  buf.writeUInt16LE(ev.borderWidth & 0xffff, 20);
+  buf[22] = ev.overrideRedirect ? 1 : 0;
+  return buf;
+}
+
+function packDestroyNotify(ev, buf) {
+  buf[0] = 17;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.event >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  return buf;
+}
+
+function packUnmapNotify(ev, buf) {
+  buf[0] = 18;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.event >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf[12] = ev.fromConfigure ? 1 : 0;
+  return buf;
+}
+
+function packMapNotify(ev, buf) {
+  buf[0] = 19;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.event >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf[12] = ev.overrideRedirect ? 1 : 0;
+  return buf;
+}
+
+function packMapRequest(ev, buf) {
+  buf[0] = 20;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.parent >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  return buf;
+}
+
+function packReparentNotify(ev, buf) {
+  buf[0] = 21;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.event >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf.writeUInt32LE(ev.parent >>> 0, 12);
+  buf.writeUInt16LE(ev.x & 0xffff, 16);
+  buf.writeUInt16LE(ev.y & 0xffff, 18);
+  buf[20] = ev.overrideRedirect ? 1 : 0;
+  return buf;
+}
+
+function packConfigureNotify(ev, buf) {
+  buf[0] = 22;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf.writeUInt32LE(ev.wid1 >>> 0, 8);
+  buf.writeUInt32LE(ev.aboveSibling >>> 0, 12);
+  buf.writeUInt16LE(ev.x & 0xffff, 16);
+  buf.writeUInt16LE(ev.y & 0xffff, 18);
+  buf.writeUInt16LE(ev.width & 0xffff, 20);
+  buf.writeUInt16LE(ev.height & 0xffff, 22);
+  buf.writeUInt16LE(ev.borderWidth & 0xffff, 24);
+  buf[26] = ev.overrideRedirect ? 1 : 0;
+  return buf;
+}
+
+function packConfigureRequest(ev, buf) {
+  buf[0] = 23;
+  buf[1] = ev.stackMode & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.parent >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf.writeUInt32LE(ev.sibling >>> 0, 12);
+  buf.writeUInt16LE(ev.x & 0xffff, 16);
+  buf.writeUInt16LE(ev.y & 0xffff, 18);
+  buf.writeUInt16LE(ev.width & 0xffff, 20);
+  buf.writeUInt16LE(ev.height & 0xffff, 22);
+  buf.writeUInt16LE(ev.borderWidth & 0xffff, 24);
+  buf.writeUInt16LE(ev.mask & 0xffff, 26);
+  return buf;
+}
+
+function packGravityNotify(ev, buf) {
+  buf[0] = 24;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.event >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf.writeUInt16LE(ev.x & 0xffff, 12);
+  buf.writeUInt16LE(ev.y & 0xffff, 14);
+  return buf;
+}
+
+function packResizeRequest(ev, buf) {
+  buf[0] = 25;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf.writeUInt16LE(ev.width & 0xffff, 8);
+  buf.writeUInt16LE(ev.height & 0xffff, 10);
+  return buf;
+}
+
+function packCirculateNotify(ev, buf) {
+  buf[0] = 26;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.event >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf[16] = ev.place & 0xff;
+  return buf;
+}
+
+function packCirculateRequest(ev, buf) {
+  buf[0] = 27;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.event >>> 0, 4);
+  buf.writeUInt32LE(ev.wid >>> 0, 8);
+  buf[16] = ev.place & 0xff;
+  return buf;
+}
+
+function packPropertyNotify(ev, buf) {
+  buf[0] = 28;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf.writeUInt32LE(ev.atom >>> 0, 8);
+  buf.writeUInt32LE(ev.time >>> 0, 12);
+  buf[16] = ev.state & 0xff;
+  return buf;
+}
+
+function packSelectionClear(ev, buf) {
+  buf[0] = 29;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.owner >>> 0, 8);
+  buf.writeUInt32LE(ev.selection >>> 0, 12);
+  return buf;
+}
+
+function packSelectionRequest(ev, buf) {
+  buf[0] = 30;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.owner >>> 0, 8);
+  buf.writeUInt32LE(ev.requestor >>> 0, 12);
+  buf.writeUInt32LE(ev.selection >>> 0, 16);
+  buf.writeUInt32LE(ev.target >>> 0, 20);
+  buf.writeUInt32LE(ev.property >>> 0, 24);
+  return buf;
+}
+
+function packSelectionNotify(ev, buf) {
+  buf[0] = 31;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.time >>> 0, 4);
+  buf.writeUInt32LE(ev.requestor >>> 0, 8);
+  buf.writeUInt32LE(ev.selection >>> 0, 12);
+  buf.writeUInt32LE(ev.target >>> 0, 16);
+  buf.writeUInt32LE(ev.property >>> 0, 20);
+  return buf;
+}
+
+function packColormapNotify(ev, buf) {
+  buf[0] = 32;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf.writeUInt32LE(ev.colormap >>> 0, 8);
+  buf[12] = ev.new ? 1 : 0;
+  buf[13] = ev.state & 0xff;
+  return buf;
+}
+
+function packClientMessage(ev, buf) {
+  buf[0] = 33;
+  buf[1] = ev.format & 0xff;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf.writeUInt32LE(ev.wid >>> 0, 4);
+  buf.writeUInt32LE(ev.message_type >>> 0, 8);
+  const data = ev.data || [];
+  if (ev.format === 32) {
+    for (let i = 0; i < 5; i++) buf.writeUInt32LE(data[i] >>> 0, 12 + i * 4);
+  } else if (ev.format === 16) {
+    for (let i = 0; i < 10; i++) buf.writeUInt16LE(data[i] & 0xffff, 12 + i * 2);
+  } else {
+    for (let i = 0; i < 20; i++) buf.writeUInt8(data[i] & 0xff, 12 + i);
+  }
+  return buf;
+}
+
+function packMappingNotify(ev, buf) {
+  buf[0] = 34;
+  buf[1] = 0;
+  buf.writeUInt16LE(ev.seq & 0xffff, 2);
+  buf[4] = ev.request & 0xff;
+  buf[5] = ev.firstKeyCode & 0xff;
+  buf[6] = ev.count & 0xff;
+  return buf;
+}
+
 const parsers = {
   2: parseKeyPress,
   3: parseKeyRelease,
@@ -403,6 +820,78 @@ const parsers = {
   34: parseMappingNotify,
 };
 
+const packers = {
+  2: packKeyPress,
+  3: packKeyRelease,
+  4: packButtonPress,
+  5: packButtonRelease,
+  6: packMotionNotify,
+  7: packEnterNotify,
+  8: packLeaveNotify,
+  9: packFocusIn,
+  10: packFocusOut,
+  11: packKeymapNotify,
+  12: packExpose,
+  13: packGraphicsExposure,
+  14: packNoExposure,
+  15: packVisibilityNotify,
+  16: packCreateNotify,
+  17: packDestroyNotify,
+  18: packUnmapNotify,
+  19: packMapNotify,
+  20: packMapRequest,
+  21: packReparentNotify,
+  22: packConfigureNotify,
+  23: packConfigureRequest,
+  24: packGravityNotify,
+  25: packResizeRequest,
+  26: packCirculateNotify,
+  27: packCirculateRequest,
+  28: packPropertyNotify,
+  29: packSelectionClear,
+  30: packSelectionRequest,
+  31: packSelectionNotify,
+  32: packColormapNotify,
+  33: packClientMessage,
+  34: packMappingNotify,
+};
+
+const eventTypes = {
+  KeyPress: 2,
+  KeyRelease: 3,
+  ButtonPress: 4,
+  ButtonRelease: 5,
+  MotionNotify: 6,
+  EnterNotify: 7,
+  LeaveNotify: 8,
+  FocusIn: 9,
+  FocusOut: 10,
+  KeymapNotify: 11,
+  Expose: 12,
+  GraphicsExposure: 13,
+  NoExposure: 14,
+  VisibilityNotify: 15,
+  CreateNotify: 16,
+  DestroyNotify: 17,
+  UnmapNotify: 18,
+  MapNotify: 19,
+  MapRequest: 20,
+  ReparentNotify: 21,
+  ConfigureNotify: 22,
+  ConfigureRequest: 23,
+  GravityNotify: 24,
+  ResizeRequest: 25,
+  CirculateNotify: 26,
+  CirculateRequest: 27,
+  PropertyNotify: 28,
+  SelectionClear: 29,
+  SelectionRequest: 30,
+  SelectionNotify: 31,
+  ColormapNotify: 32,
+  ClientMessage: 33,
+  MappingNotify: 34,
+};
+
 function unpackEvent(type, seq, extra, code, raw, headerBuf) {
   const t = type & 0x7F;
   const fn = parsers[t];
@@ -410,4 +899,74 @@ function unpackEvent(type, seq, extra, code, raw, headerBuf) {
   return { type: t, seq };
 }
 
-module.exports = { unpackEvent, parsers };
+/**
+ * Build the 32-byte wire form of an event, ready to hand to SendEvent.
+ *
+ * `ev` is shaped like the objects unpackEvent produces: `name` (or `type`)
+ * selects the layout and the remaining properties are the fields; anything
+ * left out packs as zero. The sequence number at bytes 2-3 and the 0x80
+ * "came from SendEvent" bit are filled in by the server, so callers do not
+ * need to supply them. Pass `buf` to pack into an existing 32-byte buffer
+ * (it is zeroed first) instead of allocating a new one.
+ */
+function packEvent(ev, buf) {
+  if (!ev || typeof ev !== 'object')
+    throw new TypeError('packEvent: expected an event object, got ' + typeof ev);
+
+  let type;
+  const named = ev.name === undefined ? undefined : eventTypes[ev.name];
+  if (ev.name !== undefined && named === undefined)
+    throw new TypeError('packEvent: unknown event name ' + JSON.stringify(ev.name));
+
+  if (typeof ev.type === 'number') {
+    type = ev.type & 0x7f;
+    // Extension events reuse core event names (XFixes has its own
+    // SelectionNotify); trusting the name alone would pack one as the other.
+    if (named !== undefined && named !== type) {
+      throw new TypeError('packEvent: ' + JSON.stringify(ev.name) + ' is core event ' +
+        named + ' but this event has type ' + type +
+        ' — extension events are not packed by name');
+    }
+  } else if (named !== undefined) {
+    type = named;
+  } else {
+    throw new TypeError('packEvent: event needs a name or a numeric type');
+  }
+
+  const fn = packers[type];
+  if (!fn) {
+    throw new TypeError(type === 35
+      ? 'packEvent: GenericEvent (35) has no fixed 32-byte form and cannot be sent with SendEvent'
+      : 'packEvent: no packer for event type ' + type);
+  }
+
+  if (type === 33) {
+    // The server rejects any other format with BadValue, and the format
+    // decides how it byte-swaps the 20 data bytes for the recipient.
+    if (ev.format !== 8 && ev.format !== 16 && ev.format !== 32)
+      throw new TypeError('packEvent: ClientMessage format must be 8, 16 or 32, got ' + ev.format);
+    const room = ev.format === 32 ? 5 : ev.format === 16 ? 10 : 20;
+    if (ev.data && ev.data.length > room) {
+      throw new TypeError('packEvent: ClientMessage data holds ' + room + ' values at format ' +
+        ev.format + ', got ' + ev.data.length);
+    }
+  }
+
+  if (buf === undefined) {
+    buf = Buffer.alloc(32);
+  } else {
+    if (!Buffer.isBuffer(buf))
+      throw new TypeError('packEvent: target must be a Buffer');
+    if (buf.length < 32)
+      throw new TypeError('packEvent: target buffer must be at least 32 bytes, got ' + buf.length);
+    // Return exactly the event's 32 bytes even when packing into a larger
+    // slot, so the result can go straight to SendEvent. Unused bytes must be
+    // zero: every convention built on ClientMessage (EWMH, XEmbed, XDND)
+    // requires that of the sender.
+    buf = buf.length === 32 ? buf : buf.subarray(0, 32);
+    buf.fill(0);
+  }
+  return fn(ev, buf);
+}
+
+module.exports = { unpackEvent, parsers, packEvent, packers, eventTypes };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,15 @@
 const core = require('./xcore');
 const em = require('./eventmask').eventMask;
+const coreEvents = require('./generated/core-events');
 
 module.exports.createClient = core.createClient;
 module.exports.registerDisplayProtocol = core.registerDisplayProtocol;
 module.exports.parseDisplay = core.parseDisplay;
 module.exports.eventMask = em;
+// build the 32 wire bytes of an event for SendEvent; eventTypes maps event
+// names to their protocol numbers
+module.exports.packEvent = coreEvents.packEvent;
+module.exports.eventTypes = coreEvents.eventTypes;
 
 // lazy: the server pulls in `net` at require time, which browser bundles lack
 Object.defineProperty(module.exports, 'createServer', {

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -228,6 +228,38 @@ XClient.prototype.close = function(cb) {
     cli._closing = true;
 }
 
+// Inverse of unpackEvent: turn an event object into the 32 bytes SendEvent
+// wants. Also available without a connection as `x11.packEvent`.
+XClient.prototype.packEvent = coreEvents.packEvent;
+
+// ClientMessage is the carrier of every window-manager conversation — EWMH
+// state changes, WM_DELETE_WINDOW, XEmbed, XDND — so it gets a shortcut past
+// packEvent/SendEvent.
+//
+// `destination` is where the message is delivered and `wid` is the window the
+// message is *about*; for EWMH root-window messages those differ (destination
+// is the root, wid the client window), which is why both are arguments.
+// `eventMask` defaults to SubstructureRedirect|SubstructureNotify, what EWMH
+// requires for messages sent to the root. Messages aimed at another client's
+// window — WM_PROTOCOLS, XEmbed, XDND, SelectionNotify — must pass 0 instead,
+// which delivers to the window's owner whatever that client selected.
+XClient.prototype.SendClientMessage = function(destination, wid, messageType, format, data, eventMask, cb) {
+    if (typeof eventMask === 'function') {
+        cb = eventMask;
+        eventMask = undefined;
+    }
+    if (eventMask === undefined)
+        eventMask = em.SubstructureRedirect | em.SubstructureNotify;
+
+    return this.SendEvent(destination, 0, eventMask, {
+        name: 'ClientMessage',
+        format: format,
+        wid: wid,
+        message_type: messageType,
+        data: data || []
+    }, cb);
+}
+
 XClient.prototype.importRequestsFromTemplates = function(target, reqs)
 {
     const client = this;
@@ -295,9 +327,20 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                  }
 
                  // pack template returns a Buffer (Buffer.write* style)
-                 const packet = reqTemplate.apply(this, args);
-                 if (!Buffer.isBuffer(packet))
-                     throw new TypeError(`${reqName}: pack template must return a Buffer`);
+                 let packet;
+                 try {
+                     packet = reqTemplate.apply(this, args);
+                     if (!Buffer.isBuffer(packet))
+                         throw new TypeError(`${reqName}: pack template must return a Buffer`);
+                 } catch (e) {
+                     // Nothing reached the wire, so give the sequence number
+                     // back. Keeping it would leave the client one ahead of
+                     // the server for the rest of the connection, and every
+                     // later reply would be handed to the wrong callback.
+                     delete client.pending_atoms[client.seq_num];
+                     client.seq_num--;
+                     throw e;
+                 }
 
                  const expectsReply = !!reqReplTemplate[1];
                  if (expectsReply)
@@ -487,9 +530,10 @@ XClient.prototype.expectReplyHeader = function()
                     const code = detail;
                     const ev = client.unpackEvent(type, seq_num, extra, code, buf, headerBuf);
 
-                    // raw event packet, 32 bytes unless GenericEvent (primarily
-                    // for use in SendEvent);
-                    // TODO: Event::pack based on event parameters, inverse to unpackEvent
+                    // raw event packet, 32 bytes unless GenericEvent. Still
+                    // worth keeping now that packEvent exists: it is the only
+                    // carrier of pad bytes and of the 0x80 synthetic flag,
+                    // both of which the parsers drop.
                     ev.rawData = Buffer.alloc(8 + buf.length);
                     headerBuf.copy(ev.rawData);
                     buf.copy(ev.rawData, 8);

--- a/test/event-pack.js
+++ b/test/event-pack.js
@@ -1,0 +1,530 @@
+const assert = require('assert');
+const x11 = require('../lib');
+const { unpackEvent, packers, eventTypes } = require('../lib/generated/core-events');
+
+// The client splits a 32-byte packet exactly like this before parsing
+// (lib/xcore.js, expectReplyHeader), so tests can parse a packed buffer
+// without a server in the loop.
+function parse(buf) {
+    return unpackEvent(buf[0] & 0x7f, buf.readUInt16LE(2), buf.readUInt32LE(4),
+        buf[1], buf.slice(8), buf);
+}
+
+describe('packEvent', () => {
+
+    describe('wire layout', () => {
+        // Hand-written from the protocol/ICCCM encodings rather than from the
+        // parsers, so these fail if the generated field map itself drifts.
+
+        it('packs ClientMessage: format in the detail byte, window, type, 5 longs', () => {
+            const buf = x11.packEvent({
+                name: 'ClientMessage',
+                format: 32,
+                wid: 0x00c00007,
+                message_type: 0x0000015a,
+                data: [1, 2, 3, 4, 5]
+            });
+            assert.strictEqual(buf.length, 32);
+            assert.strictEqual(buf[0], 33);
+            assert.strictEqual(buf[1], 32);
+            assert.strictEqual(buf.readUInt16LE(2), 0, 'sequence number is the server\'s to fill in');
+            assert.strictEqual(buf.readUInt32LE(4), 0x00c00007);
+            assert.strictEqual(buf.readUInt32LE(8), 0x0000015a);
+            for (let i = 0; i < 5; i++)
+                assert.strictEqual(buf.readUInt32LE(12 + i * 4), i + 1);
+        });
+
+        it('packs ClientMessage data as 10 shorts at format 16 and 20 bytes at format 8', () => {
+            const short = x11.packEvent({
+                name: 'ClientMessage', format: 16, wid: 1, message_type: 2,
+                data: [0x1111, 0x2222]
+            });
+            assert.strictEqual(short[1], 16);
+            assert.strictEqual(short.readUInt16LE(12), 0x1111);
+            assert.strictEqual(short.readUInt16LE(14), 0x2222);
+            assert.strictEqual(short.readUInt16LE(16), 0, 'unused data is zeroed');
+
+            const byte = x11.packEvent({
+                name: 'ClientMessage', format: 8, wid: 1, message_type: 2,
+                data: [0xde, 0xad]
+            });
+            assert.strictEqual(byte[1], 8);
+            assert.strictEqual(byte[12], 0xde);
+            assert.strictEqual(byte[13], 0xad);
+            assert.strictEqual(byte[14], 0);
+        });
+
+        it('packs SelectionNotify the way a selection owner answers a request', () => {
+            // ICCCM 2.2: echo time/requestor/selection/target, property = None
+            // to refuse.
+            const buf = x11.packEvent({
+                name: 'SelectionNotify',
+                time: 0x11223344,
+                requestor: 0x00a00001,
+                selection: 40,
+                target: 31,
+                property: 0
+            });
+            assert.strictEqual(buf[0], 31);
+            assert.strictEqual(buf.readUInt32LE(4), 0x11223344);
+            assert.strictEqual(buf.readUInt32LE(8), 0x00a00001);
+            assert.strictEqual(buf.readUInt32LE(12), 40);
+            assert.strictEqual(buf.readUInt32LE(16), 31);
+            assert.strictEqual(buf.readUInt32LE(20), 0);
+        });
+
+        it('packs the ICCCM 4.1.5 synthetic ConfigureNotify', () => {
+            // `wid` is the event window and `wid1` the configured window —
+            // for this message both are the client's top-level window.
+            const buf = x11.packEvent({
+                name: 'ConfigureNotify',
+                wid: 0x00a00001,
+                wid1: 0x00a00001,
+                aboveSibling: 0,
+                x: 100, y: -20, width: 640, height: 480,
+                borderWidth: 0,
+                overrideRedirect: 0
+            });
+            assert.strictEqual(buf[0], 22);
+            assert.strictEqual(buf.readUInt32LE(4), 0x00a00001);
+            assert.strictEqual(buf.readUInt32LE(8), 0x00a00001);
+            assert.strictEqual(buf.readUInt32LE(12), 0);
+            assert.strictEqual(buf.readInt16LE(16), 100);
+            assert.strictEqual(buf.readInt16LE(18), -20, 'negative coordinates wrap, they do not throw');
+            assert.strictEqual(buf.readUInt16LE(20), 640);
+            assert.strictEqual(buf.readUInt16LE(22), 480);
+            assert.strictEqual(buf.readUInt16LE(24), 0);
+            assert.strictEqual(buf[26], 0);
+        });
+
+        it('packs the ICCCM synthetic UnmapNotify used to withdraw a window', () => {
+            // Here event and window differ: the event window is the root.
+            const buf = x11.packEvent({
+                name: 'UnmapNotify',
+                event: 0x00000129,
+                wid: 0x00a00001,
+                fromConfigure: false
+            });
+            assert.strictEqual(buf[0], 18);
+            assert.strictEqual(buf.readUInt32LE(4), 0x00000129);
+            assert.strictEqual(buf.readUInt32LE(8), 0x00a00001);
+            assert.strictEqual(buf[12], 0);
+        });
+
+        it('leaves the 0x80 synthetic bit to the server', () => {
+            assert.strictEqual(x11.packEvent({ name: 'Expose', wid: 1 })[0], 12);
+            // ... and accepts a numeric type that already has it set
+            assert.strictEqual(x11.packEvent({ type: 12 | 0x80, wid: 1 })[0], 12);
+        });
+
+        it('zeroes a reused buffer so no stale bytes leak into the pads', () => {
+            const buf = Buffer.alloc(32, 0xff);
+            x11.packEvent({ name: 'Expose', wid: 0, x: 0, y: 0, width: 0, height: 0, count: 0 }, buf);
+            assert.deepStrictEqual(buf, Buffer.concat([Buffer.from([12]), Buffer.alloc(31)]));
+        });
+
+        it('packs into a larger buffer and returns the 32 bytes of the event', () => {
+            const slot = Buffer.alloc(64, 0xff);
+            const out = x11.packEvent({ name: 'Expose', wid: 7 }, slot);
+            assert.strictEqual(out.length, 32, 'SendEvent takes exactly 32 bytes');
+            assert.strictEqual(out.readUInt32LE(4), 7);
+            assert.strictEqual(slot[31], 0, 'the event bytes are zeroed');
+            assert.strictEqual(slot[32], 0xff, 'the rest of the caller\'s buffer is left alone');
+        });
+    });
+
+    describe('values wider than their field wrap instead of throwing', () => {
+        // Buffer.write* throws ERR_OUT_OF_RANGE on values a field cannot
+        // hold. Events routinely carry such values — XDND composes data words
+        // as (x << 16) | y, which is negative in JS — so the packers mask.
+
+        it('32-bit fields take negative and full-range values', () => {
+            const buf = x11.packEvent({
+                name: 'SelectionNotify',
+                time: -1,
+                requestor: 0xffffffff,
+                selection: 0x80000000,
+                target: (40000 << 16) | 300,
+                property: 0
+            });
+            assert.strictEqual(buf.readUInt32LE(4), 0xffffffff);
+            assert.strictEqual(buf.readUInt32LE(8), 0xffffffff);
+            assert.strictEqual(buf.readUInt32LE(12), 0x80000000);
+            assert.strictEqual(buf.readUInt32LE(16), ((40000 << 16) | 300) >>> 0);
+        });
+
+        it('ClientMessage data words keep their bits at every format', () => {
+            const wide = x11.packEvent({
+                name: 'ClientMessage', format: 32, wid: 1, message_type: 2,
+                data: [(40000 << 16) | 300, -1, 0xffffffff, 0x80000000, 0]
+            });
+            assert.strictEqual(wide.readUInt32LE(12), ((40000 << 16) | 300) >>> 0);
+            assert.strictEqual(wide.readUInt32LE(16), 0xffffffff);
+            assert.strictEqual(wide.readUInt32LE(20), 0xffffffff);
+            assert.strictEqual(wide.readUInt32LE(24), 0x80000000);
+
+            const short = x11.packEvent({
+                name: 'ClientMessage', format: 16, wid: 1, message_type: 2, data: [-1, 0x1ffff]
+            });
+            assert.strictEqual(short.readUInt16LE(12), 0xffff);
+            assert.strictEqual(short.readUInt16LE(14), 0xffff);
+        });
+
+        it('coordinates outside INT16 range wrap the way the wire encodes them', () => {
+            const buf = x11.packEvent({
+                name: 'ConfigureNotify', wid: 1, wid1: 1, aboveSibling: 0,
+                x: 40000, y: -40000, width: 0x1ffff, height: 480,
+                borderWidth: 0, overrideRedirect: 0
+            });
+            assert.strictEqual(buf.readUInt16LE(16), 40000 & 0xffff);
+            assert.strictEqual(buf.readUInt16LE(18), -40000 & 0xffff);
+            assert.strictEqual(buf.readUInt16LE(20), 0xffff);
+        });
+    });
+
+    describe('round trip against the parsers', () => {
+        // Probe every byte of every event: set exactly one byte, parse, pack.
+        // The *parser* decides what should happen — if the byte changed what
+        // it reported, the packer must put that byte back exactly where it
+        // was; if the parser ignored it (a pad), the packer must leave zero.
+        // Letting the packer's own output define which bytes matter would
+        // excuse a field it silently dropped.
+        const names = Object.keys(eventTypes);
+
+        names.forEach(name => {
+            it(`${name} survives parse → pack unchanged, byte by byte`, () => {
+                const type = eventTypes[name];
+                // an otherwise empty event of this type; for ClientMessage the
+                // detail byte is the format, and only 8/16/32 are legal there
+                const base = Buffer.alloc(32);
+                base[0] = type;
+                if (type === eventTypes.ClientMessage)
+                    base[1] = 32;
+                const baseFields = JSON.stringify(parse(base));
+
+                for (let i = 1; i < 32; i++) {
+                    if (i === 1 && base[1])
+                        continue;
+                    const buf = Buffer.from(base);
+                    // wider than a byte and asymmetric, so a field written at
+                    // the wrong width or offset cannot come back looking right
+                    buf[i] = 0x81;
+
+                    const parsed = parse(buf);
+                    const read = JSON.stringify(parsed) !== baseFields;
+                    const out = x11.packEvent(parsed);
+
+                    if (!read) {
+                        assert.ok(out.equals(base), `${name}: byte ${i} is a pad the parser ` +
+                            `ignores, but packing wrote ${out.toString('hex')}`);
+                        continue;
+                    }
+                    // BOOL fields are normalised to 1 on the way out; that is
+                    // exact for the 0/1 a server actually sends
+                    const asBool = Buffer.from(buf);
+                    asBool[i] = 1;
+                    assert.ok(out.equals(buf) || out.equals(asBool),
+                        `${name}: byte ${i} is a field, but parse → pack turned ` +
+                        `${buf.toString('hex')} into ${out.toString('hex')}`);
+                }
+            });
+        });
+
+        it('covers every event the parsers handle', () => {
+            assert.deepStrictEqual(Object.keys(packers).sort(), Object.keys(eventTypes)
+                .map(n => String(eventTypes[n])).sort());
+            assert.strictEqual(names.length, 33);
+        });
+
+        // one per shape of the detail byte: keycode, button, the crossing and
+        // focus `detail` enum, ConfigureRequest's stack mode, and none at all
+        [
+            { name: 'KeyPress', keycode: 38, time: 0x0f0f0f0f, root: 0x129, wid: 0x00a00001,
+                child: 0, rootx: 100, rooty: 200, x: 10, y: 20, buttons: 0x0011, sameScreen: 1 },
+            { name: 'ButtonPress', keycode: 3, time: 9, root: 2, wid: 3, child: 4,
+                rootx: 5, rooty: 6, x: 7, y: 8, buttons: 0x100, sameScreen: 0 },
+            { name: 'EnterNotify', detail: 2, time: 9, root: 2, wid: 3, child: 4,
+                rootx: 5, rooty: 6, x: 7, y: 8, buttons: 0x100, mode: 1, sameScreenFocus: 3 },
+            { name: 'FocusIn', detail: 2, wid: 3, mode: 1 },
+            { name: 'ConfigureRequest', stackMode: 4, parent: 1, wid: 2, sibling: 3,
+                x: 4, y: 5, width: 6, height: 7, borderWidth: 8, mask: 0x7f },
+            { name: 'PropertyNotify', wid: 1, atom: 2, time: 3, state: 1 }
+        ].forEach(ev => {
+            it(`reproduces a parsed ${ev.name} exactly`, () => {
+                const back = parse(x11.packEvent(ev));
+                for (const key of Object.keys(ev)) {
+                    if (key === 'name')
+                        continue;
+                    assert.strictEqual(back[key], ev[key], `${ev.name}.${key}`);
+                }
+            });
+        });
+
+        it('round-trips KeymapNotify, which has no sequence number', () => {
+            const keys = Buffer.alloc(31);
+            keys[1] = 0xff;
+            keys[30] = 0x81;
+            const back = parse(x11.packEvent({ name: 'KeymapNotify', keys }));
+            assert.deepStrictEqual(back.keys, keys);
+            assert.strictEqual(back.seq, undefined);
+        });
+
+        it('treats missing fields as zero', () => {
+            const back = parse(x11.packEvent({ name: 'Expose', wid: 7 }));
+            assert.strictEqual(back.wid, 7);
+            assert.strictEqual(back.width, 0);
+            assert.strictEqual(back.count, 0);
+        });
+    });
+
+    describe('rejects what the server would reject', () => {
+        it('an unknown event name', () => {
+            assert.throws(() => x11.packEvent({ name: 'NoSuchEvent' }), /unknown event name/);
+        });
+
+        it('GenericEvent, which has no 32-byte form', () => {
+            assert.throws(() => x11.packEvent({ type: 35 }), /GenericEvent/);
+        });
+
+        it('an event with neither a name nor a type', () => {
+            assert.throws(() => x11.packEvent({ wid: 1 }), /name or a numeric type/);
+            assert.throws(() => x11.packEvent(null), /expected an event object/);
+        });
+
+        it('an extension event that borrows a core event name', () => {
+            // XFixes has its own SelectionNotify (firstEvent + 0); packing it
+            // by name would put a completely different layout on the wire
+            assert.throws(() => x11.packEvent({ type: 86, name: 'SelectionNotify', requestor: 1 }),
+                /extension events are not packed by name/);
+            // ... while a core event carrying both stays fine
+            assert.strictEqual(x11.packEvent({ type: 31, name: 'SelectionNotify' })[0], 31);
+        });
+
+        it('a target that is not a Buffer', () => {
+            assert.throws(() => x11.packEvent({ name: 'Expose' }, 'nope'), /must be a Buffer/);
+        });
+
+        it('a ClientMessage format other than 8, 16 or 32', () => {
+            assert.throws(() => x11.packEvent({ name: 'ClientMessage', format: 24 }),
+                /format must be 8, 16 or 32/);
+            assert.throws(() => x11.packEvent({ name: 'ClientMessage' }),
+                /format must be 8, 16 or 32/);
+        });
+
+        it('more ClientMessage data than the format has room for', () => {
+            assert.throws(() => x11.packEvent({
+                name: 'ClientMessage', format: 32, data: [1, 2, 3, 4, 5, 6]
+            }), /holds 5 values at format 32, got 6/);
+            assert.throws(() => x11.packEvent({
+                name: 'ClientMessage', format: 8, data: new Array(21).fill(0)
+            }), /holds 20 values at format 8, got 21/);
+        });
+
+        it('a target buffer that is too short', () => {
+            assert.throws(() => x11.packEvent({ name: 'Expose' }, Buffer.alloc(31)),
+                /at least 32 bytes/);
+        });
+    });
+});
+
+describe('SendEvent with an event object', function() {
+
+    before(function(done) {
+        const self = this;
+        const client = x11.createClient((err, dpy) => {
+            assert.ifError(err);
+            self.X = dpy.client;
+            self.root = dpy.screen[0].root;
+            self.wid = self.X.AllocID();
+            self.X.CreateWindow(self.wid, self.root, 0, 0, 1, 1);
+            self.X.InternAtom(false, 'X11_TEST_PACK', (err, atom) => {
+                assert.ifError(err);
+                self.atom = atom;
+                done();
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(function() {
+        if (this.X) {
+            this.X.DestroyWindow(this.wid);
+            this.X.terminate();
+        }
+    });
+
+    // An empty event mask delivers to the client that created the destination
+    // window — us. That is how ICCCM/XEmbed/XDND messages reach their target,
+    // and it lets the test observe every event type without selecting it.
+    function expect(X, name, cb) {
+        X.once('event', ev => {
+            assert.strictEqual(ev.name, name);
+            cb(ev);
+        });
+    }
+
+    it('delivers a ClientMessage built from an object', function(done) {
+        const self = this;
+        expect(this.X, 'ClientMessage', ev => {
+            assert.strictEqual(ev.wid, self.wid);
+            assert.strictEqual(ev.message_type, self.atom);
+            assert.strictEqual(ev.format, 32);
+            assert.deepStrictEqual(ev.data, [1, 2, 3, 0, 0]);
+            done();
+        });
+        this.X.SendEvent(this.wid, 0, 0, {
+            name: 'ClientMessage',
+            format: 32,
+            wid: this.wid,
+            message_type: this.atom,
+            data: [1, 2, 3]
+        });
+    });
+
+    it('delivers a SelectionNotify built from an object', function(done) {
+        const self = this;
+        expect(this.X, 'SelectionNotify', ev => {
+            assert.strictEqual(ev.requestor, self.wid);
+            assert.strictEqual(ev.selection, self.atom);
+            assert.strictEqual(ev.target, self.atom);
+            assert.strictEqual(ev.property, 0);
+            assert.strictEqual(ev.time, 0x11223344);
+            done();
+        });
+        this.X.SendEvent(this.wid, 0, 0, {
+            name: 'SelectionNotify',
+            time: 0x11223344,
+            requestor: this.wid,
+            selection: this.atom,
+            target: this.atom,
+            property: 0
+        });
+    });
+
+    it('delivers a synthetic ConfigureNotify to a StructureNotify selection', function(done) {
+        const self = this;
+        this.X.ChangeWindowAttributes(this.wid, { eventMask: x11.eventMask.StructureNotify });
+        expect(this.X, 'ConfigureNotify', ev => {
+            assert.strictEqual(ev.wid, self.wid);
+            assert.strictEqual(ev.wid1, self.wid);
+            assert.strictEqual(ev.x, 100);
+            assert.strictEqual(ev.y, -20);
+            assert.strictEqual(ev.width, 640);
+            assert.strictEqual(ev.height, 480);
+            self.X.ChangeWindowAttributes(self.wid, { eventMask: 0 });
+            done();
+        });
+        this.X.SendEvent(this.wid, 0, x11.eventMask.StructureNotify, {
+            name: 'ConfigureNotify',
+            wid: this.wid,
+            wid1: this.wid,
+            aboveSibling: 0,
+            x: 100, y: -20, width: 640, height: 480,
+            borderWidth: 0,
+            overrideRedirect: 0
+        });
+    });
+
+    it('still accepts the raw 32 bytes of a received event', function(done) {
+        const self = this;
+        this.X.once('event', first => {
+            assert.strictEqual(first.name, 'ClientMessage');
+            expect(self.X, 'ClientMessage', ev => {
+                assert.deepStrictEqual(ev.data, first.data);
+                done();
+            });
+            self.X.SendEvent(self.wid, 0, 0, first.rawData);
+        });
+        this.X.SendEvent(this.wid, 0, 0, {
+            name: 'ClientMessage', format: 8, wid: this.wid,
+            message_type: this.atom, data: [9, 8, 7]
+        });
+    });
+
+    it('rejects a buffer that is not 32 bytes', function() {
+        assert.throws(() => this.X.SendEvent(this.wid, 0, 0, Buffer.alloc(40)),
+            /must be exactly 32 bytes/);
+    });
+
+    it('leaves the connection usable after a rejected event', function(done) {
+        // A request that throws while packing never reaches the wire, so the
+        // sequence number must not advance — otherwise every later reply is
+        // matched to the wrong callback and the connection silently stops
+        // answering.
+        const self = this;
+        const before = this.X.seq_num;
+        assert.throws(() => this.X.SendEvent(this.wid, 0, 0, Buffer.alloc(40)));
+        assert.throws(() => this.X.SendClientMessage(this.wid, this.wid, this.atom, 12, []));
+        assert.throws(() => this.X.SendEvent(this.wid, 0, 0, { name: 'NoSuchEvent' }));
+        assert.strictEqual(this.X.seq_num, before, 'sequence number advanced for unsent requests');
+
+        this.X.InternAtom(false, 'X11_TEST_PACK_AFTER_THROW', (err, atom) => {
+            assert.ifError(err);
+            assert.ok(atom > 0);
+            self.X.GetGeometry(self.wid, (err, geom) => {
+                assert.ifError(err);
+                assert.strictEqual(geom.width, 1);
+                done();
+            });
+        });
+    });
+
+    describe('SendClientMessage', () => {
+        it('sends with an explicit empty mask, the way WM_PROTOCOLS does', function(done) {
+            const self = this;
+            expect(this.X, 'ClientMessage', ev => {
+                assert.strictEqual(ev.wid, self.wid);
+                assert.strictEqual(ev.message_type, self.atom);
+                assert.deepStrictEqual(ev.data, [self.atom, 0, 0, 0, 0]);
+                done();
+            });
+            this.X.SendClientMessage(this.wid, this.wid, this.atom, 32, [this.atom], 0);
+        });
+
+        it('defaults the mask to SubstructureRedirect|SubstructureNotify', function(done) {
+            const self = this;
+            // What EWMH root-window messages use; select those bits on our own
+            // window so the default is observable.
+            this.X.ChangeWindowAttributes(this.wid, {
+                eventMask: x11.eventMask.SubstructureNotify | x11.eventMask.SubstructureRedirect
+            });
+            expect(this.X, 'ClientMessage', ev => {
+                assert.strictEqual(ev.format, 32);
+                assert.deepStrictEqual(ev.data, [1, 2, 0, 0, 0]);
+                self.X.ChangeWindowAttributes(self.wid, { eventMask: 0 });
+                done();
+            });
+            this.X.SendClientMessage(this.wid, this.wid, this.atom, 32, [1, 2]);
+        });
+
+        it('takes a trailing callback in place of the mask', function(done) {
+            const self = this;
+            let pending = 2;
+            const finish = () => {
+                if (--pending === 0) {
+                    self.X.ChangeWindowAttributes(self.wid, { eventMask: 0 });
+                    done();
+                }
+            };
+            this.X.ChangeWindowAttributes(this.wid, {
+                eventMask: x11.eventMask.SubstructureNotify | x11.eventMask.SubstructureRedirect
+            });
+            expect(this.X, 'ClientMessage', ev => {
+                assert.strictEqual(ev.format, 8);
+                assert.strictEqual(ev.data[0], 1);
+                finish();
+            });
+            // no mask argument: the callback is recognised in its place, and
+            // the request is still checked (issue #85) rather than silent
+            this.X.SendClientMessage(this.wid, this.wid, this.atom, 8, [1], err => {
+                assert.ifError(err);
+                finish();
+            });
+        });
+
+        it('reports a bad format instead of letting the server BadValue it', function() {
+            assert.throws(() => this.X.SendClientMessage(this.wid, this.wid, this.atom, 12, []),
+                /format must be 8, 16 or 32/);
+        });
+    });
+});

--- a/test/xserver/multiclient.js
+++ b/test/xserver/multiclient.js
@@ -117,14 +117,14 @@ describe('xserver: multiple clients', () => {
                     assert.strictEqual(ev.requestor, requestor);
                     assert.strictEqual(ev.selection, selection);
                     // owner answers with a SelectionNotify through SendEvent
-                    const reply = Buffer.alloc(32);
-                    reply.writeUInt8(31, 0);                    // SelectionNotify
-                    reply.writeUInt32LE(ev.time, 4);
-                    reply.writeUInt32LE(ev.requestor, 8);
-                    reply.writeUInt32LE(ev.selection, 12);
-                    reply.writeUInt32LE(ev.target, 16);
-                    reply.writeUInt32LE(ev.property, 20);
-                    A.SendEvent(ev.requestor, false, 0, reply);
+                    A.SendEvent(ev.requestor, false, 0, {
+                        name: 'SelectionNotify',
+                        time: ev.time,
+                        requestor: ev.requestor,
+                        selection: ev.selection,
+                        target: ev.target,
+                        property: ev.property
+                    });
                 });
                 B.on('event', ev => {
                     if (ev.name !== 'SelectionNotify')
@@ -189,14 +189,8 @@ describe('xserver: multiple clients', () => {
                 assert.strictEqual(ev.rawData[0] & 0x80, 0x80, 'send_event bit set');
                 done();
             });
-            const raw = Buffer.alloc(32);
-            raw.writeUInt8(33, 0);          // ClientMessage
-            raw.writeUInt8(32, 1);          // format
-            raw.writeUInt32LE(wid, 4);
-            raw.writeUInt32LE(6, 8);        // message type CARDINAL
-            [11, 22, 33, 44, 55].forEach((v, i) => raw.writeUInt32LE(v, 12 + i * 4));
             // event-mask 0: goes to the window's creator (A) even if B sends it
-            B.SendEvent(wid, false, 0, raw);
+            B.SendClientMessage(wid, wid, 6 /* CARDINAL */, 32, [11, 22, 33, 44, 55], 0);
         });
     });
 });


### PR DESCRIPTION
Closes #247.

## Context

`SendEvent` has only ever taken the raw 32 wire bytes. Every incoming event is
parsed into a friendly object, but going the other way you were on your own —
so any client that talks to a window manager ends up hand-packing wire structs
with `Buffer.writeUInt32LE` and a copy of the spec open in another window.
ntk has four such encoders; this repo had three more in its own tests and one
example that patched a received event's bytes in place.

## How it is built

The parsers in `lib/generated/core-events.js` are generated from
`autogen/proto/xproto.xml`, so the packers are generated from it too rather
than hand-written for the handful of events worth the effort.
`autogen/generate-events.js` now walks each event's wire layout **once**
(`describeEvent`) and feeds that single descriptor to two emitters,
`emitParser` and `emitPacker`. A parser and its packer cannot disagree about
an offset, and all 33 core events are covered instead of the 4-8 the issue
asked for.

The refactor is provably behaviour-preserving on the parsing side: the parser
half of the generated file regenerates byte-identically against the previous
committed output.

## New API

All additive — nothing existing changes shape.

- **`x11.packEvent(event[, buffer])`** → the 32-byte wire form of an event
  object, in the same shape the parsers produce. Also on the client as
  `X.packEvent`.
- **`x11.eventTypes`** — event name → protocol event number.
- **`SendEvent(destination, propagate, eventMask, event)`** now accepts an
  event object as well as a Buffer, so a received event's `rawData` keeps
  working unchanged.
- **`X.SendClientMessage(destination, wid, message_type, format, data[, eventMask][, cb])`**
  — ClientMessage carries nearly all window-manager traffic (EWMH,
  WM_PROTOCOLS, XEmbed, XDND), so it gets a shortcut. `eventMask` defaults to
  `SubstructureRedirect|SubstructureNotify`, what EWMH requires for
  root-window messages; messages aimed at another client's own window pass an
  explicit `0`.

```js
// answer a SelectionRequest, ICCCM 2.2
X.SendEvent(ev.requestor, 0, 0, {
    name: 'SelectionNotify',
    time: ev.time, requestor: ev.requestor,
    selection: ev.selection, target: ev.target, property: ev.property
});

// ask the window manager to fullscreen us
X.SendClientMessage(root, wid, _NET_WM_STATE, 32, [1, fullscreen, 0, 1]);
```

## Behaviour worth knowing

- **Invalid input throws a `TypeError`** instead of producing a packet the
  server rejects asynchronously under a sequence number you have already
  forgotten: an unknown event name, a GenericEvent (no fixed 32-byte form, and
  the server rejects it with BadValue), an extension event that reuses a core
  event's name — XFixes has its own `SelectionNotify`, and packing it by name
  would put a completely different layout on the wire — a ClientMessage
  `format` other than 8/16/32, oversized `data`, or a buffer that is not
  exactly 32 bytes.
- **Values too wide for their field wrap** rather than throwing. This matters:
  XDND composes data words as `(x << 16) | y`, which is a negative number in
  JS, and `Buffer.writeUInt32LE` would throw on it.
- `seq` and the `0x80` synthetic bit are left to the server, which rewrites
  both per recipient.

## Also fixed

The request proxy incremented `seq_num` **before** calling the pack template,
so any template that threw left the client permanently one ahead of the
server: every later reply was matched to the wrong callback and the connection
silently stopped answering. Latent before (templates only threw on nonsense
input), reachable now that throwing is the documented contract. It rolls back
on throw, with a regression test.

## Scope limits

- Extension events are not packable — `packEvent` throws rather than guessing.
  A parallel `eventPackers` registry mirroring `eventParsers` would be the way
  in, but no extension needs it yet.
- `lib/xserver/events.js` still has its own hand-written server-side packers.
  They could delegate to the generated ones, but the two differ in real ways
  (a `sameScreen` default of 1, per-call masking of unvalidated client input),
  so that is a separate change that wants its own equivalence tests.
- `test/client-message.js` deliberately keeps hand-packing: it is now the
  regression test for the raw-Buffer path.

## Testing

- New `test/event-pack.js` (71 tests): hand-written wire-layout assertions
  taken from the protocol/ICCCM encodings rather than from the parsers, a
  byte-by-byte round trip over every event, out-of-range/negative value
  contracts, the rejection cases, and live SendEvent delivery against Xvfb
  using the empty-event-mask rule (mask 0 delivers to the window's creating
  client, which lets one client round-trip any event type).
- The round trip lets the **parser** decide which bytes are fields; an earlier
  version let the packer's output define that, which quietly excused a field
  the packer had dropped entirely. Mutation testing caught it: shifting a
  field's offset, truncating a 16-bit write, dropping the detail byte and
  removing the `>>> 0` normalisation all fail the suite now, and three of
  those passed before.
- Converted the hand-packing in `test/xserver/multiclient.js` and
  `examples/smoketest/sendevent.js` to the new API, so it is exercised by
  existing tests too.
- Suites: 382 passing (311 on master), 284 xserver, 52 glx-emu, lint clean,
  `npm run gen:events` is a no-op on the committed output.