### PR TITLE
test: make the suite pass on a real server and stop the Node 22 flake

### DIFF
--- a/test/flow-control.js
+++ b/test/flow-control.js
@@ -119,14 +119,21 @@ describe('flow control', () => {
             ok = X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, chunk);
             writes++;
         }
-        assert.strictEqual(ok, false, `no backpressure after ${writes} writes`);
-        X.once('drain', () => {
+        const finish = () => {
             X.sync(err => {
                 X.DestroyWindow(wid);
                 X.ReleaseID(wid);
                 done(err);
             });
-        });
+        };
+        // A fast server can drain everything as fast as it is written, so
+        // whether the socket ever reports a full buffer is a property of the
+        // machine rather than of this library — see the note on the same
+        // assertion in test/output-buffering.js. When it does back up, 'drain'
+        // must follow and the connection must still work.
+        if (ok)
+            return finish();
+        X.once('drain', finish);
     });
   });
 

--- a/test/output-buffering.js
+++ b/test/output-buffering.js
@@ -493,14 +493,25 @@ describe('output buffering (#244)', () => {
             ok = X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, chunk);
             writes++;
         }
-        assert.strictEqual(ok, false, `no backpressure after ${writes} writes`);
-        X.once('drain', () => {
+        const finish = () => {
             X.sync(err => {
                 X.DestroyWindow(wid);
                 X.ReleaseID(wid);
                 done(err);
             });
-        });
+        };
+        // Whether the socket ever backs up depends on how fast the *server*
+        // drains it, not on anything this library does: on a quick machine
+        // Xvfb consumes these as fast as they can be written and `write()`
+        // never reports a full buffer. That is not a failure, and asserting
+        // otherwise makes this test fail on fast CI runners. The contract
+        // itself — a false return once the socket is full, nothing lost — is
+        // pinned deterministically by the FakeSocket test above; what is worth
+        // checking here is that when a real socket does back up, 'drain'
+        // follows and the connection is still usable afterwards.
+        if (ok)
+            return finish();
+        X.once('drain', finish);
     });
   });
 });

--- a/test/output-buffering.js
+++ b/test/output-buffering.js
@@ -372,12 +372,18 @@ describe('output buffering (#244)', () => {
         X.GetImage(2, pixmap, 0, 0, W, H, 0xffffffff, (err, image) => {
             assert.ifError(err);
             const bytesPP = depth <= 8 ? 1 : (depth <= 16 ? 2 : 4);
+            // A depth-24 image is delivered 4 bytes to the pixel, and the
+            // spare byte is undefined padding — Xvfb leaves it 0, Xorg here
+            // leaves it 0xff. Compare only the bits the depth defines, or the
+            // pixel never matches white_pixel on servers that fill the pad.
+            const mask = depth >= 32 ? 0xffffffff : 2 ** depth - 1;
+            const significant = value => (value % (mask + 1) + (mask + 1)) % (mask + 1);
             let lit = 0;
             for (let y = 0; y < H; y++) {
                 let pixel = 0;
                 for (let i = 0; i < bytesPP; ++i)
-                    pixel += image.data[(y * W + y) * bytesPP + i] << (8 * i);
-                if ((pixel >>> 0) === white) lit++;
+                    pixel += image.data[(y * W + y) * bytesPP + i] * 256 ** i;
+                if (significant(pixel) === significant(white)) lit++;
             }
             assert.strictEqual(lit, H, 'every pixel of the diagonal was drawn');
             // 20 requests, and the reply forced at most one write


### PR DESCRIPTION
Two test-only fixes, both found by running the suite outside CI's Xvfb. No library code changes.

## 1. The `test (22)` flake that has been failing unrelated PRs

```
AssertionError: no backpressure after 4096 writes
true !== false
```

Two real-connection tests wrote until `write()` reported a full socket, and failed if it never did. **Whether that happens is a property of the machine, not of this library.** The writing loop is synchronous, but the server drains concurrently, so on a quick runner Xvfb consumes the requests as fast as they can be written and the buffer never fills. That is why the same commit failed once and passed on rerun ([#269](https://github.com/sidorares/node-x11/pull/269) did exactly that), and why only one Node version in the matrix tended to lose.

The contract they were reaching for — a false return once the socket is full, nothing lost — is **already pinned deterministically** by the `FakeSocket` test in `output-buffering.js`, which controls when the peer accepts data. What a real connection can honestly add is the other half: when a real socket *does* back up, `'drain'` follows and the connection still works. They now assert that, and treat "the server kept up" as the ordinary outcome it is.

## 2. A test that could not pass against a real X server

```
draws the same picture as an unbuffered client:
  every pixel of the diagonal was drawn
  0 !== 16
```

A depth-24 image is delivered **four bytes to the pixel**, and the fourth is padding the X protocol leaves undefined. The test read all four and compared against `white_pixel`, so on a server that fills the pad it saw `0xffffffff` where it expected `0xffffff` and concluded nothing had been drawn. The drawing was correct the whole time.

Xvfb zeroes that byte, which is why CI never caught it. Xorg sets it, so `npx mocha test/output-buffering.js` failed for anyone running the suite against their own display — the first thing a contributor does. Now only the bits the depth defines are compared. The byte assembly also moves off `<<`, which is int32 and turns a `0xff` pad byte negative — a second way the same comparison breaks at depth 32.

## Testing

Against Xorg, `output-buffering.js` goes from 26 passing / 1 failing to **27 passing**, stable across repeated runs, and both backpressure tests pass. Unchanged under Xvfb, where the pad byte was already zero and the socket behaviour is whatever the runner's speed makes it. Lint clean.

(`flow-control.js` still has one failure on my machine — `reports BadAccess when another client owns SubstructureRedirect` — but that is the live window manager owning SubstructureRedirect, reproduces identically on `master`, and is out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
