### PR TITLE
fix: accept async functions as request callbacks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -163,7 +163,11 @@ X.on('error', err => console.error(err.message, err.badParam));
 ```
 
 If a reply callback receives an error and returns `true`, the error is
-considered handled and is not re-emitted on the client. With
+considered handled and is not re-emitted on the client. Any callable works as
+a callback, including an `async` function — with two consequences worth
+knowing: an `async` function always returns a promise, which is truthy, so
+errors routed to one always count as handled; and a rejection inside it
+surfaces as an unhandled rejection rather than reaching the client. With
 `createClient({debug: true}, …)` each error also carries the stack trace of
 the request that caused it.
 

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -254,8 +254,12 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
 
             client.seq_num++;
 
+            // A trailing function is the callback. Test the type, not the
+            // constructor name: an async or generator function is still a
+            // callable, and an object with a null prototype has no
+            // constructor to name at all.
             let callback = args.length > 0 ? args[args.length - 1] : null;
-            if (callback && callback.constructor.name != 'Function')
+            if (typeof callback !== 'function')
                 callback = null;
 
             // TODO: see how much we can calculate in advance (not in each request)

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -1,0 +1,125 @@
+const x11 = require('../lib');
+const assert = require('assert');
+
+// The request dispatcher decides whether the trailing argument is a callback.
+// It used to test `callback.constructor.name != 'Function'`, which rejected
+// every callable that is not a plain function — an `async` callback was
+// silently dropped, the request was still sent, and nothing ever fired.
+
+describe('request callbacks', () => {
+
+  let display;
+  let X;
+  let root;
+
+  beforeEach(done => {
+      const client = x11.createClient((err, dpy) => {
+          if (err) return done(err);
+          display = dpy;
+          X = display.client;
+          root = display.screen[0].root;
+          client.removeListener('error', done);
+          done();
+      });
+      client.on('error', done);
+  });
+
+  afterEach(done => {
+      X.on('end', done);
+      X.terminate();
+  });
+
+  describe('any callable is accepted', () => {
+
+    it('an async callback receives a reply', done => {
+        X.GetGeometry(root, async (err, geom) => {
+            assert.ifError(err);
+            assert.ok(geom.width > 0);
+            done();
+        });
+    });
+
+    it('an async callback receives a void request\'s confirmation (#85)', done => {
+        X.ChangeWindowAttributes(root, { eventMask: 0 }, async err => {
+            assert.strictEqual(err, null);
+            done();
+        });
+    });
+
+    it('an async callback receives an X error', done => {
+        X.GetGeometry(0, async err => {
+            assert.ok(err instanceof Error);
+            assert.strictEqual(err.error, 9); // BadDrawable
+            done();
+        });
+    });
+
+    it('a bound function receives a reply', done => {
+        function handler(err, geom) {
+            assert.ifError(err);
+            assert.strictEqual(this.tag, 'bound');
+            assert.ok(geom.width > 0);
+            done();
+        }
+        X.GetGeometry(root, handler.bind({ tag: 'bound' }));
+    });
+
+    it('a proxied function receives a reply', done => {
+        const calls = [];
+        const spy = new Proxy((err, geom) => {
+            calls.push(geom.width);
+        }, {});
+        X.GetGeometry(root, spy);
+        X.sync(() => {
+            assert.strictEqual(calls.length, 1);
+            done();
+        });
+    });
+  });
+
+  describe('non-callables are still just arguments', () => {
+
+    it('does not treat a trailing string as a callback', done => {
+        // ChangeProperty's last argument is the property value
+        X.ChangeProperty(0, root, X.atoms.WM_NAME, X.atoms.STRING, 8, 'callback-test');
+        X.GetProperty(0, root, X.atoms.WM_NAME, X.atoms.STRING, 0, 100, (err, prop) => {
+            assert.ifError(err);
+            assert.strictEqual(prop.data.toString(), 'callback-test');
+            done();
+        });
+    });
+
+    it('does not treat a trailing object as a callback', done => {
+        const wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, 10, 10, 0, 0, 0, 0, { eventMask: 0 });
+        X.GetGeometry(wid, (err, geom) => {
+            assert.ifError(err);
+            assert.strictEqual(geom.width, 10);
+            X.DestroyWindow(wid);
+            done();
+        });
+    });
+
+    it('does not throw on a trailing object with no prototype', done => {
+        // `Object.create(null)` has no `.constructor`; reading its name threw
+        assert.doesNotThrow(() => X.GetGeometry(root, Object.create(null)));
+        X.sync(err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+  });
+
+  describe('sequence numbers stay in step', () => {
+
+    it('a request whose callback slot holds a non-callable still gets its reply', done => {
+        // the dropped-callback path must not disturb the request stream
+        X.GetGeometry(root, 42);
+        X.GetGeometry(root, (err, geom) => {
+            assert.ifError(err);
+            assert.ok(geom.width > 0);
+            done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
## The symptom

```js
X.GetGeometry(root, async (err, geom) => { /* never runs */ });
```

The request goes out, the server answers, and the callback never fires. No
error, no warning — the reply is simply dropped. The same call with a
non-async arrow works.

## Why

The request dispatcher decided whether the trailing argument was a callback
by name, not by type:

```js
if (callback && callback.constructor.name != 'Function')
    callback = null;
```

`(async () => {}).constructor.name` is `'AsyncFunction'`, so async callbacks
were discarded — the request was still sent, but nothing was registered to
receive its reply or its error. Generator functions went the same way.

The same line also *threw* on a trailing argument with a null prototype:
`Object.create(null)` has no `.constructor`, so reading `.name` off it raised
a `TypeError` and killed the request before the packet was built. On master
that also desynced the connection, since the sequence number had already been
incremented (fixed separately in #248).

The check dates to
[`4164611`](https://github.com/sidorares/node-x11/commit/4164611a06fc9ee8d817e6579f266cfe0dab161a)
(2011) — an incidental line in a commit about `InternAtom`, written on Node
0.4, five years before async functions existed in V8.

## The fix

Test the type: `typeof callback !== 'function'`.

This is what the rest of the codebase already does (`lib/xcore.js:52`,
`lib/framebuffer.js:106,117,137`, `lib/xserver/server.js:161`) — the old line
was the only `constructor.name` check in `lib/`.

It also removes a real inconsistency rather than creating one: **extensions
have always accepted async callbacks.** None of the 24 modules in `lib/ext/`
go through this dispatcher, and none type-check their callbacks at all — they
take the callback as a positional argument and register it unconditionally. So
`randr.GetScreenResources(root, async cb)` worked while
`X.GetGeometry(root, async cb)` silently did not.

## Compatibility

Non-callable trailing arguments are unaffected — a `values` object, a string,
a Buffer, a resource id were not callbacks before and are not now. The only
behaviour that changes is for callables that are not plain functions, plus the
null-prototype case that used to throw:

| trailing argument | before | after |
|---|---|---|
| plain function, arrow, bound function, class, `Proxy` of a plain function | callback | callback (unchanged) |
| **async function, async arrow, generator, async generator** | **dropped** | callback |
| **`Object.create(null)`** | **TypeError** | not a callback |
| object, string, number, Buffer, array | not a callback | not a callback (unchanged) |

I swept all 126 generated request names across `lib/`, `lib/ext/`, `test/`,
`examples/`, `browser/`, `website/src/` and `scripts/` — 1389 call sites.
Nothing passes a trailing function that is not meant as a callback, and no
core or extension request template has a parameter that takes a function, so
nothing depends on the old behaviour. Nothing in the repo documents it either.

This does not make the API promise-based (AGENTS.md rules that out) — the API
stays callback-shaped, it just stops rejecting a callback for being `async`.

## Two consequences, documented rather than worked around

An `async` callback always returns a promise, which is truthy, so per the
documented convention (`docs/README.md`) an error routed to it always counts
as handled and is never re-emitted as `'error'` on the client — you cannot
opt out. And a rejection inside it surfaces as an unhandled rejection rather
than reaching the client. Both are now stated in the error-handling section.

Awaiting the return value inside the dispatcher would fix the first, but it
would move the `'error'` emit to a later microtask for every callback in the
library; documenting seemed the better trade.

## Testing

New `test/callbacks.js`, 9 tests: async callbacks receiving a reply, a void
request's confirmation (the #85 checked-void path) and an X error; a bound
function; a proxied function; the three non-callable-trailing-argument cases
including `Object.create(null)`; and a guard that a dropped callback does not
disturb the request stream.

Verified as genuine regression tests — with the fix reverted, 4 of the 9 fail
(three async cases time out, the null-prototype case throws). Full suite 320
passing, xserver 284, lint clean.