### PR TITLE
fix(auth): match FamilyWild cookies, and say when no cookie matched

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,19 @@ style, e.g. `/private/tmp/com.apple.launchd.../org.xquartz:0`), and over TCP
 (port 6000 + display number) otherwise. `~/.Xauthority` (or `$XAUTHORITY`) is
 used for authentication automatically.
 
+Cookie selection follows the file's own order, taking the first entry whose
+display matches — an empty display field in the entry matches any — and whose
+address matches, either exactly or because the entry is `FamilyWild`, the
+wildcard `xauth generate` writes. When `$XAUTHORITY` names a file that is not
+there, that is the answer; the `~/.Xauthority` and dotless-`~/Xauthority`
+guesses are only tried when the variable is unset.
+
+If a cookie file exists but nothing in it matches, the connection is still
+attempted **without** authentication — some servers accept that — and a
+warning names the file, what was looked for and what the file held instead.
+Without it the only symptom is the server's own "Authorization required",
+which looks the same as having no cookie file at all.
+
 `createClient` returns the client object immediately; subscribe to `'error'`
 on it to catch connection-phase failures.
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,24 +17,44 @@ const typeToName = {
       6: 'Internet6'
 };
 
-function parseXauth( buf )
+// FamilyWild matches any address. `xauth generate` and `xauth add :0 . <key>`
+// both write entries with this family, so it is not an exotic case.
+const FAMILY_WILD = 65535;
+const FAMILY_INTERNET = 0;
+
+function familyLabel(type) {
+    return typeToName[type] ? `${typeToName[type]} (${type})` : `unknown family ${type}`;
+}
+
+function parseXauth( buf, filename )
 {
     let offset = 0;
     const auth = [];
     const cookieProperties = ['address', 'display', 'authName', 'authData'];
 
-    while (offset < buf.length)
+    while (offset + 2 <= buf.length)
     {
         const cookie = {};
         cookie.type = buf.readUInt16BE(offset);
         if (!typeToName[cookie.type]) {
-            console.warn('Unknown address type');
+            console.warn(`x11: unknown address family ${cookie.type} in ${filename}`);
         }
         offset += 2;
-        cookieProperties.forEach(property => {
+        // A half-written or truncated file must not throw RangeError out of an
+        // fs callback, where no caller can catch it. Keep what parsed cleanly.
+        let truncated = false;
+        for (const property of cookieProperties) {
+          if (offset + 2 > buf.length) {
+            truncated = true;
+            break;
+          }
           const length = buf.readUInt16BE(offset);
           offset += 2;
-          if (cookie.type === 0 && property == 'address') { // Internet
+          if (offset + length > buf.length) {
+            truncated = true;
+            break;
+          }
+          if (cookie.type === FAMILY_INTERNET && property === 'address' && length === 4) {
             // 4 bytes of ip addess, convert to w.x.y.z string
             cookie.address = [ buf[offset], buf[offset+1], buf[offset+2], buf[offset+3]]
               .map(octet => octet.toString(10)).join('.');
@@ -42,7 +62,13 @@ function parseXauth( buf )
             cookie[property] = buf.toString('latin1', offset, offset + length);
           }
           offset += length;
-        });
+        }
+        if (truncated) {
+            console.warn(
+                `x11: ${filename} ends in the middle of an entry; using the ` +
+                `${auth.length} complete ${auth.length === 1 ? 'entry' : 'entries'} before it`);
+            break;
+        }
         auth.push(cookie);
     }
     return auth;
@@ -51,25 +77,78 @@ function parseXauth( buf )
 const homedir = require('os').homedir;
 const path = require('path');
 
+/**
+ * Read the Xauthority file, reporting which one was read.
+ *
+ * cb(err, data, filename) — `data` is null when there is simply no file,
+ * which is the ordinary state on a server that allows unauthenticated
+ * connections and must stay silent.
+ */
 function readXauthority(cb) {
-  let filename = process.env.XAUTHORITY || path.join(homedir(), '.Xauthority');
-  fs.readFile(filename, (err, data) => {
-    if (!err)
-      return cb(null, data);
-    if(err.code == 'ENOENT') {
-      // Xming/windows uses %HOME%/Xauthority ( .Xauthority with no dot ) - try with this name
-      filename = process.env.XAUTHORITY || path.join(homedir(), 'Xauthority');
-      fs.readFile(filename, (err, data) => {
-        if (err.code == 'ENOENT') {
-          cb(null, null);
-        } else {
-          cb(err);
-        }
-      });
-    } else {
+  const fromEnv = process.env.XAUTHORITY;
+  if (fromEnv) {
+    // an explicit path is the whole answer: guessing a second one would only
+    // hide the user's typo
+    return fs.readFile(fromEnv, (err, data) => {
+      if (!err)
+        return cb(null, data, fromEnv);
+      if (err.code === 'ENOENT')
+        return cb(null, null, fromEnv);
       cb(err);
-    }
+    });
+  }
+  const dotted = path.join(homedir(), '.Xauthority');
+  fs.readFile(dotted, (err, data) => {
+    if (!err)
+      return cb(null, data, dotted);
+    if (err.code !== 'ENOENT')
+      return cb(err);
+    // Xming on Windows writes %HOME%/Xauthority, with no leading dot
+    const undotted = path.join(homedir(), 'Xauthority');
+    fs.readFile(undotted, (err2, data2) => {
+      if (!err2)
+        return cb(null, data2, undotted);
+      if (err2.code === 'ENOENT')
+        return cb(null, null, dotted);
+      cb(err2);
+    });
   });
+}
+
+const MAX_LISTED_ENTRIES = 8;
+const warnedMatchFailures = new Set();
+
+/**
+ * Say why a cookie file that exists did not produce a cookie.
+ *
+ * Falling back to an unauthenticated connection is right — plenty of servers
+ * accept one — but doing it silently means the only symptom is the server's
+ * generic "Authorization required", which looks identical to having no
+ * Xauthority file at all. Naming the file, what was wanted and what was in it
+ * turns that into a one-line diagnosis.
+ */
+function warnNoMatch(filename, auth, family, host, display) {
+  let found;
+  if (auth.length === 0) {
+    found = '    (no entries)';
+  } else {
+    // never the auth data itself — that is the secret being looked up
+    const shown = auth.slice(0, MAX_LISTED_ENTRIES).map(c =>
+      `    ${familyLabel(c.type)} address ${JSON.stringify(c.address)} ` +
+      `display ${JSON.stringify(c.display)} ${c.authName}`);
+    if (auth.length > MAX_LISTED_ENTRIES)
+      shown.push(`    ... and ${auth.length - MAX_LISTED_ENTRIES} more`);
+    found = shown.join('\n');
+  }
+  const message =
+    `x11: no entry in ${filename} matches this connection, so it is being made without\n` +
+    `  authentication - the server will refuse it unless it accepts unauthenticated clients.\n` +
+    `  wanted: ${familyLabel(family)} address ${JSON.stringify(host)} display ${JSON.stringify(display)}\n` +
+    `  file has:\n${found}`;
+  if (warnedMatchFailures.has(message))
+    return;
+  warnedMatchFailures.add(message);
+  console.warn(message);
 }
 
 module.exports = (display, host, socketFamily, cb) => {
@@ -81,24 +160,27 @@ module.exports = (display, host, socketFamily, cb) => {
   } else {
     family = 256; // Local
   }
-  readXauthority((err, data) => {
+  readXauthority((err, data, filename) => {
     if(err) return cb(err);
 
-    if (!data) {
+    if (!data || data.length === 0) {
       return cb(null, {
         authName: '',
         authData: ''
       });
     }
-    const auth = parseXauth(data);
-    for (const cookieNum in auth)
+    const auth = parseXauth(data, filename);
+    for (const cookie of auth)
     {
-      const cookie = auth[cookieNum];
-      if ((typeToName[cookie.family] === 'Wild' || (cookie.type === family && cookie.address === host)) &&
+      // FamilyWild is a wildcard over the address, not over the display
+      const addressMatches = cookie.type === FAMILY_WILD ||
+          (cookie.type === family && cookie.address === host);
+      if (addressMatches &&
           (cookie.display.length === 0 || cookie.display === display))
         return cb( null, cookie );
     }
-    // If no cookie is found, proceed without authentication
+    // No cookie matched. Proceed without authentication, but say so.
+    warnNoMatch(filename, auth, family, host, display);
     cb(null, {
       authName: '',
       authData: ''

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,0 +1,221 @@
+// Xauthority cookie selection. No X server involved: everything here happens
+// before the connection is made, which is exactly why getting it wrong is so
+// hard to diagnose from the outside.
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const getAuthString = require('../lib/auth');
+
+/** One Xauthority entry in its on-disk form: family, then four length-prefixed fields. */
+function entry(family, address, display, authName, authData) {
+    const parts = [Buffer.from([family >> 8, family & 0xff])];
+    for (const field of [address, display, authName, authData]) {
+        const b = Buffer.isBuffer(field) ? field : Buffer.from(field, 'latin1');
+        parts.push(Buffer.from([b.length >> 8, b.length & 0xff]), b);
+    }
+    return Buffer.concat(parts);
+}
+
+const KEY = Buffer.alloc(16, 0xab);
+const FAMILY_WILD = 65535;
+const FAMILY_LOCAL = 256;
+const FAMILY_INTERNET = 0;
+
+describe('Xauthority', () => {
+    let home;
+    let savedEnv;
+    let warnings;
+    let originalWarn;
+
+    beforeEach(() => {
+        home = fs.mkdtempSync(path.join(os.tmpdir(), 'x11-auth-'));
+        savedEnv = { HOME: process.env.HOME, XAUTHORITY: process.env.XAUTHORITY };
+        // os.homedir() honours $HOME on POSIX, which is how the no-XAUTHORITY
+        // path gets pointed at the fixture
+        process.env.HOME = home;
+        delete process.env.XAUTHORITY;
+        warnings = [];
+        originalWarn = console.warn;
+        console.warn = (...args) => warnings.push(args.join(' '));
+    });
+
+    afterEach(() => {
+        console.warn = originalWarn;
+        for (const [k, v] of Object.entries(savedEnv)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+        fs.rmSync(home, { recursive: true, force: true });
+    });
+
+    /** Write `buf` to a file under the fixture home and point XAUTHORITY at it. */
+    const useAuthFile = (buf, name = 'authfile') => {
+        const file = path.join(home, name);
+        fs.writeFileSync(file, buf);
+        process.env.XAUTHORITY = file;
+        return file;
+    };
+
+    const lookup = (display = '0', host = 'myhost', family = 'pipe') =>
+        new Promise((resolve, reject) =>
+            getAuthString(display, host, family, (err, cookie) =>
+                err ? reject(err) : resolve(cookie)));
+
+    it('selects a FamilyWild cookie for any address', async () => {
+        // the bug: matching tested cookie.family, which parseXauth never sets,
+        // so this entry could never be chosen and the connection went out with
+        // no authentication at all
+        useAuthFile(entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('0', 'some-host-we-have-never-heard-of');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+        assert.strictEqual(cookie.authData, KEY.toString('latin1'));
+        assert.deepStrictEqual(warnings, []);
+    });
+
+    it('still selects an exact local match', async () => {
+        useAuthFile(entry(FAMILY_LOCAL, 'myhost', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('0', 'myhost', 'pipe');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+    });
+
+    it('matches an IPv4 entry by its dotted address', async () => {
+        useAuthFile(entry(FAMILY_INTERNET, Buffer.from([10, 0, 0, 5]), '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('0', '10.0.0.5', 'IPv4');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+    });
+
+    it('prefers an earlier exact entry over a later wildcard', async () => {
+        const exact = Buffer.alloc(16, 0x11);
+        useAuthFile(Buffer.concat([
+            entry(FAMILY_LOCAL, 'myhost', '0', 'MIT-MAGIC-COOKIE-1', exact),
+            entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY)
+        ]));
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authData, exact.toString('latin1'), 'file order decides');
+    });
+
+    it('an empty display field in the entry matches any display', async () => {
+        useAuthFile(entry(FAMILY_WILD, '', '', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('7', 'myhost');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+    });
+
+    it('a different display does not match', async () => {
+        useAuthFile(entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('1', 'myhost');
+        assert.strictEqual(cookie.authName, '', 'wildcard is over the address, not the display');
+    });
+
+    it('says which file it read and what was in it when nothing matches', async () => {
+        // the silent half of the bug: without this the only symptom is the
+        // server's generic "Authorization required", identical to having no
+        // Xauthority file at all
+        const file = useAuthFile(entry(FAMILY_LOCAL, 'otherhost', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, '');
+        assert.strictEqual(warnings.length, 1);
+        const said = warnings[0];
+        assert.ok(said.includes(file), 'names the file it read');
+        assert.ok(said.includes('"myhost"'), 'names what it was looking for');
+        assert.ok(said.includes('"otherhost"'), 'names what it found instead');
+        assert.ok(!said.includes(KEY.toString('latin1')), 'never prints the key itself');
+    });
+
+    it('stays quiet when there is no Xauthority file at all', async () => {
+        // the ordinary state on a server that accepts unauthenticated clients
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, '');
+        assert.deepStrictEqual(warnings, [], 'nothing was misconfigured, so nothing to say');
+    });
+
+    it('reads the dotless Xming file when ~/.Xauthority is absent', async () => {
+        // this fallback used to throw TypeError from inside the fs callback
+        // whenever it found the file, so it had never once worked
+        fs.writeFileSync(path.join(home, 'Xauthority'),
+            entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+        assert.strictEqual(cookie.authData, KEY.toString('latin1'));
+    });
+
+    it('prefers ~/.Xauthority when both spellings exist', async () => {
+        const dotted = Buffer.alloc(16, 0x22);
+        fs.writeFileSync(path.join(home, '.Xauthority'),
+            entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', dotted));
+        fs.writeFileSync(path.join(home, 'Xauthority'),
+            entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authData, dotted.toString('latin1'));
+    });
+
+    it('does not fall back to a home-directory guess when XAUTHORITY is set', async () => {
+        // an explicit path that is missing is the user's typo to see, not
+        // something to paper over with a cookie from somewhere else
+        fs.writeFileSync(path.join(home, '.Xauthority'),
+            entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+        process.env.XAUTHORITY = path.join(home, 'does-not-exist');
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, '');
+        assert.deepStrictEqual(warnings, [], 'no file read, so nothing to report about its contents');
+    });
+
+    it('keeps the entries before a truncation instead of throwing', async () => {
+        const good = entry(FAMILY_LOCAL, 'myhost', '0', 'MIT-MAGIC-COOKIE-1', KEY);
+        const cut = entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY).subarray(0, 9);
+        useAuthFile(Buffer.concat([good, cut]));
+
+        // reading past the end used to be a RangeError raised inside an fs
+        // callback, which no caller could catch
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+        assert.ok(
+            warnings.some(w => w.includes('ends in the middle of an entry')),
+            'and it says the file is damaged');
+    });
+
+    it('survives an entry cut off inside its address', async () => {
+        // the nastier truncation: the length prefix says four bytes of IPv4
+        // address and the file ends after two. Reading them back gives
+        // undefined, and the dotted-quad conversion then threw TypeError from
+        // inside the fs callback.
+        const good = entry(FAMILY_LOCAL, 'myhost', '0', 'MIT-MAGIC-COOKIE-1', KEY);
+        const cut = entry(FAMILY_INTERNET, Buffer.from([10, 0, 0, 5]), '0', 'MIT-MAGIC-COOKIE-1', KEY)
+            .subarray(0, 6);
+        useAuthFile(Buffer.concat([good, cut]));
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+        assert.ok(warnings.some(w => w.includes('ends in the middle of an entry')));
+    });
+
+    it('an empty file is treated as no file', async () => {
+        useAuthFile(Buffer.alloc(0));
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, '');
+        assert.deepStrictEqual(warnings, []);
+    });
+
+    it('reports an unknown address family without refusing the file', async () => {
+        useAuthFile(Buffer.concat([
+            entry(1234, 'weird', '0', 'MIT-MAGIC-COOKIE-1', KEY),
+            entry(FAMILY_WILD, '', '0', 'MIT-MAGIC-COOKIE-1', KEY)
+        ]));
+
+        const cookie = await lookup('0', 'myhost');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1', 'the usable entry still wins');
+        assert.ok(warnings.some(w => w.includes('unknown address family 1234')));
+    });
+});


### PR DESCRIPTION
Fixes #243.

Three bugs in `lib/auth.js`, all ending the same way: the connection goes out unauthenticated, and the only symptom is the server's generic *"Authorization required"* — which looks exactly like having no cookie file at all.

## 1. The one #243 reports

`parseXauth` writes `cookie.type`. The match loop tested `typeToName[cookie.family]`, a property nothing anywhere sets, so `typeToName[undefined]` was never `'Wild'` and the wildcard branch was dead code. Only the exact `(type, address)` pair could ever match.

That is not an exotic entry to lose. `xauth generate` writes FamilyWild, and so does a container with a bind-mounted cookie file or any host whose name changed since the entry was made.

## 2. The Xming fallback has never once worked

Found while fixing the first. The dotless-`~/Xauthority` fallback reads the file and then does this:

```js
fs.readFile(filename, (err, data) => {
  if (err.code == 'ENOENT') {   // err is null when the read SUCCEEDED
```

So the moment it actually found the file — the entire reason the fallback exists — it threw `TypeError: Cannot read properties of null` from inside an fs callback, where no caller can catch it. It took the process down rather than returning a cookie. Reproduced before touching it:

```
TypeError: Cannot read properties of null (reading 'code')
    at lib/auth.js:63:17
    at FSReqCallback.readFileAfterClose
```

Doubly broken, as it happens: even with `err` checked, the success branch called `cb(err)` and never passed `data` along, so a working read would still have reported "no cookie". The path dates to 2014.

## 3. Truncated cookie files

Reading past the end. `Buffer.toString` clamps, so that half silently produced empty fields — but the IPv4 branch indexes raw bytes and calls `.toString(10)` on `undefined`, which is `TypeError` from the same uncatchable place. Parsing now stops at the damage and uses the entries before it, saying so.

## The silence

Falling back to an unauthenticated connection **stays** — plenty of servers accept one, and turning that into a hard failure would break them. What changes is that it is no longer silent:

```
x11: no entry in /home/u/.Xauthority matches this connection, so it is being made without
  authentication - the server will refuse it unless it accepts unauthenticated clients.
  wanted: Local (256) address "myhost" display "0"
  file has:
    Local (256) address "oldhost" display "0" MIT-MAGIC-COOKIE-1
```

Never the key itself — that is the secret being looked up. A file that simply does not exist stays quiet, because nothing is misconfigured in that case; the warning fires only when a file *was* read and produced nothing.

## Also

`$XAUTHORITY` naming a missing file used to retry the identical path and then guess at the home directory. An explicit path is now the whole answer, so a typo in the variable shows up as a missing cookie rather than as a cookie from somewhere else.

## Known limitation, left alone

IPv6 entries still cannot match. `parseXauth` decodes only family 0 into a dotted string and leaves family 6's sixteen raw bytes as latin-1, which never equals the `remoteAddress` string it is compared against. Fixing it properly means comparing raw address bytes the way libXau does, rather than adding a second stringification to canonicalise against — worth its own change. The new warning at least makes it visible instead of silent.

## Test

`test/auth.js`, 15 tests, none needing an X server since all of this happens before the connection is made. 411 passing overall, lint clean.

Mutation-checked; the fourth caught a gap in my own test rather than in the fix:

| mutation | caught by |
| --- | --- |
| match on `cookie.family` again | 5 tests |
| drop the no-match diagnostic | the diagnosis test |
| restore the original Xming callback | the Xming test |
| drop the payload-length guard | **nothing at first** — the truncation test cut the file at a length prefix, which the other guard catches. Added a case that cuts inside an IPv4 address, where the raw-byte indexing actually throws, and it bites |
