### PR TITLE
feat(glx): let CreateContext report why it failed

### DIFF
--- a/browser/glx/glx-extension.js
+++ b/browser/glx/glx-extension.js
@@ -9,9 +9,15 @@
       const ext = createGlxExtension({
           backend,             // WebGLBackend or RecordingBackend
           getDrawableSurface,  // see contract below
-          visualId             // GL-capable visual advertised to clients
+          visualId,            // GL-capable visual advertised to clients
+          indirectContexts     // false = act like a server without +iglx
       });
       server.registerExtension('GLX', ext);
+
+  `indirectContexts: false` reproduces the default configuration of Xorg
+  >= 1.17 and Xwayland: queries all answer normally, and context creation
+  alone fails with BadValue, value 0. Useful for testing what a client does
+  on the servers most people actually have.
 
   Framework contract (matches lib/xserver's registerExtension, but kept
   duck-typed so the extension also runs against a minimal fake in tests):
@@ -204,9 +210,21 @@ function createGlxExtension(options = {}) {
                 ext.majorOpcode, minor);
     }
 
+    // core BadValue, which is not in the extension's error range
+    const BAD_VALUE = 2;
+
     // ---- bookkeeping helpers ---------------------------------------------
 
-    function registerContext(xid) {
+    // With options.indirectContexts false the emulator behaves like a server
+    // started without +iglx: every query request still works, and context
+    // creation alone fails with BadValue, value 0 — the shape real Xorg and
+    // Xwayland produce, and the only signal a client has to go on.
+    function registerContext(xid, client, minor) {
+        if (options.indirectContexts === false) {
+            if (typeof client.sendError === 'function')
+                client.sendError(BAD_VALUE, 0, ext.majorOpcode, minor);
+            return;
+        }
         contexts.set(xid, {
             xid: xid,
             decoder: new RenderDecoder(backend),
@@ -355,11 +373,11 @@ function createGlxExtension(options = {}) {
     // minor 16 (VendorPrivate, no reply); body: code@0, then per-vop layout.
     // The generic form carries contextTag@4 and data from 8; the SGIX
     // requests keep that 12-byte header shape with payload from body 8.
-    function vendorPrivate(client, body) {
+    function vendorPrivate(client, body, minor) {
         const code = body.readUInt32LE(0);
         switch (code) {
         case vop.CreateContextWithConfigSGIX:
-            registerContext(body.readUInt32LE(8));
+            registerContext(body.readUInt32LE(8), client, minor);
             break;
         case vop.CreateGLXPixmapWithConfigSGIX:
             glxDrawables.set(body.readUInt32LE(20), {
@@ -461,7 +479,7 @@ function createGlxExtension(options = {}) {
         }
 
         case 3:     // CreateContext: ctx, visual, screen, shareList, isDirect
-            return registerContext(body.readUInt32LE(0));
+            return registerContext(body.readUInt32LE(0), client, minor);
 
         case 4:     // DestroyContext
             return contexts.delete(body.readUInt32LE(0));
@@ -507,7 +525,7 @@ function createGlxExtension(options = {}) {
             return glxDrawables.delete(body.readUInt32LE(0));
 
         case 16:    // VendorPrivate
-            return vendorPrivate(client, body);
+            return vendorPrivate(client, body, minor);
 
         case 17:    // VendorPrivateWithReply
             return vendorPrivateWithReply(client, body);
@@ -538,7 +556,7 @@ function createGlxExtension(options = {}) {
             });
 
         case 24:    // CreateNewContext: ctx, fbconfig, screen, renderType, ...
-            return registerContext(body.readUInt32LE(0));
+            return registerContext(body.readUInt32LE(0), client, minor);
 
         case 25:    // QueryContext -> attribute pairs
             return attribPairsReply(client, [
@@ -574,7 +592,7 @@ function createGlxExtension(options = {}) {
             });
 
         case 34:    // CreateContextAttribsARB
-            return registerContext(body.readUInt32LE(0));
+            return registerContext(body.readUInt32LE(0), client, minor);
 
         // ---- GL single requests (contextTag at body 0, args from 4) ------
 

--- a/docs/ext/glx.md
+++ b/docs/ext/glx.md
@@ -26,7 +26,11 @@ the X connection. Modern X servers (Xorg ≥ 1.17, XQuartz, Xvfb) ship with
 indirect GLX contexts **disabled**; `CreateContext` then fails with
 `Bad param value` (BadValue, value 0) and every context operation after it
 fails with `GLXBadContext`. Query requests (`QueryVersion`, `GetFBConfigs`,
-...) work regardless.
+...) work regardless — which is what makes this confusing to diagnose: the
+extension is present, reports GLX 1.4 and offers a full set of fbconfigs.
+The `BadValue` from `CreateContext` is the only signal, so pass that request
+a callback (see [CreateContext](#createcontextctx-visual-screen-sharelistctx-isdirect-cb))
+rather than inferring the state from the `GLXBadContext` fallout.
 
 - **XQuartz (macOS)**:
 
@@ -152,10 +156,27 @@ Opcode 2. One GL command too big for `Render`, split into `requestTotal`
 parts; `requestNum` is 1-based. `data` is padded to 4 bytes automatically.
 No reply. Used internally by the pipeline's `TexImage2D`.
 
-### CreateContext(ctx, visual, screen, shareListCtx, isDirect)
+### CreateContext(ctx, visual, screen, shareListCtx, isDirect, [cb])
 Opcode 3. Creates GLX context `ctx` (client-allocated XID) for `visual`.
 `shareListCtx` shares display lists (0 for none); pass `isDirect` 0 — this
 client renders indirectly. No reply.
+
+`cb(err)` is optional and reports failure: it gets the X error, or `null`
+once a later packet proves the server got past this request. Return truthy
+from it to claim the error, otherwise it still reaches `client.on('error')`
+— the same contract as a core void request. Worth using: a server without
+`+iglx` answers `BadValue` with `badParam` 0 here (see [server
+setup](#server-setup-indirect-glx-must-be-enabled)), and without a callback
+that is an unattributed error followed by a misleading `GLXBadContext` from
+whatever context request you send next.
+
+```js
+GLX.CreateContext(ctx, visual, 0, 0, 0, err => {
+    if (err && err.error === 2 && err.badParam === 0)
+        console.log('this server refuses indirect GLX contexts (needs +iglx)');
+    return true; // handled
+});
+```
 
 ### DestroyContext(ctx)
 Opcode 4. No reply.
@@ -268,9 +289,10 @@ Opcode 22 (GLX 1.3 fbconfig flavour of CreateGLXPixmap). No reply.
 ### DestroyPixmap(glxpixmap)
 Opcode 23. No reply.
 
-### CreateNewContext(ctx, fbconfig, screen, renderType, shareListCtx, isDirect)
+### CreateNewContext(ctx, fbconfig, screen, renderType, shareListCtx, isDirect, [cb])
 Opcode 24. GLX 1.3 context creation from an fbconfig. `renderType` is
-`GLX.glxAttrib.RGBA_TYPE` or `COLOR_INDEX_TYPE`. No reply.
+`GLX.glxAttrib.RGBA_TYPE` or `COLOR_INDEX_TYPE`. No reply; optional `cb(err)`
+as in [CreateContext](#createcontextctx-visual-screen-sharelistctx-isdirect-cb).
 
 ### QueryContext(ctx, cb)
 Opcode 25. `cb(err, attribs)` — `{FBCONFIG_ID, VISUAL_ID, SCREEN,
@@ -307,10 +329,12 @@ Opcode 32. No reply.
 Opcode 33 (GLX_ARB_create_context). `versions` is `[[major, minor], ...]`
 of supported GL versions. No reply.
 
-### CreateContextAttribsARB(ctx, fbconfig, screen, shareListCtx, isDirect, attribs)
+### CreateContextAttribsARB(ctx, fbconfig, screen, shareListCtx, isDirect, attribs, [cb])
 Opcode 34 (GLX_ARB_create_context). Attribute-driven context creation;
 codes in `GLX.glxAttrib.CONTEXT_*` (e.g. `CONTEXT_MAJOR_VERSION_ARB`,
-`CONTEXT_PROFILE_MASK_ARB`), values in `GLX.glxConst`. No reply.
+`CONTEXT_PROFILE_MASK_ARB`), values in `GLX.glxConst`. No reply; optional
+`cb(err)` as in
+[CreateContext](#createcontextctx-visual-screen-sharelistctx-isdirect-cb).
 
 ### SetClientInfo2ARB(major, minor, versions, glExtensions, glxExtensions)
 Opcode 35. Like `SetClientInfoARB` but `versions` entries are

--- a/lib/ext/glx.js
+++ b/lib/ext/glx.js
@@ -416,6 +416,20 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.submit(expectsReply);
         }
 
+        // A void request only hears back when it fails, so an optional
+        // callback registers with the core client's void bookkeeping (issue
+        // #85): it gets the X error, or null once a later packet proves the
+        // server got past this sequence number. Same contract as a core void
+        // request — return truthy from the callback to claim the error,
+        // otherwise it still reaches client.on('error').
+        function sendVoid(b, callback) {
+            if (callback) {
+                X.replies[X.seq_num] = [null, callback];
+                X._scheduleVoidSync(X.seq_num);
+            }
+            send(b);
+        }
+
         // reply unpackers get the reply starting at byte 8 of the raw 32-byte
         // header: buf[0..24) = header bytes 8..32, variable data from buf[24]
         function sendWithReply(b, unpack, callback) {
@@ -472,15 +486,16 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.submit();
         };
 
-        // opcode 3
-        ext.CreateContext = (ctx, visual, screen, shareListCtx, isDirect) => {
+        // opcode 3; the optional callback reports failure — notably the
+        // BadValue (value 0) a server without +iglx answers with
+        ext.CreateContext = (ctx, visual, screen, shareListCtx, isDirect, callback) => {
             const b = req(3, 24);
             b.writeUInt32LE(ctx >>> 0, 4);
             b.writeUInt32LE(visual >>> 0, 8);
             b.writeUInt32LE(screen >>> 0, 12);
             b.writeUInt32LE(shareListCtx >>> 0, 16);
             b.writeUInt8(isDirect ? 1 : 0, 20);
-            send(b);
+            sendVoid(b, callback);
         };
 
         // opcode 4
@@ -721,8 +736,9 @@ exports.requireExt = (display, callback) => {
             send(b);
         };
 
-        // opcode 24; renderType: GLX.glxAttrib.RGBA_TYPE or COLOR_INDEX_TYPE
-        ext.CreateNewContext = (ctx, fbconfig, screen, renderType, shareListCtx, isDirect) => {
+        // opcode 24; renderType: GLX.glxAttrib.RGBA_TYPE or COLOR_INDEX_TYPE.
+        // Optional callback as in CreateContext.
+        ext.CreateNewContext = (ctx, fbconfig, screen, renderType, shareListCtx, isDirect, callback) => {
             const b = req(24, 28);
             b.writeUInt32LE(ctx >>> 0, 4);
             b.writeUInt32LE(fbconfig >>> 0, 8);
@@ -730,7 +746,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(renderType >>> 0, 16);
             b.writeUInt32LE(shareListCtx >>> 0, 20);
             b.writeUInt8(isDirect ? 1 : 0, 24);
-            send(b);
+            sendVoid(b, callback);
         };
 
         // opcode 25; callback gets object keyed by attribute name
@@ -831,8 +847,9 @@ exports.requireExt = (display, callback) => {
         };
 
         // opcode 34 (GLX_ARB_create_context); attribs: flat [attribute, value,
-        // ...] using GLX.glxAttrib.CONTEXT_* codes
-        ext.CreateContextAttribsARB = (ctx, fbconfig, screen, shareListCtx, isDirect, attribs) => {
+        // ...] using GLX.glxAttrib.CONTEXT_* codes. Optional callback as in
+        // CreateContext.
+        ext.CreateContextAttribsARB = (ctx, fbconfig, screen, shareListCtx, isDirect, attribs, callback) => {
             attribs = attribs || [];
             const b = req(34, 28 + attribs.length * 4);
             b.writeUInt32LE(ctx >>> 0, 4);
@@ -842,7 +859,7 @@ exports.requireExt = (display, callback) => {
             b.writeUInt8(isDirect ? 1 : 0, 20);
             b.writeUInt32LE(attribs.length / 2, 24);
             writeAttribs(b, 28, attribs);
-            send(b);
+            sendVoid(b, callback);
         };
 
         // opcode 35; like SetClientInfoARB but versions are

--- a/test/glx.js
+++ b/test/glx.js
@@ -208,17 +208,43 @@ describe('GLX extension', function() {
         }));
     });
 
+    // The callback is what makes "this server refuses indirect contexts"
+    // diagnosable: every query request succeeds on such a server, so the
+    // BadValue from CreateContext is the only signal, and without a callback
+    // it arrives unattributed on client.on('error').
+    it('CreateContext should report success or failure through its callback', function(done) {
+        const GLX = this.GLX;
+        if (!this.visualConfig || this.connDead)
+            return this.skip();
+        const probe = this.X.AllocID();
+        GLX.CreateContext(probe, this.visualConfig.visualID, 0, 0, 0, guard(done, (err) => {
+            if (!err)
+                GLX.DestroyContext(probe);
+            else {
+                // BadValue (2), value 0: indirect GLX contexts disabled
+                err.error.should.equal(2);
+                err.majorOpcode.should.equal(GLX.majorOpcode);
+                err.minorOpcode.should.equal(3);
+                err.badParam.should.equal(0);
+            }
+            done();
+            return true; // handled: keep it off client.on('error')
+        }));
+    });
+
     describe('indirect contexts', function() {
         // probe whether the server allows indirect GLX contexts; skip the
-        // whole block otherwise (servers not started with +iglx)
+        // whole block otherwise (servers not started with +iglx). The
+        // CreateContext callback is the direct answer — a server that
+        // refuses indirect contexts fails it with BadValue, value 0
         before(function(done) {
             const self = this;
             const GLX = this.GLX;
             if (!this.visualConfig || this.connDead)
                 return done();
             const probe = this.X.AllocID();
-            GLX.CreateContext(probe, this.visualConfig.visualID, 0, 0, 0);
-            GLX.IsDirect(probe, (err) => {
+            GLX.CreateContext(probe, this.visualConfig.visualID, 0, 0, 0, (err) => {
+                self.iglxError = err;
                 self.hasIndirect = !err;
                 if (!err)
                     GLX.DestroyContext(probe);


### PR DESCRIPTION
## Why

A server with indirect GLX disabled — the default for Xorg >= 1.17 and Xwayland, so most desktops — is oddly hard to recognise. Probing my own XWayland session:

| probe | result |
| --- | --- |
| `QueryExtension('GLX')` | present, opcode 149 |
| `QueryVersion` | 1.4 |
| `QueryServerString VENDOR` | SGI |
| `GetFBConfigs` | **140 configs** |
| `GetVisualConfigs` | **100 configs** |
| **`CreateContext`** | **BadValue, minor 3, value 0** |
| `IsDirect` | GLXBadContext (fallout) |

Every query says yes. The `BadValue` from `CreateContext` is the only signal — and it had nowhere to go, because `CreateContext` has no reply. It surfaced on `client.on('error')` with nothing tying it to the request, and whatever context call came next added a `GLXBadContext` about a context that was never created:

```
unhandled X error: Bad param value (opcode 149, seq 87)
unhandled X error: GLXBadContext (opcode 149, seq 88)
```

The natural reading of that is "something is wrong with my context", which is a dead end.

## What

- `CreateContext`, `CreateNewContext` and `CreateContextAttribsARB` take an optional trailing `cb(err)`, registered through the void-request bookkeeping already there for core requests (#85): it gets the X error, or `null` once a later packet proves the server got past it. Same contract as a core void request — return truthy to claim the error, otherwise it still reaches `client.on('error')`.
- The GLX emulator (`browser/glx`) gains `indirectContexts: false`, which reproduces a server without `+iglx`: queries answer normally, context creation alone fails with BadValue 0. That makes this configuration testable without an X server that has it.
- `test/glx.js` probes with the callback instead of inferring the answer from a follow-up `IsDirect`, plus a test asserting the callback fires either way.
- `docs/ext/glx.md` documents the callback and points the "server setup" section at it.

Downstream this is what turns three cryptic lines into one diagnosis — ntk uses it to send `CreateContext` on its own, wait, and skip `MakeCurrent` entirely when it failed.

`err.error === 2 && err.minorOpcode === 3 && err.badParam === 0` is specific to this cause: other `CreateContext` rejections name the value they disliked (a bad visual id) or return `GLXBadContext` (a bad share list).

## Testing

- `npm run test:glx-emu` 52 passing, `npm run test:xserver` 284 passing.
- `test/glx.js` against a nested `Xwayland :5 +iglx` (CreateContext OK) and against the session's `:0` (BadValue 0) — the classifier fires in both directions.
- The pre-existing `indirect contexts` hook failure on Ubuntu is unrelated: this distro's Xvfb and Xwayland both segfault on indirect `MakeCurrent`, which `docs/ext/glx.md` already warns about. Verified against a stashed baseline.