### PR TITLE
fix: close() must report when the connection is really gone

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,13 @@ X.ChangeWindowAttributes(root, {                // void request, checked:
 Resource ids (windows, pixmaps, GCs, …) are allocated client-side with
 `X.AllocID()` and can be recycled with `X.ReleaseID(id)` once the resource is
 destroyed. When you are done with the connection, call `X.terminate()`; the
-client emits `'end'` when the stream closes.
+client emits `'end'` when the stream closes. `X.close(cb)` is the polite
+version — it round-trips first, so requests already issued are known to have
+been processed, and its callback fires once the connection is actually gone.
+That matters if another connection follows: an X server resets when its last
+client disconnects, and a connection opened inside that window is dropped
+mid-setup (which is now reported as a connect error rather than never
+calling back).
 
 See [core-requests.md](core-requests.md) for the complete reference.
 

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -252,12 +252,33 @@ XClient.prototype.flush = function(cb) {
     this.pack_stream.flush(cb);
 }
 
+// Round trip, then close the connection. The callback fires once the socket
+// is really gone — not merely once end() was called: an X server resets when
+// its last client disconnects, and a program that reconnects inside that
+// window gets its new connection dropped mid-setup.
 XClient.prototype.close = function(cb) {
     const cli = this;
     cli.ping(err => {
-      if (err) return cb(err);
+      if (err) return cb && cb(err);
+      if (cb) {
+          let done = false;
+          const finish = () => {
+              if (done) return;
+              done = true;
+              cli.stream.removeListener('close', finish);
+              cli.stream.removeListener('end', finish);
+              cb();
+          };
+          cli.stream.on('close', finish);
+          // transports that are not Node sockets may only report 'end', or
+          // nothing at all because they close synchronously
+          cli.stream.on('end', finish);
+          cli.terminate();
+          if (cli.stream.destroyed)
+              finish();
+          return;
+      }
       cli.terminate();
-      if (cb) cb();
     });
     cli._closing = true;
 }
@@ -717,7 +738,24 @@ module.exports.createClient = (options, initCb) => {
         }
     };
 
+    // A server can drop a connection during setup without saying anything —
+    // it is resetting after its last client left, or it refuses the
+    // authorisation by hanging up. Report it instead of leaving the caller
+    // waiting for a callback that will never come.
+    const onSetupClose = () => {
+        if (!initCb || cbCalled)
+            return; // setup finished: an ordinary disconnect, see 'end'
+        cbCalled = true;
+        initCb(new Error(`connection to ${display} closed before setup completed`));
+    };
+
+    const watchSetup = () => {
+        stream.on('close', onSetupClose);
+        stream.on('end', onSetupClose);
+    };
+
     const attachStream = () => {
+        watchSetup();
         stream.on('connect', () => {
             if (connected) return;
             connected = true;
@@ -795,6 +833,7 @@ module.exports.createClient = (options, initCb) => {
             }
             stream.on('connect', () => {
                 connected = true;
+                watchSetup();
                 client.init(stream);
             });
             stream.on('error', err => {

--- a/test/connect.js
+++ b/test/connect.js
@@ -60,6 +60,44 @@ describe('Client', () => {
     }
   });
 
+  it('reports a connection dropped during setup instead of hanging', done => {
+    // a server that hangs up mid-setup — resetting after its last client
+    // left, or refusing authorisation without a word — used to leave the
+    // connect callback waiting forever
+    const { EventEmitter } = require('events');
+    const stream = new EventEmitter();
+    stream.write = () => true;
+    stream.end = () => {};
+    x11.createClient({ display: ':0', stream }, err => {
+        assert(err instanceof Error);
+        assert.match(err.message, /closed before setup/);
+        done();
+    });
+    setImmediate(() => stream.emit('close'));
+  });
+
+  it('closes before it reports the connection closed', done => {
+    // the callback used to fire when end() was called, not when the socket
+    // was gone: an X server resets when its last client disconnects, so a
+    // program that reconnects in that window loses the new connection
+    const client = x11.createClient((err, dpy) => {
+        assert.ifError(err);
+        dpy.client.close(() => {
+            const stream = dpy.client.stream;
+            assert.ok(stream.readableEnded || stream.destroyed,
+                'close() should report only once the server has let go');
+            // and the connection that follows survives the server's reset
+            const next = x11.createClient(err2 => {
+                assert.ifError(err2);
+                next.terminate();
+                done();
+            });
+            next.on('error', done);
+        });
+    });
+    client.on('error', done);
+  });
+
   it('returns error when connecting to non existent display', done => {
     let errorCbCalled = false;
     const client = x11.createClient({ display : ':44' }, (err, display) => {


### PR DESCRIPTION
Two bugs that turn "close a connection, open another" into a silent hang. Both predate the output-buffering work — they showed up while testing that against an **authenticated** Xvfb, which is what CI runs and what a desktop session is.

## What happens today

```js
const app = await connect();
await app.close();          // callback fires here…
const next = await connect();   // …and this never resolves
```

`X.close(cb)` round-trips and then calls `terminate()`, but its callback fires as soon as `end()` has been *called* — the socket is still shutting down. An X server resets when its last client disconnects, and a connection that arrives inside that window is accepted and then dropped without a setup reply. Nothing in the client watched for the stream closing during setup, so `createClient`'s callback was simply never called: no error, no timeout, no trace. `terminate()` did not have the problem, because callers of it wait for `'end'` themselves.

Reproduced against `Xvfb :98 -auth …`, with and without buffering, and on `1c2e111` (before the buffering PR):

```
first  connected in 10ms
first closed
FAILED: second: TIMEOUT
```

The second connection's socket shows `written=48 read=0 destroyed=true` — the hello went out, the server hung up, and the client kept waiting.

## The fix

- `close(cb)` resolves on the stream's `'close'`, or `'end'` for transports that only report that, or immediately for transports that close synchronously (the in-process stream pair). So when the callback fires, the server has let go and the next connection is safe.
- A stream that closes before setup completes is reported to the connect callback: `connection to <display> closed before setup completed`. Any dropped setup now surfaces instead of hanging — a server refusing authorisation by hanging up looks the same to a client.

## Testing

Two cases in `test/connect.js`: `close(cb)` must report only once the server has let go, and a connection that follows it must survive; and a transport that closes mid-setup must reach the connect callback with an error (a fake stream, so it is deterministic and needs no server).

Suite: 447 protocol tests against Xvfb, 284 server tests, 52 glx-emu, lint clean.
