### PR TITLE
feat: encode property values at their declared format, and report the connection byte order

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,12 @@ The `display` passed to the callback describes the connection setup block:
   `white_pixel`, `black_pixel`, `pixel_width`/`pixel_height`,
   `mm_width`/`mm_height`, `default_colormap`, `root_depth`, `depths`, …
 - `display.min_keycode` / `display.max_keycode`
+- `display.byte_order` — the order this connection speaks: 0 LSBFirst,
+  1 MSBFirst. Every request, reply, event and property value on the
+  connection uses it, so anything decoding property bytes should read this
+  rather than assume little-endian. Not to be confused with
+  `display.image_byte_order`, which is the server's pixel order for
+  `GetImage`/`PutImage`.
 
 ## Making requests
 

--- a/docs/core-requests.md
+++ b/docs/core-requests.md
@@ -119,12 +119,24 @@ Opcode 17. `cb(err, name)` — atom name as a string. Cached like `InternAtom`.
 
 ### ChangeProperty(mode, wid, name, type, format, data)
 Opcode 18. No reply. `mode`: 0 Replace, 1 Prepend, 2 Append. `name` and
-`type` are atoms, `format` is 8, 16 or 32 (bits per element). `data` may be
-a Buffer, an array of bytes, or a string (encoded latin1).
+`type` are atoms, `format` is 8, 16 or 32 (bits per element).
+
+`data` may be a Buffer (used as-is), a string (encoded latin1), or a number
+or array of numbers — those are encoded as elements of the declared `format`
+width, so a 32-bit property can be written without packing a Buffer by hand:
 
 ```js
 X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, 'hello');
+X.ChangeProperty(0, wid, strutAtom, X.atoms.CARDINAL, 32, [0, 0, 0, 23]);
 ```
+
+The server does not validate property contents — it stores whatever bytes it
+is given — so a `format` that does not match the data produces no error and a
+property everyone silently ignores. Two cases that cannot be right are
+reported once per process on `console.warn`: a `format` other than 8/16/32
+(the server answers BadValue), and a Buffer whose length is not a whole number
+of elements of that format (BadLength). To see what actually landed on a
+window, use [`examples/xprop.js`](../examples/xprop.js).
 
 ### DeleteProperty(wid, prop)
 Opcode 19. No reply. `prop` is the property atom.

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -5,6 +5,17 @@ const xutil = require('./xutil');
 const coreReplies = require('./generated/core-replies');
 const coreEvents = require('./generated/core-events');
 
+// Properties are opaque to the server: a format that does not match the data
+// is stored without complaint and simply ignored by whoever reads it. Warn
+// once — a caller who gets this wrong usually does it on every write.
+let warnedProperty = false;
+function warnProperty(msg) {
+    if (warnedProperty)
+        return;
+    warnedProperty = true;
+    console.warn(`ChangeProperty: ${msg} Further occurrences are not reported.`);
+}
+
 const valueMask = {
     CreateWindow: {
         backgroundPixmap      : {
@@ -619,17 +630,45 @@ const templates = {
        // format: 8/16/32
        (mode, wid, name, type, units, data) => {
           let payload;
-          if (Buffer.isBuffer(data))
+          if (Buffer.isBuffer(data)) {
               payload = data;
-          else if (Array.isArray(data))
-              payload = Buffer.from(data);
-          else
+          } else if (Array.isArray(data) || typeof data === 'number') {
+              // `format` states how wide each element is, so encode them that
+              // width. Buffer.from([1366]) would keep only the low byte and
+              // then report a fractional element count, which reaches the
+              // server as an empty property — silently, since properties are
+              // opaque bytes it never validates.
+              const values = typeof data === 'number' ? [data] : data;
+              const width = units === 32 ? 4 : units === 16 ? 2 : 1;
+              payload = Buffer.alloc(values.length * width);
+              for (let i = 0; i < values.length; ++i) {
+                  if (width === 4)
+                      payload.writeUInt32LE(values[i] >>> 0, i * 4);
+                  else if (width === 2)
+                      payload.writeUInt16LE(values[i] & 0xffff, i * 2);
+                  else
+                      payload[i] = values[i] & 0xff;
+              }
+          } else {
               payload = Buffer.from(String(data), 'latin1');
+          }
+
+          if (units !== 8 && units !== 16 && units !== 32) {
+              warnProperty(`format ${units} is not 8, 16 or 32; the server rejects ` +
+                  'this with BadValue.');
+          } else if (payload.length % (units >> 3)) {
+              // The declared element count and the padded data length then
+              // disagree, and the server answers BadLength — asynchronously,
+              // against a sequence number the caller has already forgotten.
+              warnProperty(`${payload.length} bytes of data is not a whole number ` +
+                  `of ${units}-bit elements; the server rejects this with BadLength. ` +
+                  'Check the format against the data.');
+          }
 
           const padded4 = (payload.length + 3) >> 2;
           const padLen = (padded4 << 2) - payload.length;
           const requestLength = 6 + padded4;
-          const dataLenInFormatUnits = payload.length / (units >> 3);
+          const dataLenInFormatUnits = Math.floor(payload.length / (units >> 3));
           const b = Buffer.alloc(24 + payload.length + padLen);
           b[0] = 18;
           b[1] = mode;

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -141,6 +141,13 @@ bl.get(1, statusBuf => {
              // Total after status: 1+2+2+2+4*4+2+2+8+4 = 1+6+16+4+8+4 = 39? Let me recount.
              // Old format after first C status: 'x S major S minor S xlen L release L resource_base L resource_mask L motion_buffer_size S vlen S max_request_length C screen_num C format_num C image_byte_order C bitmap_bit_order C bitmap_scanline_unit C bitmap_scanline_pad C min_keycode C max_keycode xxxx'
              // sizes: 1 + 2+2+2 + 4+4+4+4 + 2+2 + 1*8 + 4 = 1+6+16+4+8+4 = 39 bytes
+             // The order this connection speaks, declared in the client hello
+             // and used for every request, reply, event and property value on
+             // it. 0 LSBFirst, 1 MSBFirst — same encoding as image_byte_order
+             // below, which is a different thing (the server's pixel order).
+             // Anything decoding property bytes needs this rather than a
+             // hardcoded readUInt32LE.
+             display.byte_order = getByteOrder() === 'B'.charCodeAt(0) ? 1 : 0;
              display.major = hdr.readUInt16LE(1);
              display.minor = hdr.readUInt16LE(3);
              display.xlen = hdr.readUInt16LE(5);

--- a/test/change-property.js
+++ b/test/change-property.js
@@ -84,6 +84,53 @@ describe('ChangeProperty', () => {
         });
     });
 
+    it('should encode a number array at the declared format width', function(done) {
+        const self = this;
+        // Buffer.from([1366]) keeps only the low byte, so this used to reach
+        // the server as an empty property with one garbage byte behind it
+        const strut = [0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 1366];
+        this.X.InternAtom(false, 'X11_TEST_STRUT', (err, atom) => {
+            should.not.exist(err);
+            self.X.ChangeProperty(0, self.wid, atom, self.X.atoms.CARDINAL, 32, strut);
+            self.X.GetProperty(0, self.wid, atom, self.X.atoms.CARDINAL, 0, 100, (err, prop) => {
+                should.not.exist(err);
+                prop.data.length.should.equal(48);
+                const out = [];
+                for (let i = 0; i + 4 <= prop.data.length; i += 4)
+                    out.push(prop.data.readUInt32LE(i));
+                out.should.eql(strut);
+                done();
+            });
+        });
+    });
+
+    it('should encode a bare number as one element of the declared format', function(done) {
+        const self = this;
+        this.X.InternAtom(false, 'X11_TEST_NUMBER', (err, atom) => {
+            should.not.exist(err);
+            self.X.ChangeProperty(0, self.wid, atom, self.X.atoms.CARDINAL, 32, 0xdeadbeef);
+            self.X.GetProperty(0, self.wid, atom, self.X.atoms.CARDINAL, 0, 100, (err, prop) => {
+                should.not.exist(err);
+                prop.data.length.should.equal(4);
+                prop.data.readUInt32LE(0).should.equal(0xdeadbeef);
+                done();
+            });
+        });
+    });
+
+    it('should keep packing a byte array at format 8', function(done) {
+        const self = this;
+        this.X.InternAtom(false, 'X11_TEST_BYTES', (err, atom) => {
+            should.not.exist(err);
+            self.X.ChangeProperty(0, self.wid, atom, self.X.atoms.STRING, 8, [104, 105]);
+            self.X.GetProperty(0, self.wid, atom, self.X.atoms.STRING, 0, 100, (err, prop) => {
+                should.not.exist(err);
+                prop.data.toString().should.equal('hi');
+                done();
+            });
+        });
+    });
+
     after(function(done) {
         this.X.DestroyWindow(this.wid);
         this.X.terminate();

--- a/test/connect.js
+++ b/test/connect.js
@@ -28,6 +28,16 @@ describe('Client', () => {
       done();
   });
 
+  it('reports the byte order the connection speaks', done => {
+      // what the client declared in its hello, and therefore how every
+      // request, reply, event and property value on it is encoded
+      display.byte_order.should.be.oneOf([0, 1]);
+      const hostIsLittleEndian =
+          new Uint32Array(new Uint8Array([1, 2, 3, 4]).buffer)[0] === 0x04030201;
+      display.byte_order.should.equal(hostIsLittleEndian ? 0 : 1);
+      done();
+  });
+
   it('uses display variable from parameter if present ignoring anvironment $DISPLAY', done => {
      const disp = process.env.DISPLAY;
      process.env.DISPLAY = 'BOGUS DISPLAY';


### PR DESCRIPTION
## Context

Properties are the one place in the protocol where the server validates
nothing. It stores whatever bytes it is handed under whatever type and format
you declare, so a mismatch between `format` and `data` produces no error, no
warning and no visible symptom — just a property that every reader silently
ignores. That is the shape of #106, #174, #178 and #179, and it is why those
threads run long.

Two changes, both aimed at that.

## Arrays and numbers are encoded at the declared width

`ChangeProperty` packed an array with `Buffer.from()`, which keeps only the low
byte of each element. So the obvious way to write a strut:

```js
X.ChangeProperty(0, wid, atom, X.atoms.CARDINAL, 32, [0, 0, 0, 23]);
```

produced **four bytes rather than four words** — `Buffer.from([1366])` is
`<Buffer 56>` — and then an element count of `4 / 4` computed from a fractional
length, so what reached the server was a single word of nonsense. Silently.

`format` already states how wide each element is, and that is the only reading
it allows, so arrays and bare numbers are now encoded at that width:

```js
X.ChangeProperty(0, wid, strutAtom, X.atoms.CARDINAL, 32, [0, 0, 0, 23]);   // 16 bytes
X.ChangeProperty(0, wid, atom, X.atoms.CARDINAL, 32, 0xdeadbeef);           // 4 bytes
```

Compatibility: byte arrays at `format` 8 are byte-for-byte unchanged (the old
path was already `value & 0xff` per element), and Buffers are still used
verbatim. The only calls whose wire output changes are ones that were writing
a malformed property. Every `ChangeProperty` call in this repo passes a string
or a Buffer, so nothing in-tree changes.

## Two mismatches are reported instead of surfacing later

The cases that cannot be repaired now warn once per process, naming the error
the server is about to answer with:

- a `format` other than 8/16/32 → BadValue
- a Buffer whose length is not a whole number of elements of that format →
  BadLength

Both otherwise arrive asynchronously, attributed to a sequence number the
caller has long since forgotten. Once per process rather than per call,
following `Render`'s `colorToFix`: a caller who gets this wrong usually gets
it wrong on every write.

These stayed warnings rather than throws deliberately — a throw from a pack
template is safe only with the sequence-number rollback in #248, and a
malformed property is the server's call to reject, not ours to refuse.

## `display.byte_order`

The byte order a connection speaks is decided in the client hello and was then
never exposed, so anything decoding property bytes had to assume
little-endian — ntk hardcodes `readUInt32LE` in half a dozen places for exactly
this reason, and is correct today only because two independent choices happen
to agree.

```js
display.byte_order   // 0 LSBFirst, 1 MSBFirst
```

Deliberately named next to the `display.image_byte_order` it is easy to
confuse with: that one is the *server's* pixel order for `GetImage`/`PutImage`,
this one is how every request, reply, event and property value on the
connection is encoded.

## Scope

Both changes are about making the request underneath hard to misuse. Neither
adds any knowledge of what property *values* mean — no `WM_SIZE_HINTS` packer,
no EWMH — which stays out of scope here (#251); `examples/xprop.js` from #252
is the read side of the same problem.

## Testing

New cases in `test/change-property.js` (array at format 32 round-tripping
#179's twelve strut values, a bare number, and byte arrays at format 8 still
packing as before) and in `test/connect.js` for `byte_order` against the host
endianness. Suite 315 passing, xserver 284, lint clean.