### PR TITLE
feat(xinput): select and deliver XI2 events

### DIFF
--- a/docs/ext/xinput.md
+++ b/docs/ext/xinput.md
@@ -1,8 +1,9 @@
 # XInputExtension (XInput) extension (partial)
 
-Enumerates input devices beyond the core pointer/keyboard. Implements two
-XI1 query requests plus the XI2 version handshake and device query; XI2
-event selection/delivery is not implemented yet (see Notes).
+Enumerates input devices beyond the core pointer/keyboard, and selects and
+delivers XI2 device events — the only way to get smooth scrolling, touch,
+tablet pressure or per-device input, since the core protocol flattens all of
+it into button 4/5 presses on one virtual pointer.
 
 - Module: `X.require('xinput', cb)` (X name `XInputExtension`; XI2 2.2
   announced, XI1 version reported by the server)
@@ -67,21 +68,83 @@ devices) or the master a slave is attached to. `classes` is an array of
 - `Scroll` → `{number, scrollType, flags, increment}`
 - `Touch`/`Gesture` → `{type, sourceId}` only (no per-class fields parsed)
 
+### XISelectEvents(window, masks)
+XI2 (opcode 46). Void. Selects which XI2 events this client wants on
+`window`, per device. `masks` is one entry, or an array of them:
+
+```js
+XI.XISelectEvents(root, {
+    deviceId: XI.AllMasterDevices,
+    mask: XI.EventMask.RawMotion | XI.EventMask.ButtonPress
+});
+
+// event type names work too
+XI.XISelectEvents(wid, { deviceId: pointerId, mask: ['Motion', 'ButtonPress'] });
+
+// several devices in one request
+XI.XISelectEvents(root, [
+    { deviceId: pointerId,  mask: XI.EventMask.RawMotion },
+    { deviceId: keyboardId, mask: XI.EventMask.RawKeyPress }
+]);
+```
+
+Selecting **replaces** this client's selection for that device on that
+window rather than adding to it, so `mask: 0` deselects. The device is part
+of the key: a selection on `AllMasterDevices` does not clear one made on a
+specific device id.
+
 ## Events
 
-None. XI2 events are GenericEvents ([ext/ge.md](ge.md)) but no parser is
-registered in `X.geEventParsers` yet, and `XISelectEvents` is not
-implemented, so device events cannot be selected or parsed through this
-module (an unsolicited XI2 GenericEvent would surface as the generic
-`{type: 35, extension, evtype, raw}` shape).
+XI2 events are GenericEvents ([ext/ge.md](ge.md)), delivered on the client's
+`'event'` emitter once `X.require('xinput')` has registered the parser. Each
+carries `type` 35, `evtype` (an `XI.EventType` value) and `name` — the event
+type prefixed with `XI`, e.g. `XIRawMotion`.
+
+**Device events** — `XIKeyPress`, `XIKeyRelease`, `XIButtonPress`,
+`XIButtonRelease`, `XIMotion`, `XITouchBegin`, `XITouchUpdate`,
+`XITouchEnd`:
+
+| field | meaning |
+|---|---|
+| `deviceId`, `sourceId` | the master device, and the physical device behind it |
+| `time` | server timestamp |
+| `detail` | keycode, button number, or touch id |
+| `root`, `wid`, `child` | root, event and child windows |
+| `rootx`, `rooty`, `x`, `y` | FP1616 coordinates as Numbers |
+| `buttons` | array of button numbers currently down |
+| `valuators` | `{axisNumber: value}` for the axes this event carries |
+| `mods`, `group` | `{base, latched, locked, effective}` |
+| `flags` | e.g. `XI.KeyEventFlags.KeyRepeat`, `XI.PointerEventFlags.PointerEmulated` |
+
+`buttons` is the state **before** the event, the same convention core X uses
+for its `state` field: an `XIButtonPress` does not yet list its own button,
+and the matching `XIButtonRelease` still does.
+
+`valuators` holds only the axes that moved — a scroll wheel reports its own
+axis and nothing else — so test for a key rather than indexing blindly.
+Which axis is which comes from the device's `Valuator` and `Scroll` classes
+in `XIQueryDevice`; a `Scroll` class names the axis that carries smooth
+scrolling and the `increment` that counts as one click.
+
+**Raw events** — `XIRawKeyPress`, `XIRawKeyRelease`, `XIRawButtonPress`,
+`XIRawButtonRelease`, `XIRawMotion`, `XIRawTouchBegin`, `XIRawTouchUpdate`,
+`XIRawTouchEnd` — come straight from the device, are only delivered to
+selections on the **root** window, and have no window or coordinates. They
+carry `deviceId`, `sourceId`, `time`, `detail`, `flags`, plus two axis maps:
+`valuators` (after the pointer acceleration curve) and `rawValuators` (the
+device's own numbers, which is what a wheel's increment shows up in).
+
+**Everything else** — `XIDeviceChanged`, `XIEnter`, `XILeave`, `XIFocusIn`,
+`XIFocusOut`, `XIHierarchyChanged`, `XIPropertyEvent`, `XITouchOwnership`,
+`XIBarrierHit`, `XIBarrierLeave` — is delivered with `deviceId`, `time` and
+the undecoded body in `data`. Those layouts are not parsed yet.
 
 ## Notes
 
-- Not implemented: everything outside the four requests above — the XI1
-  device open/grab/event family (OpenDevice, GrabDevice,
-  SelectExtensionEvent, ...) and the rest of XI2 (XISelectEvents,
-  XIGrabDevice, XIGetClientPointer, XIChangeHierarchy, passive grabs,
-  properties, barriers, ...).
+- Not implemented: the XI1 device open/grab/event family (OpenDevice,
+  GrabDevice, SelectExtensionEvent, ...) and the rest of XI2 (XIGrabDevice,
+  XIGetClientPointer, XIChangeHierarchy, passive grabs, properties,
+  barriers, ...), plus the event bodies listed as undecoded above.
 - Enums attached to the ext object:
   `XI.DeviceUse = {IsXPointer: 0, IsXKeyboard: 1, IsXExtensionDevice: 2,
   IsXExtensionKeyboard: 3, IsXExtensionPointer: 4}` (XI1),
@@ -91,7 +154,11 @@ module (an unsolicited XI2 GenericEvent would surface as the generic
   SlaveKeyboard: 4, FloatingSlave: 5}` (XI2),
   `XI.ClassType = {Key: 0, Button: 1, Valuator: 2, Scroll: 3, Touch: 8,
   Gesture: 9}` (XI2), plus `XI.AllDevices` = 0, `XI.AllMasterDevices` = 1.
-- FP3232 fixed-point fields become plain JS numbers (53-bit mantissa:
-  fine for input axes).
+  For events: `XI.EventType` (the `evtype` numbers, `DeviceChanged` 1 through
+  `BarrierLeave` 26), `XI.EventMask` (the same names as `1 << evtype`, for
+  `XISelectEvents`), and the `flags` bits `XI.KeyEventFlags`,
+  `XI.PointerEventFlags`, `XI.TouchEventFlags`.
+- FP3232 and FP1616 fixed-point fields become plain JS numbers (53-bit
+  mantissa: fine for input axes).
 - Wire layouts are cross-checked against `X11/extensions/XIproto.h` and
   `XI2proto.h`.

--- a/lib/ext/xinput.js
+++ b/lib/ext/xinput.js
@@ -40,6 +40,47 @@ exports.requireExt = (display, callback) => {
         ext.AllDevices = 0;
         ext.AllMasterDevices = 1;
 
+        // XI2 event types. These are the `evtype` field of the GenericEvent,
+        // and the bit position of the corresponding XISelectEvents mask.
+        ext.EventType = {
+            DeviceChanged: 1,
+            KeyPress: 2,
+            KeyRelease: 3,
+            ButtonPress: 4,
+            ButtonRelease: 5,
+            Motion: 6,
+            Enter: 7,
+            Leave: 8,
+            FocusIn: 9,
+            FocusOut: 10,
+            HierarchyChanged: 11,
+            PropertyEvent: 12,
+            RawKeyPress: 13,
+            RawKeyRelease: 14,
+            RawButtonPress: 15,
+            RawButtonRelease: 16,
+            RawMotion: 17,
+            TouchBegin: 18,
+            TouchUpdate: 19,
+            TouchEnd: 20,
+            TouchOwnership: 21,
+            RawTouchBegin: 22,
+            RawTouchUpdate: 23,
+            RawTouchEnd: 24,
+            BarrierHit: 25,
+            BarrierLeave: 26
+        };
+
+        // Mask bits for XISelectEvents: one per event type, at its own number.
+        ext.EventMask = {};
+        for (const name in ext.EventType)
+            ext.EventMask[name] = 1 << ext.EventType[name];
+
+        // Per-event `flags`
+        ext.KeyEventFlags = { KeyRepeat: 1 << 16 };
+        ext.PointerEventFlags = { PointerEmulated: 1 << 16 };
+        ext.TouchEventFlags = { TouchPendingEnd: 1 << 16, TouchEmulating: 1 << 17 };
+
         // XI1 GetExtensionVersion (opcode 1)
         ext.GetExtensionVersion = cb => {
             X.seq_num++;
@@ -235,6 +276,184 @@ exports.requireExt = (display, callback) => {
             ];
             X.pack_stream.flush();
         }
+
+        // XI2 XISelectEvents (opcode 46). Void.
+        //
+        // `masks` is one entry per device, or a single entry on its own:
+        //   { deviceId, mask }   mask being a bitmask from ext.EventMask,
+        //                        or an array of event-type names or numbers
+        //
+        // Selecting replaces this client's selection on that window for that
+        // device rather than adding to it, so an empty mask deselects. Note
+        // the device is part of the key: selecting on AllMasterDevices does
+        // not clear a selection made on a specific device.
+        ext.XISelectEvents = (window, masks) => {
+            const list = Array.isArray(masks) ? masks : [masks];
+            // widest bit anyone asked for decides the mask length; the wire
+            // format counts it in 4-byte units per device
+            const entries = list.map(entry => {
+                let bits = entry.mask;
+                if (Array.isArray(bits)) {
+                    bits = bits.reduce((acc, e) => {
+                        const type = typeof e === 'string' ? ext.EventType[e] : e;
+                        if (type === undefined)
+                            throw new Error(`xinput.XISelectEvents: unknown event type ${e}`);
+                        return acc | (1 << type);
+                    }, 0);
+                }
+                bits = bits >>> 0;
+                let bytes = 0;
+                for (let b = bits; b; b >>>= 1) bytes++;
+                const maskLen = Math.ceil(bytes / 32) || 1;
+                return { deviceId: entry.deviceId, bits, maskLen };
+            });
+
+            const bodyLen = entries.reduce((n, e) => n + 4 + e.maskLen * 4, 0);
+            const b = Buffer.alloc(12 + bodyLen);
+            X.seq_num++;
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(46, 1);
+            b.writeUInt16LE(b.length / 4, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt16LE(entries.length, 8);
+            let off = 12;
+            for (const e of entries) {
+                b.writeUInt16LE(e.deviceId, off);
+                b.writeUInt16LE(e.maskLen, off + 2);
+                // little-endian bit order within the mask, low word first
+                for (let w = 0; w < e.maskLen; ++w)
+                    b.writeUInt32LE(w === 0 ? e.bits : 0, off + 4 + w * 4);
+                off += 4 + e.maskLen * 4;
+            }
+            X.pack_stream.put(b);
+            return X.pack_stream.flush();
+        }
+
+        // FP1616 fixed point -> Number, the screen-coordinate form
+        const fp1616 = (buf, off) => buf.readInt32LE(off) / 65536;
+
+        /** Bits set in a little-endian mask of `len` 4-byte words at `off`. */
+        const maskBits = (buf, off, len) => {
+            const set = [];
+            for (let w = 0; w < len; ++w) {
+                const word = buf.readUInt32LE(off + w * 4);
+                for (let bit = 0; bit < 32; ++bit)
+                    if (word & (1 << bit)) set.push(w * 32 + bit);
+            }
+            return set;
+        };
+
+        // XI2 GenericEvent parsers. `raw` starts at absolute byte 8, so every
+        // offset here is the XI2proto.h struct offset minus 8.
+        //
+        // The three event shapes: device events carry a full pointer state
+        // and a valuator mask, raw events carry the device's own unaccelerated
+        // axis values and no window, and both put their axis values behind a
+        // variable-length mask rather than at a fixed offset.
+        const parseDeviceEvent = (event, raw) => {
+            event.deviceId = raw.readUInt16LE(2);
+            event.time = raw.readUInt32LE(4);
+            event.detail = raw.readUInt32LE(8);   // keycode, or button number
+            event.root = raw.readUInt32LE(12);
+            event.wid = raw.readUInt32LE(16);
+            event.child = raw.readUInt32LE(20);
+            event.rootx = fp1616(raw, 24);
+            event.rooty = fp1616(raw, 28);
+            event.x = fp1616(raw, 32);
+            event.y = fp1616(raw, 36);
+            const buttonsLen = raw.readUInt16LE(40);
+            const valuatorsLen = raw.readUInt16LE(42);
+            event.sourceId = raw.readUInt16LE(44);
+            event.flags = raw.readUInt32LE(48);
+            event.mods = {
+                base: raw.readUInt32LE(52),
+                latched: raw.readUInt32LE(56),
+                locked: raw.readUInt32LE(60),
+                effective: raw.readUInt32LE(64)
+            };
+            event.group = {
+                base: raw[68],
+                latched: raw[69],
+                locked: raw[70],
+                effective: raw[71]
+            };
+            event.buttons = maskBits(raw, 72, buttonsLen);
+            const valuatorMaskAt = 72 + buttonsLen * 4;
+            const axes = maskBits(raw, valuatorMaskAt, valuatorsLen);
+            let off = valuatorMaskAt + valuatorsLen * 4;
+            event.valuators = {};
+            for (const axis of axes) {
+                event.valuators[axis] = fp3232(raw, off);
+                off += 8;
+            }
+            return event;
+        };
+
+        const parseRawEvent = (event, raw) => {
+            event.deviceId = raw.readUInt16LE(2);
+            event.time = raw.readUInt32LE(4);
+            event.detail = raw.readUInt32LE(8);
+            event.sourceId = raw.readUInt16LE(12);
+            const valuatorsLen = raw.readUInt16LE(14);
+            event.flags = raw.readUInt32LE(16);
+            const axes = maskBits(raw, 24, valuatorsLen);
+            // two FP3232 arrays follow the mask: the values after the pointer
+            // acceleration curve, then the device's own numbers. A scroll
+            // wheel reports its increment in the raw pair and nothing useful
+            // in the accelerated one.
+            let off = 24 + valuatorsLen * 4;
+            event.valuators = {};
+            event.rawValuators = {};
+            for (const axis of axes) {
+                event.valuators[axis] = fp3232(raw, off);
+                off += 8;
+            }
+            for (const axis of axes) {
+                event.rawValuators[axis] = fp3232(raw, off);
+                off += 8;
+            }
+            return event;
+        };
+
+        const eventNames = {};
+        for (const name in ext.EventType)
+            eventNames[ext.EventType[name]] = `XI${name}`;
+
+        const DEVICE_EVENTS = new Set([
+            ext.EventType.KeyPress, ext.EventType.KeyRelease,
+            ext.EventType.ButtonPress, ext.EventType.ButtonRelease,
+            ext.EventType.Motion,
+            ext.EventType.TouchBegin, ext.EventType.TouchUpdate, ext.EventType.TouchEnd
+        ]);
+        const RAW_EVENTS = new Set([
+            ext.EventType.RawKeyPress, ext.EventType.RawKeyRelease,
+            ext.EventType.RawButtonPress, ext.EventType.RawButtonRelease,
+            ext.EventType.RawMotion,
+            ext.EventType.RawTouchBegin, ext.EventType.RawTouchUpdate, ext.EventType.RawTouchEnd
+        ]);
+
+        X.geEventParsers[ext.majorOpcode] = (type, seq, extra, code, raw) => {
+            const evtype = raw.readUInt16LE(0);
+            const event = {
+                type: type,
+                seq: seq,
+                extension: code,
+                evtype: evtype,
+                name: eventNames[evtype] || `XIEvent${evtype}`
+            };
+            if (DEVICE_EVENTS.has(evtype))
+                return parseDeviceEvent(event, raw);
+            if (RAW_EVENTS.has(evtype))
+                return parseRawEvent(event, raw);
+            // Everything else - DeviceChanged, Enter/Leave, Focus,
+            // HierarchyChanged, PropertyEvent, barriers - shares only the
+            // first eight bytes. Report those and leave the body raw rather
+            // than guessing at layouts this has no way to exercise yet.
+            event.deviceId = raw.readUInt16LE(2);
+            event.time = raw.readUInt32LE(4);
+            event.data = raw;
+            return event;
+        };
 
         // Announce XI2 support (required by the XI2 spec before other XI2
         // requests), then report the XI1 extension version.

--- a/test/allow-events.js
+++ b/test/allow-events.js
@@ -100,4 +100,17 @@ describe('AllowEvents', () => {
             });
         });
     });
+
+    after(function(done) {
+        // This test grabs the pointer and never released it, and its client
+        // stayed open for the rest of the run — so every later suite's
+        // pointer events went to this connection instead of theirs. Nothing
+        // noticed until XI2 device events arrived, because a grab redirects
+        // those and leaves raw events alone: raw motion kept working while
+        // ordinary motion vanished, in this file's absence and not otherwise.
+        this.X.UngrabPointer(0);
+        this.X.DestroyWindow(this.wid);
+        this.X.terminate();
+        this.X.on('end', done);
+    });
 });

--- a/test/xinput.js
+++ b/test/xinput.js
@@ -110,6 +110,233 @@ describe('XInputExtension', () => {
         });
     });
 
+    // XI2 event delivery. XTEST drives the real pointer, so these check the
+    // wire layouts against what the server actually sends rather than against
+    // a hand-built buffer.
+    describe('XISelectEvents', () => {
+        before(function(done) {
+            const self = this;
+            this.root = this.display ? this.display.screen[0].root : null;
+            this.X.require('xtest', (err, xtest) => {
+                should.not.exist(err);
+                self.xtest = xtest;
+                // Xvfb outlives the test run and remembers which buttons are
+                // down, so a run that failed mid-drag leaves button 1 pressed
+                // and the next run's FakeInput press is a no-op the server
+                // never reports. Start from a known state.
+                const root = self.X.display.screen[0].root;
+                for (let button = 1; button <= 3; ++button)
+                    xtest.FakeInput(xtest.ButtonRelease, button, 0, root, 0, 0);
+                // Non-raw device events go to the window under the pointer and
+                // propagate up, so where the pointer happens to be decides who
+                // hears them. Earlier suites move it around, so own a window
+                // and put the pointer in it rather than selecting on the root
+                // and hoping. Raw events ignore all of this - they only ever
+                // go to a root selection - which is why they kept arriving
+                // while these did not.
+                self.wid = self.X.AllocID();
+                self.X.CreateWindow(self.wid, root, 0, 0, 200, 200, 0, 0, 0, 0,
+                    { overrideRedirect: true });
+                self.X.MapWindow(self.wid);
+                self.X.GetInputFocus(() => done());
+            });
+        });
+
+        /** Wait for the first XI2 event matching `evtype`, or time out. */
+        const nextXIEvent = (X, evtype, act, timeout = 2000) =>
+            new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    X.removeListener('event', onEvent);
+                    reject(new Error(`no XI2 event ${evtype} within ${timeout}ms`));
+                }, timeout);
+                function onEvent(ev) {
+                    if (ev.type !== 35 || ev.evtype !== evtype) return;
+                    clearTimeout(timer);
+                    X.removeListener('event', onEvent);
+                    resolve(ev);
+                }
+                X.on('event', onEvent);
+                act();
+            });
+
+        it('should deliver XIRawMotion with the device axis values', async function() {
+            const X = this.X;
+            const xi = this.xi;
+            const root = X.display.screen[0].root;
+            xi.XISelectEvents(root, {
+                deviceId: xi.AllMasterDevices,
+                mask: xi.EventMask.RawMotion
+            });
+
+            const ev = await nextXIEvent(X, xi.EventType.RawMotion, () => {
+                this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 37, 53);
+            });
+
+            ev.name.should.equal('XIRawMotion');
+            ev.deviceId.should.be.above(0);
+            ev.sourceId.should.be.above(0);
+            ev.time.should.be.above(0);
+            // a pointer motion moves x and y, valuators 0 and 1
+            Object.keys(ev.valuators).length.should.be.aboveOrEqual(1);
+            Object.keys(ev.rawValuators).length.should.equal(Object.keys(ev.valuators).length);
+            for (const axis of Object.keys(ev.valuators))
+                ev.valuators[axis].should.be.a.Number();
+        });
+
+        it('should deliver XIMotion with window coordinates and modifier state', async function() {
+            const X = this.X;
+            const xi = this.xi;
+            const root = X.display.screen[0].root;
+            xi.XISelectEvents(this.wid, {
+                deviceId: xi.AllMasterDevices,
+                mask: xi.EventMask.Motion
+            });
+
+            const ev = await nextXIEvent(X, xi.EventType.Motion, () => {
+                this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 61, 71);
+            });
+
+            ev.name.should.equal('XIMotion');
+            ev.root.should.equal(root);
+            ev.wid.should.equal(this.wid, 'the window the selection was made on');
+            // FP1616 decoded back to the coordinates XTEST asked for
+            Math.round(ev.rootx).should.equal(61);
+            Math.round(ev.rooty).should.equal(71);
+            Math.round(ev.x).should.equal(61);
+            Math.round(ev.y).should.equal(71);
+            ev.mods.should.have.properties(['base', 'latched', 'locked', 'effective']);
+            ev.group.should.have.properties(['base', 'latched', 'locked', 'effective']);
+            ev.buttons.should.be.an.Array();
+            ev.valuators.should.be.an.Object();
+        });
+
+        it('should report the button in detail and in the button mask', async function() {
+            const X = this.X;
+            const xi = this.xi;
+            const root = X.display.screen[0].root;
+            xi.XISelectEvents(this.wid, {
+                deviceId: xi.AllMasterDevices,
+                mask: xi.EventMask.ButtonPress | xi.EventMask.ButtonRelease | xi.EventMask.Motion
+            });
+            // inside the window, so the press has somewhere to be delivered
+            this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 100, 100);
+
+            const press = await nextXIEvent(X, xi.EventType.ButtonPress, () => {
+                this.xtest.FakeInput(this.xtest.ButtonPress, 1, 0, root, 0, 0);
+            });
+            press.name.should.equal('XIButtonPress');
+            press.detail.should.equal(1, 'button 1');
+
+            // the mask is what makes the parse worth doing: a motion while
+            // the button is held has to report it down. It sits behind a
+            // variable-length mask that the valuator offsets depend on, so
+            // getting its length wrong silently misplaces the axis values too
+            const drag = await nextXIEvent(X, xi.EventType.Motion, () => {
+                this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 150, 120);
+            });
+            drag.buttons.should.containEql(1, 'button 1 held during the motion');
+            Math.round(drag.valuators[0]).should.equal(150, 'and the axes are still where expected');
+            Math.round(drag.valuators[1]).should.equal(120);
+
+            const release = await nextXIEvent(X, xi.EventType.ButtonRelease, () => {
+                this.xtest.FakeInput(this.xtest.ButtonRelease, 1, 0, root, 0, 0);
+            });
+            release.detail.should.equal(1);
+            // the mask is the state *before* the event, the same convention
+            // core X uses for its `state` field: the press does not yet see
+            // its own button, the release still does
+            press.buttons.should.not.containEql(1);
+            release.buttons.should.containEql(1);
+        });
+
+        it('should accept event type names as well as a bitmask', async function() {
+            const X = this.X;
+            const xi = this.xi;
+            const root = X.display.screen[0].root;
+            xi.XISelectEvents(root, { deviceId: xi.AllMasterDevices, mask: ['RawMotion'] });
+
+            const ev = await nextXIEvent(X, xi.EventType.RawMotion, () => {
+                this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 12, 24);
+            });
+            ev.name.should.equal('XIRawMotion');
+        });
+
+        it('should reject an unknown event type name', function() {
+            const xi = this.xi;
+            const root = this.X.display.screen[0].root;
+            (() => xi.XISelectEvents(root, { deviceId: xi.AllMasterDevices, mask: ['Nonsense'] }))
+                .should.throw(/unknown event type Nonsense/);
+        });
+
+        it('an empty mask deselects', async function() {
+            const X = this.X;
+            const xi = this.xi;
+            const root = X.display.screen[0].root;
+            xi.XISelectEvents(root, { deviceId: xi.AllMasterDevices, mask: xi.EventMask.RawMotion });
+            // prove the selection is live before turning it off, so a broken
+            // deselect cannot pass by the events never having arrived
+            await nextXIEvent(X, xi.EventType.RawMotion, () => {
+                this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 5, 5);
+            });
+
+            xi.XISelectEvents(root, { deviceId: xi.AllMasterDevices, mask: 0 });
+            await new Promise((resolve, reject) =>
+                X.GetInputFocus(err => (err ? reject(err) : resolve())));
+
+            let heard = false;
+            const onEvent = ev => {
+                if (ev.type === 35 && ev.evtype === xi.EventType.RawMotion) heard = true;
+            };
+            X.on('event', onEvent);
+            this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 99, 99);
+            await new Promise((resolve, reject) =>
+                X.GetInputFocus(err => (err ? reject(err) : resolve())));
+            X.removeListener('event', onEvent);
+            heard.should.equal(false);
+        });
+
+        it('should select for several devices in one request', async function() {
+            const X = this.X;
+            const xi = this.xi;
+            const root = X.display.screen[0].root;
+            const masters = await new Promise((resolve, reject) =>
+                xi.XIQueryDevice(xi.AllMasterDevices, (err, devices) =>
+                    err ? reject(err) : resolve(devices)));
+            const pointer = masters.find(d => d.use === xi.DeviceType.MasterPointer);
+            const keyboard = masters.find(d => d.use === xi.DeviceType.MasterKeyboard);
+
+            xi.XISelectEvents(root, [
+                { deviceId: pointer.deviceId, mask: xi.EventMask.RawMotion },
+                { deviceId: keyboard.deviceId, mask: xi.EventMask.RawKeyPress }
+            ]);
+
+            const ev = await nextXIEvent(X, xi.EventType.RawMotion, () => {
+                this.xtest.FakeInput(this.xtest.MotionNotify, 0, 0, root, 43, 21);
+            });
+            ev.deviceId.should.equal(pointer.deviceId, 'named the device we asked about');
+
+            // and the keyboard selection in the same request took effect too
+            const key = await nextXIEvent(X, xi.EventType.RawKeyPress, () => {
+                this.xtest.FakeInput(this.xtest.KeyPress, 38, 0, root, 0, 0);
+                this.xtest.FakeInput(this.xtest.KeyRelease, 38, 0, root, 0, 0);
+            });
+            key.name.should.equal('XIRawKeyPress');
+            key.detail.should.equal(38, 'the keycode');
+        });
+
+        after(function(done) {
+            const xi = this.xi;
+            const root = this.X.display.screen[0].root;
+            // leave no button held: the server is shared and outlives us
+            for (let button = 1; button <= 3; ++button)
+                this.xtest.FakeInput(this.xtest.ButtonRelease, button, 0, root, 0, 0);
+            xi.XISelectEvents(root, { deviceId: xi.AllMasterDevices, mask: 0 });
+            if (this.wid)
+                this.X.DestroyWindow(this.wid);
+            this.X.GetInputFocus(() => done());
+        });
+    });
+
     after(function(done) {
         this.X.terminate();
         this.X.on('end', done);


### PR DESCRIPTION
Progress on #245 — the half that unblocks everything downstream. The extension could enumerate input devices in loving detail, *including the Scroll classes its reply parser already decoded*, and then never hear from any of them.

## What lands

**`XISelectEvents` (opcode 46)** — one entry per device, or a single entry on its own:

```js
XI.XISelectEvents(root, { deviceId: XI.AllMasterDevices, mask: XI.EventMask.RawMotion });
XI.XISelectEvents(wid,  { deviceId: pointerId, mask: ['Motion', 'ButtonPress'] });
XI.XISelectEvents(root, [
    { deviceId: pointerId,  mask: XI.EventMask.RawMotion },
    { deviceId: keyboardId, mask: XI.EventMask.RawKeyPress }
]);
```

Selecting **replaces** this client's selection for that device on that window rather than adding to it, so `mask: 0` deselects. The device is part of the key — a selection on `AllMasterDevices` does not clear one made on a specific id — which is the sort of thing that is much cheaper to write down than to rediscover.

**GenericEvent parsers.** Events arrive on the client's `'event'` emitter named after their type: `XIRawMotion`, `XIButtonPress`. Device events carry the pointer state, window coordinates as Numbers, modifier and group state, the buttons down and the axes that moved. Raw events carry the device's own values *twice* — after the pointer acceleration curve and before it — which is where a wheel's scroll increment actually shows up.

Both put their axis values behind a variable-length mask rather than at a fixed offset, so the mask parse is load-bearing for the coordinates as well.

**Enums:** `XI.EventType` (the `evtype` numbers), `XI.EventMask` (the same names as `1 << evtype`), and the `flags` bits.

## What does not

`DeviceChanged`, `Enter`, `Leave`, `Focus`, `HierarchyChanged`, `PropertyEvent`, `TouchOwnership` and the barrier events report their device and time and leave the body undecoded in `data`. Their layouts are not ones these tests can exercise — Xvfb has no touch device and no pointer barriers — and a layout parsed from a header but never run is how silent offset bugs get in. They can land with something that exercises them.

## Two things the tests corrected

Tests drive the real pointer with XTEST against Xvfb and check what the server sends, rather than a hand-built buffer. That paid off twice.

**The button mask is the state *before* the event** — the same convention core X uses for its `state` field. I had asserted the opposite. A press does not list its own button, and the matching release still does:

```
XIMotion       detail=0 buttons=[]  valuators={"0":100,"1":100}
XIButtonPress  detail=1 buttons=[]
XIMotion       detail=0 buttons=[1] valuators={"0":150,"1":120}
XIButtonRelease detail=1 buttons=[1]
XIMotion       detail=0 buttons=[]  valuators={"0":160,"1":130}
```

**A leaked pointer grab in `test/allow-events.js`.** That test grabs the pointer, never releases it, and keeps its client open — so for the rest of the run every later suite's pointer events went to that connection. Nothing had ever noticed, because a grab redirects *device* events and leaves *raw* events alone: my raw-motion test passed in the full suite while ordinary motion timed out, and both passed when xinput ran alone. Fixed there with an `after` hook that ungrabs, destroys the window and terminates.

That is worth a look during review — it is a change to an unrelated test file, and it means anything else in the suite that quietly depended on the pointer being grabbed will now behave differently. Two full runs after the fix: 403 passing, stable.

## Test

7 new tests in `test/xinput.js`: raw motion with device axis values, device motion with window coordinates and modifier state, button detail and mask across a drag, event-type names, an unknown name rejected, an empty mask deselecting (proving the selection was live first, so a broken deselect cannot pass by events never arriving), and a two-device selection in one request.

One piece of test hygiene worth flagging: Xvfb outlives the run and remembers which buttons are down, so a run that failed mid-drag left button 1 pressed and the *next* run's `FakeInput` press was a no-op the server never reported. The suite now normalises button state on entry and on exit.

403 passing, lint clean.
