### PR TITLE
feat: buffer the output stream, opt in with bufferRequests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,11 @@ browser bundle boots and renders), `check-share` (share links round-trip).
 ## Conventions
 
 - Request definitions in `corereqs.js` return a `Buffer` built with `writeUInt*` (plus optional reply unpacker) — study a neighbouring request before adding one.
-- Outbound I/O: `pack_stream.put(buf).flush()` via [`lib/framebuffer.js`](lib/framebuffer.js); length field must equal `buf.length / 4`.
+- Outbound I/O: `pack_stream.put(buf).submit(expectsReply)` via
+  [`lib/framebuffer.js`](lib/framebuffer.js); length field must equal
+  `buf.length / 4`. `submit()` marks the end of a request and lets the
+  buffering policy decide when to write; `flush()` writes immediately and is
+  for the handshake, `X.flush()` and connection teardown only.
 - Extensions self-register: `X.require('name', cb)` loads `lib/ext/name.js`.
 - Tests that talk to the server clean up after themselves (`X.terminate()`
   in `after`); leaked windows/clients make later files flaky.

--- a/ISSUES_SUMMARY.md
+++ b/ISSUES_SUMMARY.md
@@ -152,10 +152,12 @@ against the current client, `createClient({ bufferRequests: … })` alone takes
 a 2000-request ntk frame from 2003 writes to 1–2, because `_runFrame()` emits
 a frame in one synchronous run and ends with the frame fence's
 `GetInputFocus`, whose reply gate flushes exactly at the frame boundary. The
-`X.flush()` at `_present()` the issue proposes is redundant there and would
-split writes in a multi-window app. What is left for ntk: pass the option
-through and size `maxSize` to a frame (16 KB default = ~5 writes for a 72 KB
-frame, 256 KB = 1); `tcpNoDelay` already defaults to on with buffering.
+`X.flush()` at `_present()` the issue proposes is therefore redundant, and it
+would pin one write per window-frame — where `flushOnReply: false` plus the
+end-of-tick flush lets several windows' frames in one tick coalesce into a
+single write. What is left for ntk: pass the option through and size
+`maxSize` to a frame (16 KB default = ~5 writes for a 72 KB frame, 256 KB =
+1); `tcpNoDelay` already defaults to on with buffering.
 
 **Clipboard:** [#120](https://github.com/sidorares/ntk/issues/120) XFixes
 selection-changed events, [#119](https://github.com/sidorares/ntk/issues/119)

--- a/ISSUES_SUMMARY.md
+++ b/ISSUES_SUMMARY.md
@@ -13,7 +13,11 @@ than carried forward.
 
 ---
 
-# node-x11 — 9 open
+Since the audit, [#244](https://github.com/sidorares/node-x11/issues/244)
+(output buffering) has been implemented — opt-in `bufferRequests`, see
+"Buffering the output" in `docs/README.md`.
+
+# node-x11 — 8 open
 
 ## Worth doing next
 
@@ -58,18 +62,6 @@ the deprecated directory-main — fold it into any other PR. The real fix is
 converting `lib/` to ESM sources, which is a major, and the tempting shortcut
 does not work: a thin ESM wrapper over CJS still `require()`s builtins
 underneath, which is the exact failing construct.
-
-## Deferred by choice
-
-### [#244](https://github.com/sidorares/node-x11/issues/244) — Buffer the output stream (2026-07-31)
-
-Every request is `put()` + unconditional `flush()`, and `flush()` hands each
-buffer to `socket.write` individually — N requests, N syscalls, no writev, no
-cork. Nothing calls `setNoDelay`, so Nagle is on for TCP and small writes
-stall on the previous ACK. Xlib has had a 16 KB output buffer since 1987.
-
-Real and structural, but perf-only, and perf is deferred. Note it pairs with
-the flush/backpressure machinery #195 added, so the groundwork exists.
 
 ## Old, and closeable rather than workable
 
@@ -153,7 +145,17 @@ one-write-per-frame, [#124](https://github.com/sidorares/ntk/issues/124)
 maxLines/ellipsis, [#123](https://github.com/sidorares/ntk/issues/123)
 half-leading, [#122](https://github.com/sidorares/ntk/issues/122) downscale
 before upload. #124 and #123 are self-contained TextLayout work with obvious
-tests; #125 and #122 are perf, deferred.
+tests; #122 is perf, deferred.
+
+#125 has shrunk to a one-liner now that node-x11 buffers output: measured
+against the current client, `createClient({ bufferRequests: … })` alone takes
+a 2000-request ntk frame from 2003 writes to 1–2, because `_runFrame()` emits
+a frame in one synchronous run and ends with the frame fence's
+`GetInputFocus`, whose reply gate flushes exactly at the frame boundary. The
+`X.flush()` at `_present()` the issue proposes is redundant there and would
+split writes in a multi-window app. What is left for ntk: pass the option
+through and size `maxSize` to a frame (16 KB default = ~5 writes for a 72 KB
+frame, 256 KB = 1); `tcpNoDelay` already defaults to on with buffering.
 
 **Clipboard:** [#120](https://github.com/sidorares/ntk/issues/120) XFixes
 selection-changed events, [#119](https://github.com/sidorares/ntk/issues/119)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ x11.createClient((err, display) => {
 | `display` | display string, e.g. `':0'`, `'localhost:1.0'` or a literal socket path (default: `$DISPLAY`) |
 | `debug` | log outgoing requests and capture per-request stack traces for errors |
 | `disableBigRequests` | skip the automatic BIG-REQUESTS handshake done at connect time |
+| `bufferRequests` | batch outgoing requests into fewer socket writes: `true`, or `{ maxSize, maxDelay, flushOnReply, shouldFlush }` — see [Buffering the output](#buffering-the-output) |
+| `tcpNoDelay` | turn Nagle's algorithm off on a TCP connection (default: on when `bufferRequests` is set) |
 
 The client connects over a unix socket when the display refers to the local
 host (on macOS the display must be a literal socket path, XQuartz launchd
@@ -142,6 +144,73 @@ Sequence numbers are 16-bit on the wire but full-width on the client
 (`err.seq` keeps growing past 65535); the client transparently inserts a
 cheap round-trip request once per 60000 reply-less requests to keep the
 mapping unambiguous, the same way libxcb does.
+
+### Buffering the output
+
+By default every request is written to the socket as it is issued: one
+`write()` per request, and on a TCP connection one packet per request. A
+frame that draws a hundred small rectangles is a hundred sub-MTU writes.
+`bufferRequests` batches them instead:
+
+```js
+x11.createClient({ bufferRequests: true }, (err, display) => { /* ... */ });
+```
+
+Requests then accumulate in a 16 KB buffer — the size Xlib has used since
+X11R1 — and leave in one write. Buffering never costs a round trip of
+latency, because the batch is written as soon as any of these happens:
+
+- it reaches `maxSize` bytes (default `16384`);
+- its oldest request is `maxDelay` ms old (default `5`; `Infinity` disables
+  the gate, and the age is sampled every few requests rather than on each
+  one). This is what keeps a producer that holds the event loop for several
+  frames from starving the server;
+- a request that expects a reply is issued (`flushOnReply`, default `true`);
+- the event loop is about to wait for I/O — nothing is ever left sitting in
+  the buffer while the process is idle;
+- `X.flush()` is called, the connection is closed with `X.terminate()`, or
+  the process exits — including a hard `process.exit()`, which runs no
+  further timers.
+
+A toolkit that knows its own frame boundaries can take over the middle two
+gates with `shouldFlush`:
+
+```js
+const X = x11.createClient({
+    bufferRequests: {
+        maxSize: 64 * 1024,
+        shouldFlush: () => false   // never on my own; I flush per frame
+    }
+}, /* ... */);
+
+function frame() {
+    draw(X);
+    X.flush();
+}
+```
+
+`shouldFlush(info)` is called once per request with the pending batch's
+`bytes`, `packets`, `age` in ms, and whether this request `expectsReply`. It
+returns `true` to write now, `false` to keep buffering, or `undefined` to
+leave the decision to the gates above. The `maxSize` cap and the flush
+before the event loop polls always apply, so a `shouldFlush` that never says
+yes still cannot make the client sit on data.
+
+What actually happened is on `X.pack_stream.stats`: `packets` and `bytes`
+queued, `writes` issued to the socket, and `allocs` output buffers allocated
+(the buffer is reused, so this stays flat no matter how many requests are
+sent).
+
+On TCP the client also disables Nagle's algorithm by default when buffering
+— as libxcb does, because batched requests already leave in full segments
+and Nagle's interaction with delayed ACKs would only add latency. Pass
+`tcpNoDelay: false` to keep it on.
+
+A toolkit driving a frame clock usually needs nothing beyond switching this
+on: the requests of one frame are issued in a single synchronous run, so
+they are batched, and the round trip such toolkits already use to pace
+frames flushes them at exactly the frame boundary. Size `maxSize` to a
+frame's worth of bytes to make that one write rather than a handful.
 
 ## Listening for events
 

--- a/lib/ext/apple-wm.js
+++ b/lib/ext/apple-wm.js
@@ -38,7 +38,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.FrameRect = {
@@ -75,7 +75,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.FrameHitTest = (frame_class, px, py, ix, iy, iw, ih, ox, oy, ow, oh, cb) => {
@@ -103,7 +103,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
 
@@ -160,7 +160,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(title.length >>> 0, 32);
             X.pack_stream.put(b);
             X.pack_stream.put(titleBuf);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.NotifyMask = {
@@ -199,7 +199,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(mask >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.SetFrontProcess = () => {
@@ -209,7 +209,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(8, 1);
             b.writeUInt16LE(1, 2);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.WindowLevel = {
@@ -229,7 +229,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(window >>> 0, 4);
             b.writeUInt32LE(level >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.CanQuit = state => {
@@ -240,7 +240,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt8(state, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // shortcut is single-byte ASCII (optional, 0=no shortcut)
@@ -268,7 +268,7 @@ exports.requireExt = (display, callback) => {
                 b.writeUInt8(0, off++);
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.SetWindowMenuCheck = index => {
@@ -279,7 +279,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(index >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.DisableUpdate = screen => {
@@ -290,7 +290,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE((screen || 0) >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.ReenableUpdate = screen => {
@@ -301,7 +301,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE((screen || 0) >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // https://developer.apple.com
@@ -315,7 +315,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(hi >>> 0, 4);
             b.writeUInt32LE(lo >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.AttachTransient = (child, parent) => {
@@ -327,7 +327,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(child >>> 0, 4);
             b.writeUInt32LE(parent >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.events = {

--- a/lib/ext/big-requests.js
+++ b/lib/ext/big-requests.js
@@ -19,7 +19,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readUInt32LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
         callback(null, ext);
     });

--- a/lib/ext/composite.js
+++ b/lib/ext/composite.js
@@ -41,7 +41,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.RedirectWindow = (window, updateType) => {
@@ -53,7 +53,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(window >>> 0, 4);
             b.writeUInt8(updateType, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.RedirectSubwindows = (window, updateType) => {
@@ -65,7 +65,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(window >>> 0, 4);
             b.writeUInt8(updateType, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.UnredirectWindow = window => {
@@ -76,7 +76,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(window >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.UnredirectSubwindows = window => {
@@ -87,7 +87,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(window >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.CreateRegionFromBorderClip = (region, window) => {
@@ -99,7 +99,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(region >>> 0, 4);
             b.writeUInt32LE(window >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.NameWindowPixmap = (window, pixmap) => {
@@ -111,7 +111,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(window >>> 0, 4);
             b.writeUInt32LE(pixmap >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.GetOverlayWindow = (window, callback) => {
@@ -128,7 +128,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.ReleaseOverlayWindow = window => {
@@ -139,7 +139,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(window >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // currently version 0.4 TODO: bump up with coordinate translations

--- a/lib/ext/damage.js
+++ b/lib/ext/damage.js
@@ -32,7 +32,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.Create = (damage, drawable, reportlevel) => {
@@ -45,7 +45,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(drawable >>> 0, 8);
             b.writeUInt8(reportlevel, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.Destroy = damage => {
@@ -56,7 +56,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(damage >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.Subtract = (damage, repair, parts) => {
@@ -69,7 +69,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(repair >>> 0, 8);
             b.writeUInt32LE(parts >>> 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.Add = (damage, region) => {
@@ -81,7 +81,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(damage >>> 0, 4);
             b.writeUInt32LE(region >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.QueryVersion(1, 1, (err, vers) => {

--- a/lib/ext/dbe.js
+++ b/lib/ext/dbe.js
@@ -30,7 +30,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => [buf.readUInt8(0), buf.readUInt8(1)],
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // Associate `backBuffer` (a fresh XID) with the back buffer of `window`.
@@ -45,7 +45,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(backBuffer >>> 0, 8);
             b.writeUInt8(swapActionHint, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.DeallocateBackBufferName = backBuffer => {
@@ -56,7 +56,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(backBuffer >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // swapInfos: array of { window: WINDOW, swapAction: ext.SwapAction.* }
@@ -75,7 +75,7 @@ exports.requireExt = (display, callback) => {
                 off += 8;
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.BeginIdiom = () => {
@@ -85,7 +85,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(4, 1);
             b.writeUInt16LE(1, 2);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.EndIdiom = () => {
@@ -95,7 +95,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(5, 1);
             b.writeUInt16LE(1, 2);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // drawables: array of screen specifiers (any drawable per screen, e.g. root windows).
@@ -136,7 +136,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.GetBackBufferAttributes = (backBuffer, cb) => {
@@ -153,7 +153,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => ({ window: buf.readUInt32LE(0) }),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // The spec requires GetVersion to be issued before any other DBE request

--- a/lib/ext/dpms.js
+++ b/lib/ext/dpms.js
@@ -27,7 +27,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.Capable = callback => {
@@ -41,7 +41,7 @@ exports.requireExt = (display, callback) => {
                 buf => [dpmsReplies.Capable(buf).capable],
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.GetTimeouts = callback => {
@@ -58,7 +58,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.SetTimeouts = (standby_t, suspend_t, off_t) => {
@@ -71,7 +71,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(suspend_t, 6);
             b.writeUInt16LE(off_t, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.Enable = () => {
@@ -81,7 +81,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(4, 1);
             b.writeUInt16LE(1, 2);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.Disable = () => {
@@ -91,7 +91,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(5, 1);
             b.writeUInt16LE(1, 2);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.ForceLevel = // 0 : On, 1 : Standby, 2 : Suspend, 3 : Off
@@ -103,7 +103,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt16LE(level, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.Info = callback => {
@@ -120,7 +120,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         callback(null, ext);

--- a/lib/ext/fixes.js
+++ b/lib/ext/fixes.js
@@ -52,7 +52,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.SaveSetMode = { Insert: 0, Delete: 1 };
@@ -71,7 +71,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(map, 6);
             b.writeUInt32LE(window >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.SelectionEvent = {
@@ -97,7 +97,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(selection >>> 0, 8);
             b.writeUInt32LE(eventMask >>> 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.CursorNotify = { DisplayCursor: 0 };
@@ -113,7 +113,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(window >>> 0, 4);
             b.writeUInt32LE(eventMask >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         const parseCursorImageReply = buf => {
@@ -144,7 +144,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => parseCursorImageReply(buf),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.WindowRegionKind = {
@@ -162,7 +162,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(region >>> 0, 4);
             writeRectangles(b, 8, rects);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 6
@@ -175,7 +175,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(region >>> 0, 4);
             b.writeUInt32LE(bitmap >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 7
@@ -189,7 +189,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(wid >>> 0, 8);
             b.writeUInt8(kind, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 8
@@ -202,7 +202,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(region >>> 0, 4);
             b.writeUInt32LE(gc >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 9
@@ -215,7 +215,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(region >>> 0, 4);
             b.writeUInt32LE(picture >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 10
@@ -227,7 +227,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(region >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 11
@@ -240,7 +240,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(region >>> 0, 4);
             writeRectangles(b, 8, rects);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 12
@@ -253,7 +253,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(src >>> 0, 4);
             b.writeUInt32LE(dst >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 13
@@ -267,7 +267,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(src2 >>> 0, 8);
             b.writeUInt32LE(dst >>> 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 14
@@ -281,7 +281,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(src2 >>> 0, 8);
             b.writeUInt32LE(dst >>> 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 15
@@ -295,7 +295,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(src2 >>> 0, 8);
             b.writeUInt32LE(dst >>> 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 16; bounds is { x, y, width, height }
@@ -309,7 +309,7 @@ exports.requireExt = (display, callback) => {
             writeRectangles(b, 8, [bounds]);
             b.writeUInt32LE(dst >>> 0, 16);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 17
@@ -323,7 +323,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(dx, 8);
             b.writeInt16LE(dy, 10);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 18
@@ -336,7 +336,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(src >>> 0, 4);
             b.writeUInt32LE(dst >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 19
@@ -380,7 +380,7 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
 
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // opcode 20; region 0 = None (remove clip)
@@ -395,7 +395,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(xOrigin, 12);
             b.writeInt16LE(yOrigin, 14);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 21; kind from ext.WindowRegionKind (+ Input: 2 with SHAPE), region 0 = None
@@ -411,7 +411,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(yOffset, 14);
             b.writeUInt32LE(region >>> 0, 16);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 22; region 0 = None
@@ -426,7 +426,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(xOrigin, 12);
             b.writeInt16LE(yOrigin, 14);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 23
@@ -441,7 +441,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(nameBuf.length, 8);
             nameBuf.copy(b, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 24
@@ -463,7 +463,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // opcode 25
@@ -486,7 +486,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // opcode 26
@@ -499,7 +499,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(src >>> 0, 4);
             b.writeUInt32LE(dst >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 27
@@ -514,7 +514,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(nameBuf.length, 8);
             nameBuf.copy(b, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 28
@@ -531,7 +531,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(top, 16);
             b.writeUInt16LE(bottom, 18);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 29
@@ -543,7 +543,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(window >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 30
@@ -555,7 +555,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(window >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.BarrierDirections = {
@@ -585,7 +585,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(devices.length, 26);
             devices.forEach((dev, i) => b.writeUInt16LE(dev, 28 + i * 2));
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // opcode 32 (XFIXES 5.0)
@@ -597,7 +597,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(barrier >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.events = {

--- a/lib/ext/ge.js
+++ b/lib/ext/ge.js
@@ -32,7 +32,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // the spec requires clients to negotiate the version before use

--- a/lib/ext/glx.js
+++ b/lib/ext/glx.js
@@ -411,16 +411,16 @@ exports.requireExt = (display, callback) => {
             return b;
         }
 
-        function send(b) {
+        function send(b, expectsReply) {
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit(expectsReply);
         }
 
         // reply unpackers get the reply starting at byte 8 of the raw 32-byte
         // header: buf[0..24) = header bytes 8..32, variable data from buf[24]
         function sendWithReply(b, unpack, callback) {
             X.replies[X.seq_num] = [unpack, callback];
-            send(b);
+            send(b, true);
         }
 
         function writeAttribs(b, offset, attribs) {
@@ -453,7 +453,7 @@ exports.requireExt = (display, callback) => {
             else
                 for (let i = 0; i < data.length; ++i)
                     X.pack_stream.put(data[i]);
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         // opcode 2
@@ -469,7 +469,7 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.put(data);
             if (padLength)
                 X.pack_stream.put(Buffer.alloc(padLength));
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         // opcode 3
@@ -615,7 +615,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(contextTag >>> 0, 8);
             X.pack_stream.put(b);
             X.pack_stream.put(data);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         // opcode 17; callback gets {retval, size, data} where data is the
@@ -635,7 +635,7 @@ exports.requireExt = (display, callback) => {
             ];
             X.pack_stream.put(b);
             X.pack_stream.put(data);
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         // opcode 18

--- a/lib/ext/present.js
+++ b/lib/ext/present.js
@@ -77,7 +77,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // PresentPixmap: copy `pixmap` to `window` at the target msc.
@@ -116,7 +116,7 @@ exports.requireExt = (display, callback) => {
                 off += 8;
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // Request a CompleteNotify(kind=NotifyMSC) event when the msc reaches
@@ -134,7 +134,7 @@ exports.requireExt = (display, callback) => {
             writeUInt64LE(b, divisor || 0, 24);
             writeUInt64LE(b, remainder || 0, 32);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // eid is a fresh XID (X.AllocID()) naming the event context;
@@ -150,7 +150,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(window >>> 0, 8);
             b.writeUInt32LE((eventMask || 0) >>> 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // target is a window (or RandR crtc); returns an ext.Capability mask
@@ -166,7 +166,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readUInt32LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // GenericEvent parsers; raw is the event from byte 8 on, so absolute

--- a/lib/ext/randr.js
+++ b/lib/ext/randr.js
@@ -90,7 +90,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.events = {
@@ -186,7 +186,7 @@ exports.requireExt = (display, callback) => {
                 }
             ];
 
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.SelectInput = (win, mask) => {
@@ -198,7 +198,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(win >>> 0, 4);
             b.writeUInt16LE(mask, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         ext.GetScreenInfo = (win, cb) => {
@@ -258,7 +258,7 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
 
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.GetScreenResources = (win, cb) => {
@@ -274,7 +274,7 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
 
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
         ext.GetScreenResourcesCurrent = (win, cb) => {
             X.seq_num ++;
@@ -289,7 +289,7 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
 
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
         ext.GetOutputInfo = (output, ts, cb) => {
             X.seq_num ++;
@@ -346,7 +346,7 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
 
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
         ext.GetCrtcInfo = (crtc, configTs, cb) => {
             X.seq_num ++;
@@ -397,7 +397,7 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
 
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.GetScreenSizeRange = (win, cb) => {
@@ -419,7 +419,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         // width/height in pixels, mmWidth/mmHeight in millimeters
@@ -435,7 +435,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(mmWidth >>> 0, 12);
             b.writeUInt32LE(mmHeight >>> 0, 16);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         ext.ListOutputProperties = (output, cb) => {
@@ -456,7 +456,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.QueryOutputProperty = (output, property, cb) => {
@@ -483,7 +483,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         // values: array of INT32 (min/max pair when range, else list of valid values)
@@ -501,7 +501,7 @@ exports.requireExt = (display, callback) => {
                 b.writeInt32LE(v, 16 + i * 4);
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         // mode: 0 replace, 1 prepend, 2 append; format: 8/16/32
@@ -538,7 +538,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE((payload.length / (format >> 3)) >>> 0, 20);
             payload.copy(b, 24);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         ext.DeleteOutputProperty = (output, property) => {
@@ -550,7 +550,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(output >>> 0, 4);
             b.writeUInt32LE(property >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         // longOffset/longLength in 4-byte units (as in core GetProperty)
@@ -582,7 +582,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         // modeInfo: { width, height, dot_clock, h_sync_start, h_sync_end, h_total, h_skew,
@@ -615,7 +615,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readUInt32LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.DestroyMode = (mode) => {
@@ -626,7 +626,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(mode >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         ext.AddOutputMode = (output, mode) => {
@@ -638,7 +638,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(output >>> 0, 4);
             b.writeUInt32LE(mode >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         ext.DeleteOutputMode = (output, mode) => {
@@ -650,7 +650,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(output >>> 0, 4);
             b.writeUInt32LE(mode >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         // status is ext.ConfigStatus; mode 0 disables the crtc (outputs must be [])
@@ -680,7 +680,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.GetCrtcGammaSize = (crtc, cb) => {
@@ -695,7 +695,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readUInt16LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.GetCrtcGamma = (crtc, cb) => {
@@ -719,7 +719,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         // red/green/blue: equal-length arrays of CARD16 (length == GetCrtcGammaSize)
@@ -739,7 +739,7 @@ exports.requireExt = (display, callback) => {
                 b.writeUInt16LE(blue[i], 12 + (2 * size + i) * 2);
             }
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         // transform: array of 9 floats (3x3 row-major matrix, converted to 16.16 FIXED —
@@ -762,7 +762,7 @@ exports.requireExt = (display, callback) => {
                 b.writeInt32LE(Math.round(v * 65536), 48 + padded + i * 4);
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         ext.GetCrtcTransform = (crtc, cb) => {
@@ -800,7 +800,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         ext.GetPanning = (crtc, cb) => {
@@ -832,7 +832,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         // panning: object with the same fields GetPanning returns (left, top, width, height,
@@ -867,7 +867,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         // output = 0 (None) clears the primary output
@@ -880,7 +880,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(win >>> 0, 4);
             b.writeUInt32LE(output >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         },
 
         ext.GetOutputPrimary = (win, cb) => {
@@ -895,7 +895,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readUInt32LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         },
 
         X.eventParsers[ext.firstEvent + ext.events.RRScreenChangeNotify] = (type, seq, extra, code, raw) => {

--- a/lib/ext/record.js
+++ b/lib/ext/record.js
@@ -125,7 +125,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => [buf.readUInt16LE(0), buf.readUInt16LE(2)],
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         // shared body for CreateContext (opcode 1) and RegisterClients (opcode 2)
@@ -152,7 +152,7 @@ exports.requireExt = (display, callback) => {
                 off += RANGE_SIZE;
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.CreateContext = (context, elementHeader, clientSpecs, ranges) => {
@@ -181,7 +181,7 @@ exports.requireExt = (display, callback) => {
                 off += 4;
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.GetContext = (context, cb) => {
@@ -218,7 +218,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         // EnableContext is a multi-reply request. RECORD keeps sending replies on
@@ -259,7 +259,7 @@ exports.requireExt = (display, callback) => {
                 cb,
                 true // multi-reply
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.DisableContext = context => {
@@ -270,7 +270,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(context >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.FreeContext = context => {
@@ -281,7 +281,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(context >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         // BadContext error (number 0): carries the invalid record context id

--- a/lib/ext/render.js
+++ b/lib/ext/render.js
@@ -27,7 +27,7 @@ exports.requireExt = (display, callback) => {
         },
         callback
       ];
-      X.pack_stream.flush();
+      X.pack_stream.submit(true);
     };
 
     ext.QueryPictFormat = callback => {
@@ -70,7 +70,7 @@ exports.requireExt = (display, callback) => {
         },
         callback
       ];
-      X.pack_stream.flush();
+      X.pack_stream.submit(true);
     };
 
     // protocol-name alias (spec: QueryPictFormats)
@@ -106,7 +106,7 @@ exports.requireExt = (display, callback) => {
         },
         callback
       ];
-      X.pack_stream.flush();
+      X.pack_stream.submit(true);
     };
 
     // only valid for indexed pictformats; on TrueColor-only servers
@@ -138,7 +138,7 @@ exports.requireExt = (display, callback) => {
         },
         callback
       ];
-      X.pack_stream.flush();
+      X.pack_stream.submit(true);
     };
 
     const valueList = [
@@ -203,7 +203,7 @@ exports.requireExt = (display, callback) => {
       for (let i = 0; i < selected.length; ++i)
         off = writeValueField(b, off, selected[i].fmt, selected[i].val);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -229,7 +229,7 @@ exports.requireExt = (display, callback) => {
       for (let i = 0; i < selected.length; ++i)
         off = writeValueField(b, off, selected[i].fmt, selected[i].val);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -252,7 +252,7 @@ exports.requireExt = (display, callback) => {
         off += 8;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -263,7 +263,7 @@ exports.requireExt = (display, callback) => {
       b.writeUInt16LE(2, 2);
       b.writeUInt32LE(pid >>> 0, 4);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -318,7 +318,7 @@ exports.requireExt = (display, callback) => {
         off += 4;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -377,7 +377,7 @@ exports.requireExt = (display, callback) => {
           params.writeInt32LE(fixedParams[i], i * 4);
         X.pack_stream.put(params);
       }
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -392,7 +392,7 @@ exports.requireExt = (display, callback) => {
       buf.writeUInt16LE(colorToFix(b), 12);
       buf.writeUInt16LE(colorToFix(a), 14);
       X.pack_stream.put(buf);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -420,7 +420,7 @@ exports.requireExt = (display, callback) => {
         }
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     }
 
@@ -479,7 +479,7 @@ exports.requireExt = (display, callback) => {
         off += 8;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -501,7 +501,7 @@ exports.requireExt = (display, callback) => {
       b.writeUInt16LE(width, 32);
       b.writeUInt16LE(height, 34);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -526,7 +526,7 @@ exports.requireExt = (display, callback) => {
         off += 4;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -545,7 +545,7 @@ exports.requireExt = (display, callback) => {
         off += 4;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -572,7 +572,7 @@ exports.requireExt = (display, callback) => {
         off += 24;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -595,7 +595,7 @@ exports.requireExt = (display, callback) => {
         off += 4;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     }
 
@@ -611,7 +611,7 @@ exports.requireExt = (display, callback) => {
       b.writeUInt32LE(gsid >>> 0, 4);
       b.writeUInt32LE(format >>> 0, 8);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -623,7 +623,7 @@ exports.requireExt = (display, callback) => {
       b.writeUInt32LE(gsid >>> 0, 4);
       b.writeUInt32LE(existing >>> 0, 8);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -634,7 +634,7 @@ exports.requireExt = (display, callback) => {
       b.writeUInt16LE(2, 2);
       b.writeUInt32LE(gsid >>> 0, 4);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -648,7 +648,7 @@ exports.requireExt = (display, callback) => {
       for (let i = 0; i < glyphIds.length; ++i)
         b.writeUInt32LE(glyphIds[i] >>> 0, 8 + i * 4);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -706,7 +706,7 @@ exports.requireExt = (display, callback) => {
 
       for (let i = 0; i < numGlyphs; i++)
         X.pack_stream.put(glyphs[i].image);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -741,7 +741,7 @@ exports.requireExt = (display, callback) => {
         metrics.writeInt16LE(glyphs[i].srcY, off + 14);
       }
       X.pack_stream.put(metrics);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -944,7 +944,7 @@ exports.requireExt = (display, callback) => {
           }
         }
       }
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -965,7 +965,7 @@ exports.requireExt = (display, callback) => {
       b.writeUInt16LE(x, 12);
       b.writeUInt16LE(y, 14);
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 
@@ -987,7 +987,7 @@ exports.requireExt = (display, callback) => {
         off += 8;
       }
       X.pack_stream.put(b);
-      X.pack_stream.flush();
+      X.pack_stream.submit();
       X.seq_num++;
     };
 

--- a/lib/ext/res.js
+++ b/lib/ext/res.js
@@ -29,7 +29,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => [buf.readUInt16LE(0), buf.readUInt16LE(2)],
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // Lists all connected clients as { resourceBase, resourceMask } XID ranges
@@ -55,7 +55,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // xid: any XID in the client's resource range. Returns a list of
@@ -83,7 +83,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // Estimated pixmap memory usage of the client owning `xid`, in bytes.
@@ -101,7 +101,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readUInt32LE(4) * 0x100000000 + buf.readUInt32LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // Since 1.2. specs: array of { client: XID or 0 (all clients),
@@ -144,7 +144,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         const parseResourceSizeSpec = (buf, off) => ({
@@ -194,7 +194,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.QueryVersion(1, 2, (err, vers) => {

--- a/lib/ext/screen-saver.js
+++ b/lib/ext/screen-saver.js
@@ -27,7 +27,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.State = {
@@ -64,7 +64,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.eventMask = {
@@ -81,7 +81,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(drawable >>> 0, 4);
             b.writeUInt32LE(eventMask >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // Window attribute value-mask bits (same set as core CreateWindow /
@@ -136,7 +136,7 @@ exports.requireExt = (display, callback) => {
             for (let i = 0; i < list.length; ++i)
                 b.writeUInt32LE(list[i] >>> 0, 28 + i * 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.UnsetAttributes = drawable => {
@@ -147,7 +147,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(drawable >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // suspend is a bool; suspensions of one client are counted by the
@@ -160,7 +160,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(suspend ? 1 : 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.QueryVersion(1, 1, (err, vers) => {

--- a/lib/ext/shape.js
+++ b/lib/ext/shape.js
@@ -53,7 +53,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // Accepts rectangles as [[x, y, width, height]]
@@ -84,7 +84,7 @@ exports.requireExt = (display, callback) => {
             X.seq_num++;
 //            captureStack();
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.Mask = (op, kind, window, x, y, bitmap) => {
@@ -101,7 +101,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(y, 14);
             b.writeUInt32LE(bitmap >>> 0, 16);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.Combine = (op, destKind, srcKind, destWindow, x, y, srcWindow) => {
@@ -119,7 +119,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(y, 14);
             b.writeUInt32LE(srcWindow >>> 0, 16);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.Offset = (kind, window, x, y) => {
@@ -134,7 +134,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(x, 12);
             b.writeInt16LE(y, 14);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.QueryExtents = (window, cb) => {
@@ -167,7 +167,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // Returns { ordering, rectangles: [[x, y, width, height]] }
@@ -199,7 +199,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.SelectInput = (window, enable) => {
@@ -212,7 +212,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(window >>> 0, 4);
             b.writeUInt8(enable, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.InputSelected = (window, cb) => {
@@ -228,7 +228,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => opt,
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.events = {

--- a/lib/ext/shm.js
+++ b/lib/ext/shm.js
@@ -45,7 +45,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // shmseg: client-allocated XID (X.AllocID()), shmid: SysV segment id
@@ -59,7 +59,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(shmid >>> 0, 8);
             b.writeUInt8(readOnly ? 1 : 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.Detach = shmseg => {
@@ -70,7 +70,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(shmseg >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // img: { totalWidth, totalHeight, srcX, srcY, srcWidth, srcHeight,
@@ -99,7 +99,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(img.shmseg >>> 0, 32);
             b.writeUInt32LE(img.offset >>> 0, 36);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // The image data is written into the shared segment at `offset`;
@@ -130,7 +130,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // pid: client-allocated pixmap XID backed by the shared segment
@@ -148,7 +148,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(shmseg >>> 0, 20);
             b.writeUInt32LE(offset >>> 0, 24);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // AttachFd (minor opcode 6): intentionally not implemented, see note

--- a/lib/ext/sync.js
+++ b/lib/ext/sync.js
@@ -78,7 +78,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.ListSystemCounters = cb => {
@@ -106,7 +106,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.CreateCounter = (id, initialValue) => {
@@ -118,7 +118,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(id >>> 0, 4);
             writeInt64(b, initialValue, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.SetCounter = (counter, value) => {
@@ -130,7 +130,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(counter >>> 0, 4);
             writeInt64(b, value, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.ChangeCounter = (counter, amount) => {
@@ -142,7 +142,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(counter >>> 0, 4);
             writeInt64(b, amount, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.QueryCounter = (counter, cb) => {
@@ -159,7 +159,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.DestroyCounter = counter => {
@@ -170,7 +170,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(counter >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         // waitList: array of { counter, valueType, value, testType, eventThreshold }
@@ -192,7 +192,7 @@ exports.requireExt = (display, callback) => {
                 off += 28;
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         const packAlarmRequest = (minorOpcode, id, values) => {
@@ -224,7 +224,7 @@ exports.requireExt = (display, callback) => {
                 }
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         // values: { counter, valueType, value, testType, delta, events }
@@ -263,7 +263,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         ext.DestroyAlarm = alarm => {
@@ -274,7 +274,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(alarm >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         // id: client resource XID, or 0 for the requesting client
@@ -287,7 +287,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(id >>> 0, 4);
             b.writeInt32LE(priority, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.GetPriority = (id, cb) => {
@@ -304,7 +304,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         // Fence requests (SYNC 3.1)
@@ -319,7 +319,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(fence >>> 0, 8);
             b.writeUInt8(initiallyTriggered ? 1 : 0, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         const simpleFenceRequest = minorOpcode => fence => {
@@ -330,7 +330,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt32LE(fence >>> 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.TriggerFence = simpleFenceRequest(15);
@@ -351,7 +351,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         };
 
         // Blocks (server side) further request processing for this client until
@@ -366,7 +366,7 @@ exports.requireExt = (display, callback) => {
                 b.writeUInt32LE(fence >>> 0, 4 + i * 4);
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         };
 
         ext.events = {

--- a/lib/ext/xc-misc.js
+++ b/lib/ext/xc-misc.js
@@ -27,7 +27,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
         ext.QueryVersion = ext.GetVersion;
 
@@ -47,7 +47,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.GetXIDList = (count, cb) => {
@@ -68,7 +68,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.GetVersion(1, 1, (err, vers) => {

--- a/lib/ext/xinerama.js
+++ b/lib/ext/xinerama.js
@@ -24,7 +24,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.GetState = (window, cb) => {
@@ -39,7 +39,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => opt,
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.GetScreenCount = (window, cb) => {
@@ -54,7 +54,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => opt,
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.GetScreenSize = (window, screen, cb) => {
@@ -75,7 +75,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.IsActive = cb => {
@@ -89,7 +89,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readUInt32LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.QueryScreens = cb => {
@@ -116,7 +116,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.QueryVersion(1, 1, (err, vers) => {

--- a/lib/ext/xinput.js
+++ b/lib/ext/xinput.js
@@ -102,7 +102,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // XI1 ListInputDevices (opcode 2)
@@ -169,7 +169,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // XI2 XIQueryVersion (opcode 47). Announces the client's supported
@@ -192,7 +192,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // FP3232 fixed point -> Number (53-bit mantissa: fine for input axes)
@@ -274,7 +274,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // XI2 XISelectEvents (opcode 46). Void.
@@ -326,7 +326,7 @@ exports.requireExt = (display, callback) => {
                 off += 4 + e.maskLen * 4;
             }
             X.pack_stream.put(b);
-            return X.pack_stream.flush();
+            return X.pack_stream.submit();
         }
 
         // FP1616 fixed point -> Number, the screen-coordinate form

--- a/lib/ext/xkb.js
+++ b/lib/ext/xkb.js
@@ -80,7 +80,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // Per-event detail payloads of SelectEvents, in wire (= bit) order.
@@ -143,7 +143,7 @@ exports.requireExt = (display, callback) => {
                 }
             });
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // Bell. name/window may be 0 (None).
@@ -164,7 +164,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(name >>> 0, 20);
             b.writeUInt32LE(window >>> 0, 24);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.GetState = (deviceSpec, cb) => {
@@ -197,7 +197,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.LatchLockState = (deviceSpec, affectModLocks, modLocks, lockGroup, groupLock, affectModLatches, modLatches, latchGroup, groupLatch) => {
@@ -216,7 +216,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(latchGroup ? 1 : 0, 13);
             b.writeInt16LE(groupLatch, 14);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.GetControls = (deviceSpec, cb) => {
@@ -264,7 +264,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         const popcount = v => {
@@ -368,7 +368,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // XKB multiplexes all its events on one event code; byte 1 of the

--- a/lib/ext/xtest.js
+++ b/lib/ext/xtest.js
@@ -26,7 +26,7 @@ exports.requireExt = (display, callback) => {
                 },
                 callback
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.Cursor = {
@@ -50,7 +50,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => !!opt, // "same" is in byte 1 of the reply header
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.KeyPress = 2;
@@ -75,7 +75,7 @@ exports.requireExt = (display, callback) => {
             b.writeInt16LE(x, 24);
             b.writeInt16LE(y, 26);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         // impervious=true makes this client immune to server grabs by other
@@ -88,7 +88,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt16LE(2, 2);
             b.writeUInt8(impervious ? 1 : 0, 4);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         callback(null, ext);

--- a/lib/ext/xv.js
+++ b/lib/ext/xv.js
@@ -61,7 +61,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.QueryAdaptors = (window, cb) => {
@@ -102,7 +102,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.QueryEncodings = (port, cb) => {
@@ -138,7 +138,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         // time: 0 = CurrentTime; reply is an ext.GrabPortStatus value
@@ -155,7 +155,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => opt,
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.UngrabPort = (port, time) => {
@@ -167,7 +167,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(port >>> 0, 4);
             b.writeUInt32LE(time >>> 0, 8);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.QueryBestSize = (port, vidW, vidH, drwW, drwH, motion, cb) => {
@@ -192,7 +192,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.SetPortAttribute = (port, attribute, value) => {
@@ -205,7 +205,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(attribute >>> 0, 8);
             b.writeInt32LE(value, 12);
             X.pack_stream.put(b);
-            X.pack_stream.flush();
+            X.pack_stream.submit();
         }
 
         ext.GetPortAttribute = (port, attribute, cb) => {
@@ -221,7 +221,7 @@ exports.requireExt = (display, callback) => {
                 (buf, opt) => buf.readInt32LE(0),
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.QueryPortAttributes = (port, cb) => {
@@ -253,7 +253,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.ListImageFormats = (port, cb) => {
@@ -301,7 +301,7 @@ exports.requireExt = (display, callback) => {
                 },
                 cb
             ];
-            X.pack_stream.flush();
+            X.pack_stream.submit(true);
         }
 
         ext.events = {

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -4,15 +4,63 @@ const { EventEmitter } = require('events');
 
 const EMPTY = Buffer.alloc(0);
 
+// Xlib has buffered its output in a 16 KB buffer since X11R1, and the size
+// still fits: big enough for a frame's worth of small requests, small enough
+// that a full batch goes out in one socket send.
+const DEFAULT_MAX_SIZE = 16384;
+// How long a request may sit in the buffer while more are being queued. A
+// frame's requests are issued in one synchronous run, so this only bites when
+// a producer holds the event loop for longer than that — and then it lets the
+// server start working on the first requests instead of waiting for the last.
+const DEFAULT_MAX_DELAY = 5;
+// Output buffers kept for reuse. One is enough while writes complete inside
+// the tick that issued them; the rest cover bursts that flush several times.
+const POOL_MAX = 4;
+// Reading the clock costs more per request than the age gate saves, so sample
+// it every few packets. Nothing is lost: the age only decides anything while
+// a producer keeps issuing requests, and a batch that stops growing is
+// written when the event loop comes round anyway. Sub-millisecond maxDelay
+// settings check every packet (mask 0).
+const AGE_SAMPLE_MASK = 7;
+
+// performance.now() is monotonic (Date.now() can step with the system clock)
+// and is present in Node and in browsers.
+const monotonic = (typeof performance === 'object' && performance !== null &&
+                   typeof performance.now === 'function')
+    ? () => performance.now()
+    : () => Date.now();
+
+// The backstop that keeps buffering off the latency path: whatever the policy
+// says, nothing is left in the buffer when the event loop goes to poll for
+// I/O. In Node that is setImmediate (runs after the current phase, before the
+// next poll); in a browser, as soon as the current stack unwinds.
+const scheduleFlush = typeof setImmediate === 'function'
+    ? setImmediate
+    : fn => queueMicrotask(fn);
+
+function positive(value, name) {
+    if (typeof value !== 'number' || !(value > 0))
+        throw new TypeError(`${name} must be a positive number`);
+    return value;
+}
+
 /**
  * Bidirectional X11 framing buffer.
  * - Inbound: accumulate socket chunks; satisfy exact-length get(n, cb) reads.
- * - Outbound: put(Buffer) queues packets; flush() writes with drain/backpressure.
+ * - Outbound: put(Buffer) queues a packet, submit() hands the queue to the
+ *   socket — immediately, or batched with the packets around it when the
+ *   client was created with output buffering. flush() always writes now;
  *   flush(cb) additionally invokes cb once everything queued before the call
  *   has been handed to the OS. 'drain' is emitted when a backpressured socket
  *   catches up and the queue is empty again.
+ *
+ * The buffering policy (see `bufferRequests` in docs/README.md) is:
+ * batch until the batch reaches `maxSize`, until its oldest packet is
+ * `maxDelay` ms old, until a request that expects a reply is sent, or until
+ * the event loop is about to poll — whichever comes first. `shouldFlush`
+ * overrides the middle two.
  */
-function FrameBuffer() {
+function FrameBuffer(options) {
     EventEmitter.call(this);
     this._chunks = [];
     this._length = 0;
@@ -21,6 +69,48 @@ function FrameBuffer() {
     this.write_queue = []; // Buffers, and flush-callback sentinels between them
     this._socket = null;
     this._draining = false;
+    // a transport with no writableLength is not a Node stream: it consumes
+    // (or copies) what it is given before write() returns
+    this._syncTransport = true;
+
+    const policy = options === true ? {} : options;
+    this._batching = !!policy;
+    this._maxSize = DEFAULT_MAX_SIZE;
+    this._maxDelay = DEFAULT_MAX_DELAY;
+    this._flushOnReply = true;
+    this._shouldFlush = null;
+    if (policy && typeof policy === 'object') {
+        if (policy.maxSize !== undefined)
+            this._maxSize = positive(policy.maxSize, 'bufferRequests.maxSize');
+        if (policy.maxDelay !== undefined) {
+            if (typeof policy.maxDelay !== 'number' || policy.maxDelay < 0)
+                throw new TypeError('bufferRequests.maxDelay must be a number of milliseconds');
+            this._maxDelay = policy.maxDelay;
+        }
+        if (policy.flushOnReply !== undefined)
+            this._flushOnReply = !!policy.flushOnReply;
+        if (policy.shouldFlush !== undefined) {
+            if (typeof policy.shouldFlush !== 'function')
+                throw new TypeError('bufferRequests.shouldFlush must be a function');
+            this._shouldFlush = policy.shouldFlush;
+        }
+    }
+    this._ageMask = this._maxDelay >= 1 ? AGE_SAMPLE_MASK : 0;
+
+    // the batch being filled: one reused buffer, never reallocated per packet
+    this._out = null;
+    this._used = 0;
+    this._packets = 0;
+    this._started = 0;
+    this._pool = [];
+    this._flushScheduled = false;
+
+    this.stats = {
+        packets: 0, // put() calls
+        bytes: 0,   // bytes queued
+        writes: 0,  // socket writes carrying data
+        allocs: 0   // output buffers allocated
+    };
 }
 
 Object.setPrototypeOf(FrameBuffer.prototype, EventEmitter.prototype);
@@ -38,6 +128,7 @@ FrameBuffer.prototype.write = function(buf) {
  */
 FrameBuffer.prototype.attach = function(socket) {
     this._socket = socket;
+    this._syncTransport = typeof socket.writableLength !== 'number';
     const self = this;
     socket.on('drain', () => {
         self._draining = false;
@@ -88,57 +179,206 @@ FrameBuffer.prototype._pumpReads = function() {
     }
 };
 
+// A dedicated allocation, never the shared Buffer pool: this memory is handed
+// to the socket and refilled afterwards, so it must not alias anything else.
+FrameBuffer.prototype._takeBuffer = function() {
+    const buf = this._pool.pop();
+    if (buf)
+        return buf;
+    this.stats.allocs++;
+    return Buffer.allocUnsafeSlow(this._maxSize);
+};
+
+FrameBuffer.prototype._recycle = function(buf) {
+    if (this._pool.length < POOL_MAX)
+        this._pool.push(buf);
+};
+
 /** Queue an outbound packet Buffer (built with Buffer.write*). */
 FrameBuffer.prototype.put = function(buf) {
     if (!Buffer.isBuffer(buf))
         throw new TypeError('FrameBuffer.put expects a Buffer');
-    this.write_queue.push(buf);
+    this.stats.packets++;
+    this.stats.bytes += buf.length;
+
+    if (!this._batching) {
+        this.write_queue.push(buf);
+        return this;
+    }
+
+    // A packet that would fill the batch on its own (a big PutImage, a glyph
+    // upload) is written as it is: copying it would cost more than the write
+    // it saves.
+    if (buf.length >= this._maxSize) {
+        this.flush();
+        this.write_queue.push(buf);
+        this.flush();
+        return this;
+    }
+
+    if (this._out !== null && buf.length > this._maxSize - this._used)
+        this.flush(); // the batch is full: this is the size gate
+
+    if (this._out === null)
+        this._out = this._takeBuffer();
+    if (this._used === 0) {
+        this._packets = 0;
+        this._started = this._maxDelay === Infinity && !this._shouldFlush ? 0 : monotonic();
+    }
+    buf.copy(this._out, this._used);
+    this._used += buf.length;
+    this._packets++;
     return this;
 };
 
 /**
- * Write the queue out. Returns false when the socket applied backpressure
- * (remaining data is sent on 'drain'). An optional callback fires once all
- * data queued up to this call has been handed to the OS.
+ * A complete request has been put(): send it, now or with the packets around
+ * it. Returns false when the socket applied backpressure — the caller should
+ * stop producing until the client emits 'drain'.
+ *
+ * `expectsReply` marks a request whose caller is waiting for the server, so
+ * the default policy sends it without waiting for more.
  */
-FrameBuffer.prototype.flush = function(doneCb) {
-    if (doneCb) {
-        if (typeof doneCb !== 'function')
-            throw new TypeError('FrameBuffer.flush expects a callback function');
-        this.write_queue.push(doneCb);
+FrameBuffer.prototype.submit = function(expectsReply) {
+    if (!this._batching)
+        return this.flush();
+    if (this._used === 0 && this.write_queue.length === 0)
+        return !this._draining;
+
+    let flush;
+    if (this._shouldFlush) {
+        flush = this._shouldFlush({
+            bytes: this._used,
+            packets: this._packets,
+            age: monotonic() - this._started,
+            expectsReply: !!expectsReply
+        });
+        // undefined: no opinion, fall back to the built-in gates
+        if (flush === undefined)
+            flush = this._defaultGates(expectsReply);
+    } else {
+        flush = this._defaultGates(expectsReply);
     }
 
-    if (this._draining)
-        return false;
+    if (flush)
+        return this.flush();
 
-    if (this._socket) {
+    this._scheduleFlush();
+    return !this._draining;
+};
+
+FrameBuffer.prototype._defaultGates = function(expectsReply) {
+    if (expectsReply && this._flushOnReply)
+        return true;
+    if (this._maxDelay === Infinity || (this._packets & this._ageMask) !== 0)
+        return false;
+    return monotonic() - this._started >= this._maxDelay;
+};
+
+// Nothing may still be buffered when the event loop goes to poll for I/O.
+FrameBuffer.prototype._scheduleFlush = function() {
+    if (this._flushScheduled)
+        return;
+    this._flushScheduled = true;
+    scheduleFlush(() => {
+        this._flushScheduled = false;
+        if (this._used > 0 || this.write_queue.length > 0)
+            this.flush();
+    });
+};
+
+// Move the batch to the write queue, giving up its buffer. Only needed when
+// something must be queued behind it (a flush callback, an oversized packet,
+// a socket that is backed up); the fast path writes the batch directly and
+// keeps the buffer.
+FrameBuffer.prototype._seal = function() {
+    if (this._used === 0)
+        return;
+    this.write_queue.push(this._out.subarray(0, this._used));
+    this._out = null;
+    this._used = 0;
+    this._packets = 0;
+};
+
+FrameBuffer.prototype._writeChunk = function(chunk, cb) {
+    this.stats.writes++;
+    const ok = this._socket.write(chunk, cb);
+    if (!ok)
+        this._draining = true;
+    return ok;
+};
+
+// Fire a flush callback once everything written before it has reached the OS.
+FrameBuffer.prototype._notify = function(cb) {
+    if (!this._socket || this._syncTransport || this._socket.writableLength === 0)
+        queueMicrotask(cb);
+    else
+        this._socket.write(EMPTY, cb);
+};
+
+// Write queued items in order; returns false if the socket backed up.
+FrameBuffer.prototype._drainQueue = function() {
+    while (this.write_queue.length > 0) {
+        if (typeof this.write_queue[0] === 'function') {
+            this._notify(this.write_queue.shift());
+            continue;
+        }
+        if (!this._writeChunk(this.write_queue.shift()))
+            return false;
+    }
+    return true;
+};
+
+/**
+ * Write everything buffered so far. Returns false when the socket applied
+ * backpressure (the rest is sent on 'drain'). An optional callback fires once
+ * all data queued up to this call has been handed to the OS.
+ */
+FrameBuffer.prototype.flush = function(doneCb) {
+    if (doneCb !== undefined && typeof doneCb !== 'function')
+        throw new TypeError('FrameBuffer.flush expects a callback function');
+
+    if (!this._socket) {
+        // detached: hand everything to 'data' listeners in order
+        this._seal();
         while (this.write_queue.length > 0) {
             const item = this.write_queue.shift();
-            if (typeof item === 'function') {
-                // everything before this sentinel is inside the socket;
-                // fire once it reaches the OS
-                if (this._socket.writableLength === 0)
-                    queueMicrotask(item);
-                else
-                    this._socket.write(EMPTY, item);
-                continue;
-            }
-            const ok = this._socket.write(item);
-            if (!ok) {
-                this._draining = true;
-                return false;
-            }
+            if (typeof item === 'function')
+                queueMicrotask(item);
+            else
+                this.emit('data', item);
         }
+        if (doneCb)
+            queueMicrotask(doneCb);
         return true;
     }
 
-    while (this.write_queue.length > 0) {
-        const item = this.write_queue.shift();
-        if (typeof item === 'function')
-            queueMicrotask(item);
-        else
-            this.emit('data', item);
+    if (this._draining || !this._drainQueue()) {
+        // socket is backed up: everything goes to the queue, in order
+        this._seal();
+        if (doneCb)
+            this.write_queue.push(doneCb);
+        return false;
     }
+
+    if (this._used > 0) {
+        // hand the batch to the socket and refill the buffer once the socket
+        // is done with it — no reallocation per flush, let alone per request
+        const owner = this._out;
+        const chunk = this._used === this._maxSize ? owner : owner.subarray(0, this._used);
+        this._out = null;
+        this._used = 0;
+        this._packets = 0;
+        const ok = this._writeChunk(chunk, () => this._recycle(owner));
+        if (!ok) {
+            if (doneCb)
+                this.write_queue.push(doneCb);
+            return false;
+        }
+    }
+
+    if (doneCb)
+        this._notify(doneCb);
     return true;
 };
 

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -75,6 +75,28 @@ function hostname() {
     }
 }
 
+// Requests still in the output buffer when the process exits would be lost:
+// process.exit() runs no more timers or immediates. One 'exit' listener for
+// all clients — a listener per connection would leak and trip the max
+// listeners warning.
+const exitFlush = new Set();
+let exitHooked = false;
+function flushBeforeExit(pack_stream, stream) {
+    if (typeof process !== 'object' || typeof process.on !== 'function')
+        return; // not Node: no exit to hook
+    if (!exitHooked) {
+        exitHooked = true;
+        process.on('exit', () => {
+            for (const entry of exitFlush)
+                if (!entry.stream.destroyed && !entry.stream.writableEnded)
+                    entry.pack_stream.flush();
+        });
+    }
+    const entry = { pack_stream, stream };
+    exitFlush.add(entry);
+    stream.on('close', () => exitFlush.delete(entry));
+}
+
 function XClient(displayNum, screenNum, options)
 {
     EventEmitter.call(this);
@@ -101,10 +123,20 @@ XClient.prototype.init = function(stream)
       this.authFamily = null;
     }
 
-    const pack_stream = new PackStream();
+    const pack_stream = new PackStream(this.options.bufferRequests);
     const client = this;
     // Outbound: FrameBuffer.attach handles write + drain/backpressure
     pack_stream.attach(stream);
+    // Nagle holds a small write back until the previous segment is ACKed,
+    // which on a remote display serialises a batch into round trips. Off by
+    // default once requests are batched, since they then leave in full
+    // segments anyway; that is what libxcb does.
+    const noDelay = this.options.tcpNoDelay === undefined ?
+        !!this.options.bufferRequests : !!this.options.tcpNoDelay;
+    if (noDelay && typeof stream.setNoDelay === 'function')
+        stream.setNoDelay(true);
+    if (this.options.bufferRequests)
+        flushBeforeExit(pack_stream, stream);
     pack_stream.on('drain', () => {
         client.emit('drain');
     });
@@ -179,6 +211,8 @@ XClient.prototype.init = function(stream)
 // TODO: close() = set 'closing' flag, watch it in replies and writeQueue, terminate if empty
 XClient.prototype.terminate = function()
 {
+    // buffered requests would go down with the socket otherwise
+    this.pack_stream.flush();
     this.stream.end();
 }
 
@@ -360,7 +394,7 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
 
                  client.pack_stream.put(packet);
                  // false = socket backpressure: pause and wait for 'drain'
-                 return client.pack_stream.flush();
+                 return client.pack_stream.submit(expectsReply);
 
             } else if (templateType == 'Array'){
                  // legacy: should not happen once all templates are functions returning Buffer

--- a/test/apple-wm.js
+++ b/test/apple-wm.js
@@ -24,7 +24,7 @@ function makeExt() {
     eventParsers: {},
     pack_stream: {
       put: (buf) => written.push(buf),
-      flush: () => {},
+      submit: () => {},
     },
     QueryExtension: (name, cb) => {
       assert.strictEqual(name, 'Apple-WM');
@@ -47,7 +47,7 @@ describe('Apple-WM', () => {
       seq_num: 0,
       replies: {},
       eventParsers: {},
-      pack_stream: { put: () => {}, flush: () => {} },
+      pack_stream: { put: () => {}, submit: () => {} },
       QueryExtension: (name, cb) =>
         cb(null, { present: true, majorOpcode: MAJOR, firstEvent: FIRST_EVENT }),
     };

--- a/test/glx-emu/glx-extension.js
+++ b/test/glx-emu/glx-extension.js
@@ -35,7 +35,7 @@ function createRig(done) {
             put(buf) {
                 pending.push(buf);
             },
-            flush() {
+            submit() {
                 if (pending.length === 0)
                     return;
                 const req = Buffer.concat(pending);

--- a/test/output-buffering.js
+++ b/test/output-buffering.js
@@ -1,0 +1,500 @@
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const x11 = require('../lib');
+const FrameBuffer = require('../lib/framebuffer');
+
+// A socket that keeps what it is handed without copying and only reports it
+// consumed when the test says so — the way a real socket behaves while its
+// send buffer is full. Any buffer the client reuses too early shows up as
+// corrupted content at ack() time.
+class FakeSocket extends EventEmitter {
+    constructor(highWaterMark) {
+        super();
+        this.highWaterMark = highWaterMark === undefined ? Infinity : highWaterMark;
+        this.pending = [];   // [chunk, cb]
+        this.taken = [];     // chunks in write order
+        this.writableLength = 0;
+    }
+
+    write(chunk, cb) {
+        this.taken.push(chunk);
+        this.writableLength += chunk.length;
+        this.pending.push([chunk, cb]);
+        return this.writableLength < this.highWaterMark;
+    }
+
+    /** Consume everything written so far, then emit 'drain'. */
+    ack() {
+        const pending = this.pending;
+        this.pending = [];
+        this.writableLength = 0;
+        for (const [, cb] of pending)
+            if (cb) cb();
+        this.emit('drain');
+    }
+
+    /** Bytes handed over, in order, as one Buffer. */
+    written() {
+        return Buffer.concat(this.taken.map(c => Buffer.from(c)));
+    }
+
+    get writes() {
+        return this.taken.filter(c => c.length > 0).length;
+    }
+}
+
+// packet with a recognisable body, `len` bytes long
+function packet(byte, len) {
+    return Buffer.alloc(len === undefined ? 8 : len, byte);
+}
+
+function spin(ms) {
+    const until = Date.now() + ms;
+    while (Date.now() < until)
+        ; // deterministic clock advance: the age gate is checked on submit()
+}
+
+describe('output buffering (#244)', () => {
+
+  describe('unbuffered (default)', () => {
+
+    it('writes every packet as it is submitted', () => {
+        const fb = new FrameBuffer();
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        for (let i = 0; i < 5; i++)
+            fb.put(packet(i)).submit();
+        assert.strictEqual(socket.writes, 5);
+        assert.strictEqual(fb.stats.writes, 5);
+    });
+  });
+
+  describe('batching', () => {
+
+    it('coalesces the packets of one tick into a single write', () => {
+        const fb = new FrameBuffer(true);
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        for (let i = 0; i < 100; i++)
+            fb.put(packet(i % 256)).submit();
+        fb.flush();
+        assert.strictEqual(socket.writes, 1);
+        assert.strictEqual(socket.written().length, 800);
+        assert.strictEqual(fb.stats.packets, 100);
+    });
+
+    it('preserves packet order and content', () => {
+        const fb = new FrameBuffer({ maxSize: 64 });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        const expected = [];
+        for (let i = 1; i <= 40; i++) {
+            const buf = packet(i, 4 * (i % 5 + 1));
+            expected.push(buf);
+            fb.put(buf).submit();
+        }
+        fb.flush();
+        assert.ok(socket.writes < 20, `${socket.writes} writes for 40 packets`);
+        assert.deepStrictEqual(socket.written(), Buffer.concat(expected));
+    });
+
+    it('writes without an explicit flush before the event loop polls', done => {
+        const fb = new FrameBuffer(true);
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        fb.put(packet(1)).submit();
+        assert.strictEqual(socket.writes, 0, 'held back within the tick');
+        setImmediate(() => {
+            assert.strictEqual(socket.writes, 1);
+            assert.strictEqual(socket.written().length, 8);
+            done();
+        });
+    });
+
+    it('flushes when the batch is full', () => {
+        const fb = new FrameBuffer({ maxSize: 1024, maxDelay: Infinity });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        for (let i = 0; i < 128; i++)  // 128 * 8 = exactly maxSize
+            fb.put(packet(i % 256)).submit();
+        assert.strictEqual(socket.writes, 0);
+        fb.put(packet(0xff)).submit();
+        assert.strictEqual(socket.writes, 1);
+        assert.strictEqual(socket.written().length, 1024);
+    });
+
+    it('hands an oversized packet straight to the socket, in order', () => {
+        const fb = new FrameBuffer({ maxSize: 1024, maxDelay: Infinity });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        const small = packet(1);
+        const huge = packet(2, 4096);
+        fb.put(small).submit();
+        fb.put(huge).submit();
+        assert.deepStrictEqual(socket.written(), Buffer.concat([small, huge]));
+        // the big one is written as it is rather than copied through the batch
+        assert.strictEqual(socket.taken[socket.taken.length - 1], huge);
+    });
+
+    it('flushes when the oldest packet reaches maxDelay', () => {
+        const fb = new FrameBuffer({ maxDelay: 5 });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        for (let i = 0; i < 8; i++)
+            fb.put(packet(i)).submit();
+        assert.strictEqual(socket.writes, 0);
+        spin(8);
+        // the age is sampled every few packets, not on every single one
+        for (let i = 0; i < 8; i++)
+            fb.put(packet(i)).submit();
+        assert.strictEqual(socket.writes, 1, 'the age gate should have fired');
+        fb.flush();
+        assert.strictEqual(socket.written().length, 16 * 8);
+    });
+
+    it('sends a request that expects a reply without waiting', () => {
+        const fb = new FrameBuffer(true);
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        fb.put(packet(1)).submit();
+        assert.strictEqual(socket.writes, 0);
+        fb.put(packet(2)).submit(true);
+        assert.strictEqual(socket.writes, 1);
+    });
+
+    it('keeps batching replies too when flushOnReply is off', () => {
+        const fb = new FrameBuffer({ flushOnReply: false, maxDelay: Infinity });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        fb.put(packet(1)).submit(true);
+        assert.strictEqual(socket.writes, 0);
+    });
+
+    it('flush(cb) writes now and reports when the data reached the socket', done => {
+        const fb = new FrameBuffer(true);
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        fb.put(packet(1)).submit();
+        let fired = false;
+        fb.flush(() => { fired = true; });
+        assert.strictEqual(socket.writes, 1, 'flush() is not subject to the policy');
+        assert.strictEqual(fired, false);
+        socket.ack();
+        setTimeout(() => {
+            assert.strictEqual(fired, true);
+            done();
+        }, 5);
+    });
+  });
+
+  describe('shouldFlush', () => {
+
+    it('receives the state of the batch', () => {
+        const seen = [];
+        const fb = new FrameBuffer({ shouldFlush: info => { seen.push(info); return false; } });
+        fb.attach(new FakeSocket());
+        fb.put(packet(1, 12)).submit();
+        fb.put(packet(2, 4)).submit(true);
+        assert.strictEqual(seen.length, 2);
+        assert.deepStrictEqual(
+            seen.map(i => [i.bytes, i.packets, i.expectsReply]),
+            [[12, 1, false], [16, 2, true]]);
+        assert.ok(seen[1].age >= 0 && seen[1].age < 1000);
+    });
+
+    it('holds the batch back when it returns false', () => {
+        const fb = new FrameBuffer({ maxDelay: 0, shouldFlush: () => false });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        for (let i = 0; i < 10; i++)
+            fb.put(packet(i)).submit(true);  // both built-in gates would fire
+        assert.strictEqual(socket.writes, 0);
+    });
+
+    it('falls back to the built-in gates when it returns undefined', () => {
+        const fb = new FrameBuffer({ shouldFlush: info => (info.bytes > 100 ? true : undefined) });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        fb.put(packet(1)).submit();
+        assert.strictEqual(socket.writes, 0);
+        fb.put(packet(2)).submit(true);      // expectsReply gate still applies
+        assert.strictEqual(socket.writes, 1);
+        fb.put(packet(3, 200)).submit();     // its own rule
+        assert.strictEqual(socket.writes, 2);
+    });
+
+    it('cannot hold data past the point where the loop would poll', done => {
+        const fb = new FrameBuffer({ shouldFlush: () => false });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        fb.put(packet(1)).submit();
+        setImmediate(() => {
+            assert.strictEqual(socket.writes, 1);
+            done();
+        });
+    });
+
+    it('cannot hold more than maxSize', () => {
+        const fb = new FrameBuffer({ maxSize: 256, shouldFlush: () => false });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        for (let i = 0; i < 64; i++)   // 512 bytes: one full batch and a half
+            fb.put(packet(i)).submit();
+        assert.strictEqual(socket.writes, 1, 'the full batch went out');
+        assert.strictEqual(socket.written().length, 256);
+        fb.flush();
+        assert.strictEqual(socket.written().length, 512);
+    });
+  });
+
+  describe('buffer reuse', () => {
+
+    it('does not allocate per request', () => {
+        const fb = new FrameBuffer(true);
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        for (let round = 0; round < 50; round++) {
+            for (let i = 0; i < 100; i++)
+                fb.put(packet(i % 256)).submit();
+            fb.flush();
+            socket.ack(); // the socket is done with the buffer: back to the pool
+        }
+        assert.strictEqual(fb.stats.packets, 5000);
+        assert.strictEqual(fb.stats.allocs, 1, 'one output buffer for 5000 requests');
+    });
+
+    it('never refills a buffer the socket still holds', () => {
+        const fb = new FrameBuffer({ maxSize: 64 });
+        const socket = new FakeSocket();
+        fb.attach(socket);
+        const expected = [];
+        // several batches in flight at once: nothing is acked in between
+        for (let i = 1; i <= 32; i++) {
+            const buf = packet(i, 16);
+            expected.push(buf);
+            fb.put(buf).submit();
+            fb.flush();
+        }
+        assert.deepStrictEqual(socket.written(), Buffer.concat(expected));
+        socket.ack();
+        assert.deepStrictEqual(socket.written(), Buffer.concat(expected),
+            'chunks handed to the socket must not change afterwards');
+        assert.ok(fb.stats.allocs > 1, 'in-flight buffers cannot be reused');
+    });
+  });
+
+  describe('backpressure', () => {
+
+    it('reports the socket backing up and loses nothing', () => {
+        const fb = new FrameBuffer({ maxSize: 64 });
+        const socket = new FakeSocket(128); // room for two batches
+        fb.attach(socket);
+        const expected = [];
+        let ok = true;
+        for (let i = 1; ok && i <= 100; i++) {
+            const buf = packet(i % 256, 32);
+            expected.push(buf);
+            ok = fb.put(buf).submit();
+        }
+        assert.strictEqual(ok, false, 'backpressure should have been reported');
+        const queued = expected.length;
+        socket.ack();
+        fb.flush();
+        assert.deepStrictEqual(socket.written(), Buffer.concat(expected.slice(0, queued)));
+    });
+
+    it('emits drain once the queue is empty again', done => {
+        const fb = new FrameBuffer(true);
+        const socket = new FakeSocket(16);
+        fb.attach(socket);
+        fb.put(packet(1, 64)).submit();
+        fb.flush();
+        fb.on('drain', () => done());
+        socket.ack();
+    });
+  });
+
+  describe('option validation', () => {
+
+    it('rejects nonsense', () => {
+        assert.throws(() => new FrameBuffer({ maxSize: 0 }), /maxSize/);
+        assert.throws(() => new FrameBuffer({ maxSize: '16k' }), /maxSize/);
+        assert.throws(() => new FrameBuffer({ maxDelay: -1 }), /maxDelay/);
+        assert.throws(() => new FrameBuffer({ shouldFlush: 5 }), /shouldFlush/);
+    });
+  });
+
+  describe('over a real connection', () => {
+
+    let display;
+    let X;
+    let root;
+
+    function connect(options, cb) {
+        const client = x11.createClient(options, (err, dpy) => {
+            if (err) return cb(err);
+            client.removeListener('error', cb);
+            cb(null, dpy);
+        });
+        client.on('error', cb);
+    }
+
+    beforeEach(done => {
+        connect({ bufferRequests: true }, (err, dpy) => {
+            if (err) return done(err);
+            display = dpy;
+            X = display.client;
+            root = display.screen[0].root;
+            done();
+        });
+    });
+
+    afterEach(done => {
+        if (X.stream.writableEnded)  // the test closed the connection itself
+            return done();
+        X.on('end', done);
+        X.terminate();
+    });
+
+    it('draws the same picture as an unbuffered client', done => {
+        const W = 16, H = 16;
+        const depth = display.screen[0].root_depth;
+        const white = display.screen[0].white_pixel;
+        const pixmap = X.AllocID();
+        const gc = X.AllocID();
+        X.CreatePixmap(pixmap, root, depth, W, H);
+        X.CreateGC(gc, pixmap, { foreground: display.screen[0].black_pixel });
+        X.PolyFillRectangle(pixmap, gc, [0, 0, W, H]);
+        X.ChangeGC(gc, { foreground: white });
+        for (let i = 0; i < W; i++)         // a diagonal, one request per pixel
+            X.PolyFillRectangle(pixmap, gc, [i, i, 1, 1]);
+        const writes = X.pack_stream.stats.writes;
+        X.GetImage(2, pixmap, 0, 0, W, H, 0xffffffff, (err, image) => {
+            assert.ifError(err);
+            const bytesPP = depth <= 8 ? 1 : (depth <= 16 ? 2 : 4);
+            let lit = 0;
+            for (let y = 0; y < H; y++) {
+                let pixel = 0;
+                for (let i = 0; i < bytesPP; ++i)
+                    pixel += image.data[(y * W + y) * bytesPP + i] << (8 * i);
+                if ((pixel >>> 0) === white) lit++;
+            }
+            assert.strictEqual(lit, H, 'every pixel of the diagonal was drawn');
+            // 20 requests, and the reply forced at most one write
+            assert.ok(X.pack_stream.stats.writes - writes <= 1,
+                `${X.pack_stream.stats.writes - writes} writes for the GetImage`);
+            X.FreeGC(gc);
+            X.FreePixmap(pixmap);
+            done();
+        });
+    });
+
+    it('batches a run of requests into one write', done => {
+        X.sync(err => {
+            assert.ifError(err);
+            const before = X.pack_stream.stats.writes;
+            for (let i = 0; i < 200; i++)
+                X.ChangeWindowAttributes(root, { eventMask: 0 });
+            assert.strictEqual(X.pack_stream.stats.writes, before,
+                'nothing should have been written yet');
+            X.sync(err2 => {
+                assert.ifError(err2);
+                const writes = X.pack_stream.stats.writes - before;
+                assert.ok(writes <= 2, `${writes} writes for 200 requests + sync`);
+                done();
+            });
+        });
+    });
+
+    it('a request expecting a reply is not held back', done => {
+        X.GetInputFocus(err => {
+            assert.ifError(err);
+            done();
+        });
+        assert.ok(X.pack_stream.stats.writes > 0, 'written within the tick');
+    });
+
+    it('still confirms a checked void request', done => {
+        // the sync the client issues on its behalf expects a reply, so it
+        // takes the buffered request out with it
+        X.ChangeWindowAttributes(root, { eventMask: 0 }, err => {
+            assert.strictEqual(err, null);
+            done();
+        });
+    });
+
+    it('flushes what is buffered before the connection is closed', done => {
+        // terminate() is the last thing a program does; a buffered request
+        // issued just before it must still reach the server
+        const name = `x11-buffering-test-${process.pid}`;
+        X.InternAtom(false, name, (err, atom) => {
+            assert.ifError(err);
+            X.ChangeProperty(0, root, atom, X.atoms.STRING, 8, Buffer.from('kept'));
+            X.terminate();
+            connect({}, (err2, dpy) => {
+                assert.ifError(err2);
+                const X2 = dpy.client;
+                X2.GetProperty(0, root, atom, X2.atoms.STRING, 0, 10, (err3, prop) => {
+                    assert.ifError(err3);
+                    assert.strictEqual(prop.data.toString(), 'kept');
+                    X2.DeleteProperty(root, atom);
+                    X2.terminate();
+                    done();
+                });
+            });
+        });
+    });
+
+    it('flushes what is buffered when the process exits', function(done) {
+        // process.exit() runs no timers and no immediates: without an exit
+        // hook a buffered request would be lost with no trace
+        this.timeout(20000);
+        const name = `x11-buffering-exit-${process.pid}`;
+        const child = `
+            const x11 = require(${JSON.stringify(require.resolve('../lib'))});
+            x11.createClient({ bufferRequests: true }, (err, display) => {
+                if (err) throw err;
+                const X = display.client;
+                X.InternAtom(false, ${JSON.stringify(name)}, (err, atom) => {
+                    if (err) throw err;
+                    X.ChangeProperty(0, display.screen[0].root, atom,
+                                     X.atoms.STRING, 8, Buffer.from('kept'));
+                    process.exit(0);
+                });
+            });`;
+        require('child_process').execFile(process.execPath, ['-e', child], err => {
+            assert.ifError(err);
+            X.InternAtom(false, name, (err2, atom) => {
+                assert.ifError(err2);
+                X.GetProperty(0, root, atom, X.atoms.STRING, 0, 10, (err3, prop) => {
+                    assert.ifError(err3);
+                    assert.strictEqual(prop.data.toString(), 'kept');
+                    X.DeleteProperty(root, atom);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('still reports backpressure to the caller', function(done) {
+        this.timeout(30000);
+        const wid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, 1, 1);
+        const chunk = Buffer.alloc(0xfff0, 0xab);
+        let ok = true;
+        let writes = 0;
+        while (ok && writes < 4096) {
+            ok = X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, chunk);
+            writes++;
+        }
+        assert.strictEqual(ok, false, `no backpressure after ${writes} writes`);
+        X.once('drain', () => {
+            X.sync(err => {
+                X.DestroyWindow(wid);
+                X.ReleaseID(wid);
+                done(err);
+            });
+        });
+    });
+  });
+});

--- a/website/docs/guides/custom-transports.md
+++ b/website/docs/guides/custom-transports.md
@@ -66,6 +66,13 @@ stream is not immediately usable, follow `net.Socket` semantics: set
 `connecting = true` and emit `'connect'` once ready. A stream that is
 already open is used as-is.
 
+`write(buf)` must consume or copy `buf` before it returns, unless it is a
+real `stream.Writable` (one with a numeric `writableLength`, whose
+`write(buf, cb)` callback says when the buffer is free). The client packs
+requests into a buffer it reuses, so a transport that keeps the object
+around — queueing it for a later send, say — must take its own copy, the way
+`MessagePortStream` does.
+
 Connecting with an unregistered protocol prefix throws
 `unknown display protocol: <name>`.
 

--- a/website/docs/guides/getting-started.mdx
+++ b/website/docs/guides/getting-started.mdx
@@ -26,6 +26,8 @@ x11.createClient((err, display) => {
 | `display` | display string, e.g. `':0'`, `'localhost:1.0'` or a literal socket path (default: `$DISPLAY`) |
 | `debug` | log outgoing requests and capture per-request stack traces for errors |
 | `disableBigRequests` | skip the automatic BIG-REQUESTS handshake done at connect time |
+| `bufferRequests` | batch outgoing requests into fewer socket writes: `true`, or `{ maxSize, maxDelay, flushOnReply, shouldFlush }` — see [Buffering the output](../reference/index.md#buffering-the-output) |
+| `tcpNoDelay` | turn Nagle's algorithm off on a TCP connection (default: on when `bufferRequests` is set) |
 | `stream` | an already-connected duplex stream to use instead of opening a socket (see [Custom transports](custom-transports.md)) |
 | `auth` | authentication override, `{ name, data }` (see [Custom transports](custom-transports.md)) |
 


### PR DESCRIPTION
Closes #244.

## Why

Every request was `put()` followed by an unconditional `flush()`, and `flush()`
handed each queued buffer to `socket.write()` on its own. N requests meant N
writes — no accumulation, no `writev`. A frame of 200 small drawing requests
was 200 sub-MTU writes; on TCP, with Nagle on (nothing called `setNoDelay`),
those writes then serialised against the previous segment's ACK, which is what
makes remote displays feel slow. Xlib has buffered its output in a 16 KB buffer
since X11R1.

## What changed

`createClient({ bufferRequests: true })` — opt-in, default behaviour is
unchanged — batches requests into one reused buffer and writes it out when any
of these happens:

- the batch reaches `maxSize` (default 16384);
- its oldest request is `maxDelay` ms old (default 5, sampled every few
  requests rather than on each one; `Infinity` disables it);
- a request that expects a reply is issued (`flushOnReply`, default true);
- the event loop is about to wait for I/O — a `setImmediate` backstop, so
  nothing is ever left sitting while the process is idle;
- `X.flush()`, `X.terminate()`, or the process exits (including a hard
  `process.exit()`, which runs no timers).

That set is chosen so buffering cannot cost interactivity: input-to-pixel is
bounded by the current tick, because the requests a handler issues are written
before the loop can poll again, and a caller waiting on a reply never waits for
the buffer.

A `shouldFlush(info)` predicate overrides the age and reply gates for a program
that knows its own boundaries. It is called per request with the pending
batch's `bytes`, `packets`, `age` and whether this request `expectsReply`, and
returns `true` to write now, `false` to keep buffering, `undefined` to defer to
the built-in gates. It cannot defeat the `maxSize` cap or the
before-the-loop-polls flush, so no policy can make the client sit on data.

`tcpNoDelay` disables Nagle and defaults to on when buffering is enabled —
batched requests already leave in full segments, so Nagle can only add its
delayed-ACK interaction. Pass it explicitly to override either way.

## Allocation behaviour

The batch is packed into a buffer allocated once and reused, never reallocated
per request and never `Buffer.concat`ed per flush. A buffer is only refilled
after the socket says it is done with it (its write callback), so a batch the
kernel has not taken yet can never be overwritten; buffers still in flight come
from a small pool. `pack_stream.stats.allocs` makes this observable: 5000
requests over 50 flushes allocate **one** output buffer.

## New API

| | |
|---|---|
| `createClient({ bufferRequests })` | `true`, or `{ maxSize, maxDelay, flushOnReply, shouldFlush }` |
| `createClient({ tcpNoDelay })` | override the Nagle default |
| `X.pack_stream.stats` | `{ packets, bytes, writes, allocs }` |
| `pack_stream.submit(expectsReply)` | end of a request: write per policy (replaces the `put().flush()` pair) |

`pack_stream.flush([cb])` keeps its meaning — write everything now — so
`X.flush()` and third-party code that builds raw requests are unaffected. The
233 `put()`/`flush()` pairs in `lib/ext/` became `put()`/`submit()`; the ~100
that register a reply handler pass `submit(true)`.

Also fixed in passing: `X.flush(cb)` never fired its callback over a transport
that is not a Node stream (the browser `MessagePortStream`), because the
callback rode on `socket.write(EMPTY, cb)`, which such transports ignore.

## Effect

Measured against Xvfb over a unix socket — where there is no Nagle and no RTT,
so this is the *floor* of the win:

| | writes | time until the server had processed all of it |
|---|---|---|
| 20000 requests, unbuffered | 20001 | 177 ms |
| 20000 requests, buffered (16 KB) | 25 | 9.6 ms |
| 20000 requests, buffered (64 KB) | 7 | 9.2 ms |

Per-request cost in the client goes *down*, not up: 45 ns unbuffered vs 34 ns
buffered in a FrameBuffer microbenchmark (the copy into the batch is cheaper
than the queue-and-write path it replaces, and the age gate's clock read is
sampled, not per request).

Downstream, ntk needs no code change — its frame runs in one synchronous pass
and ends with the frame fence's `GetInputFocus`, whose reply gate flushes at
exactly the frame boundary. Passing `bufferRequests` through takes a
2000-request ntk frame from 2003 writes to 1 (16 KB default: 5 writes for a
72 KB frame; 256 KB: 1). This is worth noting against
[ntk#125](https://github.com/sidorares/ntk/issues/125), which assumed an
explicit `X.flush()` at `_present()` was needed — it is redundant, and in a
multi-window app it would split writes that would otherwise coalesce.

## Testing

`test/output-buffering.js`, 27 cases: the policy gates one at a time against a
fake socket that keeps what it is handed without copying (so any buffer reused
too early shows up as corrupted output), buffer reuse and allocation counts,
backpressure and `'drain'`, option validation, and over a real server — pixel
output identical to an unbuffered client, one write for a 200-request run,
checked void requests still confirmed, and requests surviving both
`X.terminate()` and a hard `process.exit()` in a spawned child.

Full suite green: 445 protocol tests against Xvfb, 284 server tests, 52
glx-emu, plus the website's demo/bundle/share checks (the browser bundle
includes `framebuffer.js`).
