### PR TITLE
fix: PutImage and AddGlyphs are malformed with disableBigRequests

### DIFF
--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -1475,17 +1475,42 @@ const templates = {
       // format:  0 - Bitmap, 1 - XYPixmap, 2 - ZPixmap
       (format, drawable, gc, width, height, dstX, dstY, leftPad, depth, data) => {
           const padded = xutil.padded_length(data.length);
-          const reqLen = 6 + padded / 4; // (length + 3) >> 2 ???
-          const padLength = padded - data.length;
-          const pad = Buffer.alloc(padLength);
+          // length of the standard (non-BigReq) request in 4-byte units:
+          // 24-byte header (6 words) + padded image data
+          const reqLen = 6 + padded / 4;
 
-          // TODO: move code to calculate reqLength and use BigReq if needed outside of corereq.js
-          // NOTE: big req is used here (length field 0 then CARD32 big length), won't work if not enabled
-          const b = Buffer.alloc(28 + data.length + pad.length);
+          if (reqLen <= 0xffff) {
+              // Fits the 16-bit length field, so use the plain encoding — valid
+              // whether or not BIG-REQUESTS was negotiated. Buffer.alloc
+              // zero-fills, so the pad bytes after the image are already there.
+              const b = Buffer.alloc(24 + padded);
+              b[0] = 72;
+              b[1] = format;
+              b.writeUInt16LE(reqLen, 2);
+              b.writeUInt32LE(drawable >>> 0, 4);
+              b.writeUInt32LE(gc >>> 0, 8);
+              b.writeUInt16LE(width, 12);
+              b.writeUInt16LE(height, 14);
+              b.writeInt16LE(dstX, 16);
+              b.writeInt16LE(dstY, 18);
+              b[20] = leftPad;
+              b[21] = depth;
+              data.copy(b, 24);
+              return b;
+          }
+
+          // Too large for a 16-bit length: BIG-REQUESTS encoding — length field
+          // 0, then a CARD32 holding the real length (one word longer, for that
+          // extra word). This requires BIG-REQUESTS to have been enabled at
+          // connect (the default). A connection created with
+          // `disableBigRequests` cannot carry a request this large; the caller
+          // must split the image into bands that each fit under
+          // `display.max_request_length`.
+          const b = Buffer.alloc(28 + padded);
           b[0] = 72;
           b[1] = format;
           b.writeUInt16LE(0, 2);
-          b.writeUInt32LE((1 + reqLen) >>> 0, 4);
+          b.writeUInt32LE((reqLen + 1) >>> 0, 4);
           b.writeUInt32LE(drawable >>> 0, 8);
           b.writeUInt32LE(gc >>> 0, 12);
           b.writeUInt16LE(width, 16);
@@ -1495,7 +1520,6 @@ const templates = {
           b[24] = leftPad;
           b[25] = depth;
           data.copy(b, 28);
-          pad.copy(b, 28 + data.length);
           return b;
       }
    ],

--- a/lib/ext/render.js
+++ b/lib/ext/render.js
@@ -673,19 +673,33 @@ exports.requireExt = (display, callback) => {
         glyph.offX = glyph.offX / 64;
         glyph.offY = glyph.offY / 64;
       }
+      // length of the standard (non-BigReq) request in 4-byte units: 12-byte
+      // header (3 words) + glyph ids + metrics + padded image data
       const len = numGlyphs * 4 + imageBytes / 4 + 3;
-      // TODO: check length, use bigReq
-      // X.pack_stream.pack('CCSLL', [ext.majorOpcode, 20, len, gsid, glyphs.length]);
 
-      // BigReq: S + [ length ] replaced with SL + [ 0, length+1 ]
-      const hdr = Buffer.alloc(16);
-      hdr.writeUInt8(ext.majorOpcode, 0);
-      hdr.writeUInt8(20, 1);
-      hdr.writeUInt16LE(0, 2);
-      hdr.writeUInt32LE(len + 1, 4);
-      hdr.writeUInt32LE(gsid >>> 0, 8);
-      hdr.writeUInt32LE(glyphs.length >>> 0, 12);
-      X.pack_stream.put(hdr);
+      if (len <= 0xffff) {
+        // fits the 16-bit length field: plain encoding, valid whether or not
+        // BIG-REQUESTS was negotiated
+        const hdr = Buffer.alloc(12);
+        hdr.writeUInt8(ext.majorOpcode, 0);
+        hdr.writeUInt8(20, 1);
+        hdr.writeUInt16LE(len, 2);
+        hdr.writeUInt32LE(gsid >>> 0, 4);
+        hdr.writeUInt32LE(glyphs.length >>> 0, 8);
+        X.pack_stream.put(hdr);
+      } else {
+        // too large for a 16-bit length: BIG-REQUESTS encoding (length field 0,
+        // then a CARD32 holding the real length + 1 for the extra word). Needs
+        // BIG-REQUESTS enabled at connect (the default).
+        const hdr = Buffer.alloc(16);
+        hdr.writeUInt8(ext.majorOpcode, 0);
+        hdr.writeUInt8(20, 1);
+        hdr.writeUInt16LE(0, 2);
+        hdr.writeUInt32LE(len + 1, 4);
+        hdr.writeUInt32LE(gsid >>> 0, 8);
+        hdr.writeUInt32LE(glyphs.length >>> 0, 12);
+        X.pack_stream.put(hdr);
+      }
 
       const ids = Buffer.alloc(numGlyphs * 4);
       for (let i = 0; i < numGlyphs; i++)

--- a/test/putimage-bigreq.js
+++ b/test/putimage-bigreq.js
@@ -1,0 +1,108 @@
+const x11 = require('../lib');
+const should = require('should');
+
+// PutImage (and RENDER AddGlyphs) used to always emit the BIG-REQUESTS length
+// encoding — length field 0 followed by a CARD32 — which a server only accepts
+// once BIG-REQUESTS has been enabled. A connection created with
+// `disableBigRequests: true` therefore sent a request the server read as
+// zero-length and rejected with "Bad length". These tests exercise both a
+// normal connection and one with BIG-REQUESTS disabled, at sizes that do and
+// do not fit the 16-bit length field.
+
+function withClient(options, fn, done) {
+    x11.createClient(options, (err, dpy) => {
+        should.not.exist(err);
+        const X = dpy.client;
+        fn(X, dpy, () => {
+            X.terminate();
+            X.on('end', done);
+        });
+    });
+}
+
+// PutImage a gradient into a fresh pixmap and read it back; the pixels must
+// survive the round trip, which they only do if the request encoding is valid.
+function putGetRoundTrip(X, dpy, w, h, finish) {
+    const scr = dpy.screen[0];
+    const depth = scr.root_depth;
+    const pid = X.AllocID();
+    const gc = X.AllocID();
+    X.CreatePixmap(pid, scr.root, depth, w, h);
+    X.CreateGC(gc, pid);
+    const bytes = w * h * 4;
+    const src = Buffer.alloc(bytes);
+    for (let i = 0; i < bytes; i++) src[i] = (i * 37 + 11) & 0xff;
+    X.PutImage(2, pid, gc, w, h, 0, 0, 0, depth, src);
+    X.GetImage(2, pid, 0, 0, w, h, 0xffffffff, (err, img) => {
+        should.not.exist(err);
+        let bad = 0;
+        for (let i = 0; i < bytes; i += 4) {
+            if (img.data[i] !== src[i] ||
+                img.data[i + 1] !== src[i + 1] ||
+                img.data[i + 2] !== src[i + 2]) bad++;
+        }
+        bad.should.equal(0);
+        X.FreeGC(gc);
+        X.FreePixmap(pid);
+        finish();
+    });
+}
+
+describe('PutImage request encoding', () => {
+    it('round-trips a small image on a normal connection', function(done) {
+        withClient({}, (X, dpy, close) => {
+            putGetRoundTrip(X, dpy, 64, 64, close);
+        }, done);
+    });
+
+    it('round-trips a small image with BIG-REQUESTS disabled', function(done) {
+        // the regression: this used to fail with "Bad length"
+        withClient({ disableBigRequests: true }, (X, dpy, close) => {
+            putGetRoundTrip(X, dpy, 64, 64, close);
+        }, done);
+    });
+
+    it('round-trips a ~196 KB image (still under the 16-bit length) without BIG-REQUESTS', function(done) {
+        // 224*224*4 = ~196 KB, request length ~49155 words < 65535
+        withClient({ disableBigRequests: true }, (X, dpy, close) => {
+            putGetRoundTrip(X, dpy, 224, 224, close);
+        }, done);
+    });
+
+    it('round-trips a >256 KB image (needs the BIG-REQUESTS encoding) on a normal connection', function(done) {
+        // 512*512*4 = 1 MB, request length > 65535 words -> BigReq encoding
+        withClient({}, (X, dpy, close) => {
+            putGetRoundTrip(X, dpy, 512, 512, close);
+        }, done);
+    });
+});
+
+// The same unconditional-BigReq encoding lived in RENDER AddGlyphs; a small
+// glyph upload must be accepted with BIG-REQUESTS disabled too. Upload a glyph
+// and round-trip: a malformed request would come back as a "Bad length" error
+// against the AddGlyphs sequence number.
+describe('RENDER AddGlyphs request encoding', () => {
+    it('uploads a small glyph with BIG-REQUESTS disabled', function(done) {
+        withClient({ disableBigRequests: true }, (X, dpy, close) => {
+            let xerr = null;
+            X.on('error', err => { xerr = err; });
+            X.require('render', (err, render) => {
+                should.not.exist(err);
+                const gsid = X.AllocID();
+                render.CreateGlyphSet(gsid, render.a8);
+                // a 4x4 fully-opaque glyph, origin at its lower-left
+                render.AddGlyphs(gsid, [{
+                    id: 65, width: 4, height: 4, x: 0, y: 4,
+                    offX: 4 * 64, offY: 0, image: Buffer.alloc(16, 255)
+                }]);
+                // force a round trip so any error against the AddGlyphs request
+                // has been delivered before we assert
+                X.GetInputFocus(() => {
+                    should.not.exist(xerr);
+                    render.FreeGlyphSet(gsid);
+                    close();
+                });
+            });
+        }, done);
+    });
+});


### PR DESCRIPTION
## The bug

Core `PutImage` — and, with the same code, RENDER `AddGlyphs` — always emitted
the **BIG-REQUESTS** length encoding: a zero in the 16-bit length field followed
by a `CARD32` holding the real length. A server only understands that encoding
once BIG-REQUESTS has been enabled, which `createClient` does automatically at
connect.

So on a connection created with `disableBigRequests: true`, every `PutImage` was
sent as a request the server read as **zero-length** and rejected — the symptom
is a `BadLength` ("Bad length") error, and image upload (and glyph upload) simply
does not work on such a connection. The old code even carried a `// NOTE: … won't
work if not enabled` and a `// TODO: check length, use bigReq`.

## The fix

Both requests now emit the **plain encoding** — valid whether or not
BIG-REQUESTS was negotiated — whenever the request fits the 16-bit length field
(`< 65535` four-byte units, i.e. up to ~256 KB), and fall back to the
BIG-REQUESTS encoding only when the request is genuinely too large to express in
16 bits. Those large requests necessarily require BIG-REQUESTS anyway, so a
`disableBigRequests` client must split them into bands under
`display.max_request_length` — which callers already do (the request layer has
never enforced that limit, and this doesn't change that). A side benefit: a
request that fits is now 4 bytes smaller, and BIG-REQUESTS-enabled clients are
unaffected (a server accepts the plain encoding regardless).

## Testing

New `test/putimage-bigreq.js`, all against a real server:

- small `PutImage` round-trips on a normal connection (unchanged);
- small `PutImage` round-trips with `disableBigRequests` — **this used to fail
  with "Bad length"**;
- a ~196 KB `PutImage` (still under the 16-bit length) round-trips without
  BIG-REQUESTS;
- a >256 KB `PutImage` (needs the BIG-REQUESTS encoding) still round-trips on a
  normal connection;
- a small `AddGlyphs` upload is accepted with `disableBigRequests`.

The existing RENDER suite (which uploads a glyph on a normal connection, now
through the plain-encoding branch) still passes. `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
