### PR TITLE
fix(shm): don't throw when a connection closes mid-attach

### DIFF
--- a/lib/ext/shm.js
+++ b/lib/ext/shm.js
@@ -200,22 +200,47 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(shmseg >>> 0, 4);
             b.writeUInt8(readOnly ? 1 : 0, 8);
             // bytes 9..11 are pad (already zero)
-            X.seq_num++;                    // reserve the sequence now
-            const seq = X.seq_num;
-            if (cb)
-                X.replies[seq] = [null, cb];
+            // Both steps below are asynchronous, and the connection can start
+            // closing while they are in flight — a segment warmed in the
+            // background outliving the app's close() is ordinary, not a corner
+            // case. Issuing a request on a closing client throws, so check
+            // before each step and report it on the callback instead.
+            const gone = () =>
+                X._closing || !X.stream || X.stream.writableEnded || X.stream.destroyed;
             // Flush queued requests to the wire first, then hand the fd to the
             // same socket handle so it is ordered strictly after them.
             X.flush(() => {
+                if (gone()) {
+                    if (cb) cb(new Error('MIT-SHM: connection closed before AttachFd was sent'));
+                    return;
+                }
+                // The sequence number is reserved here, immediately before the
+                // write, and not when the request was built: a number reserved
+                // and then never sent leaves the client one ahead of the server
+                // for the rest of the connection, and every later reply goes to
+                // the wrong callback.
+                X.seq_num++;
+                const seq = X.seq_num;
+                if (cb)
+                    X.replies[seq] = [null, cb];
                 socket.sendFd(b, fd, sendErr => {
                     if (sendErr) {
-                        if (X.replies[seq]) delete X.replies[seq];
+                        delete X.replies[seq];
                         if (cb) cb(sendErr);
+                        return;
+                    }
+                    if (!cb)
+                        return;
+                    if (gone()) {
+                        // the request did reach the socket, so the sequence
+                        // number is spent; only the confirmation is lost
+                        delete X.replies[seq];
+                        cb(new Error('MIT-SHM: connection closed before the segment was attached'));
                         return;
                     }
                     // AttachFd is void: force a round trip so a success is
                     // confirmed and any error has arrived before cb fires.
-                    if (cb) X.GetInputFocus(() => true);
+                    X.GetInputFocus(() => true);
                 });
             });
         }

--- a/test/shm.js
+++ b/test/shm.js
@@ -322,3 +322,39 @@ describe('MIT-SHM disabled (shm: false)', () => {
         });
     });
 });
+
+// A segment attach is asynchronous — the descriptor goes out after a flush,
+// and the confirming round trip after that. A client that closes in between
+// used to make the attach path issue a request on a closing connection, which
+// throws out of a callback and takes the process down. Closing mid-attach must
+// report an error on the callback instead.
+describe('MIT-SHM attach racing connection close', () => {
+    it('reports an error instead of throwing when the client closes mid-attach', function(done) {
+        x11.createClient((err, dpy) => {
+            should.not.exist(err);
+            const X = dpy.client;
+            X.on('error', () => {}); // teardown noise is not the subject
+            X.require('shm', (err, ext) => {
+                should.not.exist(err);
+                if (!ext.provider) {
+                    X.terminate();
+                    return X.on('end', () => done());
+                }
+                let settled = false;
+                ext.createSegment(64 * 1024, err => {
+                    // may succeed (won the race) or fail, but must not throw
+                    settled = true;
+                    if (err) err.should.be.an.Error();
+                });
+                // close() while the attach is still in flight: it sets the
+                // client's closing flag, which is what made the confirming
+                // round trip throw out of the fd-send callback
+                X.close();
+                setTimeout(() => {
+                    settled.should.equal(true, 'the attach callback was answered');
+                    done();
+                }, 300);
+            });
+        });
+    });
+});


### PR DESCRIPTION
A crash in the MIT-SHM segment support released in 3.7.0, found while using it from ntk.

## Symptom

```
Error: client is in closing state
    at XClient.req_proxy [as GetInputFocus]
    at lib/ext/shm.js:218
    at wr.oncomplete (lib/fdpass.js:88)
```

An uncaught throw out of a callback, so it takes the process down.

## Cause

Attaching a segment is asynchronous in two steps — the descriptor goes out after a `flush`, and the round trip that confirms it after that. If the connection starts closing in between, the confirming `GetInputFocus` is issued on a closing client, and issuing any request then throws.

This is easy to reach rather than exotic: a consumer that warms segments in the background — which is the entire point of pooling them — will routinely have one in flight when the app closes. I hit it from ntk with nothing more unusual than `getImageData()` followed by `app.close()`.

## Fix

Both asynchronous steps now check whether the connection is going away and report it on the callback instead of throwing.

The sequence number is also reserved **later** — immediately before the write, rather than when the request is built. Reserving a number and then never sending the request leaves the client permanently one ahead of the server, so every later reply is handed to the wrong callback. That was the second half of the bug: a client that closed mid-attach could hang instead of finishing its close, because the reply its `close()` ping was waiting for had been misrouted. With the reservation moved, a bailed-out attach consumes nothing and the connection closes cleanly.

## Testing

New regression test closes a client while an attach is in flight. It reproduces the crash on the unfixed code (`Uncaught Error: client is in closing state`) and passes here, with the process exiting cleanly rather than hanging. 45 tests pass across `shm`, `render`, `connect` and `callbacks`; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
