### PR TITLE
docs: record where ICCCM/EWMH work belongs, and why it is not here

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,34 @@ No build step, no transpilation: `lib/` is what ships.
   new packages go to `devDependencies` only, and only when clearly justified.
 - The public API is callback-based (`createClient(cb)`, `X.SomeRequest(args, cb)`).
   Don't convert it to promises/async — that's a breaking change out of scope.
+- **Scope: the wire protocol, not the conventions layered on it.** In scope are
+  core requests/replies/events, extensions negotiated with `QueryExtension`,
+  the predefined atom *numbers* (`lib/stdatoms.js` is the X protocol's
+  Appendix B table, nothing more), and anything else whose byte layout comes
+  from `autogen/proto/*.xml`. Out of scope are ICCCM and EWMH property
+  *values* — the `WM_SIZE_HINTS` and `WM_HINTS` structs, `_NET_WM_*`,
+  `WM_PROTOCOLS` membership, `_NET_SUPPORTED` probing, `_MOTIF_WM_HINTS`.
+  Those belong to [ntk](https://github.com/sidorares/ntk), which already
+  implements them (see its AGENTS.md). This has been the standing answer
+  since [#177](https://github.com/sidorares/node-x11/issues/177) ("part of
+  xlib but not core protocol") and was reaffirmed closing
+  [#191](https://github.com/sidorares/node-x11/issues/191) and
+  [#87](https://github.com/sidorares/node-x11/issues/87).
+
+  The test that decides a borderline case: **can the server tell?** A wrong
+  request encoding is a protocol error the server rejects and Xvfb can prove
+  in CI; a wrong `WM_SIZE_HINTS` flags word is bytes the server stores
+  verbatim and only a *window manager* can judge — which is why the repo has
+  no generator, no round trip and no authority for it. `SendEvent`'s
+  `packEvent`/`SendClientMessage` are in scope despite being mostly used for
+  EWMH, because a 32-byte event layout is core protocol and is generated from
+  `xproto.xml` like everything else in `lib/generated/`.
+
+  What *is* ours in this area: making the requests underneath hard to misuse
+  (the `ChangeProperty` `(type, format, data)` tuple is where the filed bugs
+  actually landed — #106, #174, #178), exposing what only we know (the
+  connection byte order negotiated in `lib/handshake.js`), and decoding
+  properties for diagnostics (`examples/`).
 - Node-API usage must work on maintained Node versions (see CI matrix in
   `.github/workflows/ci.yml`). Avoid long-deprecated APIs
   (`util.isError`, `new Buffer()`, …).


### PR DESCRIPTION
## Why now

Triaging ntk#117 / ntk#118 / ntk#126 alongside #179 kept running into the same
question — which side of the node-x11/ntk line does a window-manager property
sit on — and I started out getting it wrong, reasoning that `WM_SIZE_HINTS` is
a spec-fixed 18-word struct with a flags word and therefore "bytes ↔ values",
which is this library's charter.

It isn't, and this repo has said so three times already:

- [#177](https://github.com/sidorares/node-x11/issues/177) (2018) asked for
  exactly `XSetWMNormalHints`/`XSetWMSizeHints` — *"No, they are part of xlib
  but not core protocol."*
- [#191](https://github.com/sidorares/node-x11/issues/191) (2020) —
  *"this library only provides low level X11 protocol
  serialisation/deserealisation."*
- [#87](https://github.com/sidorares/node-x11/issues/87) (last week) —
  *"belongs in higher-level layers (ntk etc.)."*

Writing it down so the next round starts from the answer instead of
rediscovering it.

## What the rule says

In scope: core requests/replies/events, extensions negotiated with
`QueryExtension`, the predefined atom *numbers*, and anything whose byte
layout comes from `autogen/proto/*.xml`. Out of scope: ICCCM/EWMH property
*values* — the `WM_SIZE_HINTS` and `WM_HINTS` structs, `_NET_WM_*`,
`WM_PROTOCOLS` membership, `_NET_SUPPORTED` probing, `_MOTIF_WM_HINTS`.

The useful part is the test for a borderline case rather than the list:

> **Can the server tell?** A wrong request encoding is a protocol error the
> server rejects and Xvfb proves in CI. A wrong `WM_SIZE_HINTS` flags word is
> bytes the server stores verbatim, and only a *window manager* can judge it —
> which is why this repo has no generator, no round trip and no authority for
> it.

That test also settles the case that looks like an exception: `packEvent` and
`SendClientMessage` (#248) are in scope despite being used mostly for EWMH,
because a 32-byte event layout is core protocol generated from `xproto.xml`,
and the server does reject a bad one.

It also names what *is* ours in this area, which is not nothing: making the
requests underneath hard to misuse (the `ChangeProperty` `(type, format,
data)` tuple is where the filed bugs actually landed — #106, #174, #178),
exposing what only we know (the connection byte order negotiated in
`lib/handshake.js`, which downstream currently hardcodes), and decoding
properties for diagnostics.

## Note on `lib/stdatoms.js`

Worth recording because it reads like a counter-example: it is the X
protocol's Appendix B predefined-atom table, generated from the xcb-proto
enum — not an ICCCM commitment. Every ICCCM-*invented* atom is absent
(`WM_PROTOCOLS`, `WM_STATE`, `WM_TAKE_FOCUS`, all `_NET_*`), and it ships
`WM_ZOOM_HINTS`, which ICCCM obsoletes. The core protocol fixes the atom's
number; ICCCM fixes the layout.

## The matching half

ntk gets the other side of the same decision in
[sidorares/ntk#129](https://github.com/sidorares/ntk/pull/129) — it already
implements these (including ICCCM INCR clipboard transfer, a harder wire
problem than any hint struct).

Docs only; no code change.
