### PR TITLE
feat(dri3): direct rendering — DRI3 protocol, fd-carrying request queue, Present examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-x11
 
-X11 protocol client for Node.js: implements the core X11 protocol, as well as Xrender, Damage, Composite, Big-Requests, Dpms, Screensaver, XFixes, Shape, XTest, XC-Misc, GLX, and Apple-WM extensions.
+X11 protocol client for Node.js: implements the core X11 protocol, as well as Xrender, Damage, Composite, Big-Requests, Dpms, Screensaver, XFixes, Shape, XTest, XC-Misc, GLX, DRI3, Present, and Apple-WM extensions — including the modern direct-rendering path (GPU frames as dma-buf pixmaps via DRI3 + Present, see [docs/ext/dri3.md](docs/ext/dri3.md)).
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sidorares/node-x11?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![CI](https://github.com/sidorares/node-x11/actions/workflows/ci.yml/badge.svg)](https://github.com/sidorares/node-x11/actions/workflows/ci.yml)

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,8 +70,8 @@ The `display` passed to the callback describes the connection setup block:
   `GetImage`/`PutImage`.
 - `display.isLocalSocket` — true only for a same-machine unix-socket
   connection (not TCP, not an injected/custom transport). Same-host fast paths
-  such as [MIT-SHM](ext/shm.md) gate on it (necessary, not sufficient — the
-  segment still has to attach).
+  such as [MIT-SHM](ext/shm.md) and [DRI3](ext/dri3.md) gate on it (necessary,
+  not sufficient — the segment still has to attach, the buffer to import).
 
 ## Making requests
 
@@ -296,6 +296,7 @@ extension name. Requiring an extension twice returns the cached instance.
 | `damage` | DAMAGE | [ext/damage.md](ext/damage.md) |
 | `dbe` | DOUBLE-BUFFER | [ext/dbe.md](ext/dbe.md) |
 | `dpms` | DPMS | [ext/dpms.md](ext/dpms.md) |
+| `dri3` | DRI3 | [ext/dri3.md](ext/dri3.md) |
 | `fixes` | XFIXES | [ext/fixes.md](ext/fixes.md) |
 | `ge` | Generic Event Extension | [ext/ge.md](ext/ge.md) |
 | `glx` | GLX | [ext/glx.md](ext/glx.md) |

--- a/docs/ext/dri3.md
+++ b/docs/ext/dri3.md
@@ -1,0 +1,143 @@
+# DRI3 extension
+
+Direct Rendering Infrastructure, take 3: the descriptor-passing half of the
+modern OpenGL/Vulkan path on X. The client renders on the GPU itself —
+entirely outside the X protocol — exports each finished buffer as a **dma-buf
+file descriptor**, wraps it into an X pixmap with `PixmapFromBuffer`, and puts
+it on screen with the [Present extension](present.md). No pixel data ever
+crosses the socket; the server imports the very memory the client rendered to.
+
+```
+GPU (render node)                        X server
+-----------------                        --------
+render into a buffer
+export -> dma-buf fd  --- fd over unix socket (DRI3) --->  pixmap
+Present.Pixmap(window, pixmap)  ------ vsync'd flip/copy -> on screen
+                    <--- PresentCompleteNotify   (pace the next frame)
+                    <--- PresentIdleNotify       (buffer reusable)
+```
+
+This is what Mesa does under every GL/Vulkan application on modern Xorg and
+Xwayland, and the successor to indirect [GLX](glx.md) (GL 1.x serialized
+through the server, one round trip per batch — still supported by this
+library, see `examples/opengl/glxgears.js`, but capped at what X11R6 could
+say on the wire).
+
+- Module: `X.require('dri3', cb)` (X name `DRI3`, version 1.4 announced by
+  the client)
+- Source: [`lib/ext/dri3.js`](../../lib/ext/dri3.js) ·
+  Tests: [`test/dri3.js`](../../test/dri3.js) (encoding, no server needed),
+  [`test/dri3-live.js`](../../test/dri3-live.js) (against a DRI3 server)
+- Spec: [dri3proto.txt](https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/dri3proto.txt)
+- Working samples: [`examples/dri3/`](../../examples/dri3/) — a
+  self-contained folder (own `package.json`, `npm install && npm start`)
+  with [`cube.js`](../../examples/dri3/cube.js) (GPU, spinning cube) and
+  [`software.js`](../../examples/dri3/software.js) (CPU pixels through
+  udmabuf)
+
+```js
+X.require('dri3', (err, DRI3) => {
+    const pixmap = X.AllocID();
+    DRI3.PixmapFromBuffer(pixmap, wid, {
+        fd: dmabufFd,          // consumed by the send
+        width: 512, height: 512,
+        stride: 2048,          // bytes per row, as the producer reports it
+        depth: 24, bpp: 32
+    }, err => {
+        if (err) throw err;    // server could not import this buffer
+        Present.Pixmap(wid, pixmap, { serial: 1 });
+    });
+});
+```
+
+Where the dma-buf comes from is up to the producer: a GBM/EGL swapchain, a
+Vulkan exporter, a V4L2 camera, the kernel's udmabuf device. The optional
+native companion package [`x11-dri`](https://github.com/sidorares/node-x11-dri)
+(`npm install x11-dri`) provides two such producers (an OpenGL ES 2 renderer
+and udmabuf) plus `dup()`; the `x11` package itself stays pure JS.
+
+## Descriptors only flow client → server
+
+Requests that *send* descriptors (`PixmapFromBuffer`, `PixmapFromBuffers`,
+`FenceFromFD`, `ImportSyncobj`) work on any fd-capable connection — the
+default for local unix-socket displays (see `lib/fdpass.js`). The descriptors
+are **consumed**: closed once written, whether the write succeeded or not,
+matching how they are produced (`gbm_bo_get_fd` returns a fresh fd whose only
+purpose is this send). Keep a copy with `dup()` first if you need one.
+
+The four requests whose **replies carry descriptors** — `Open`,
+`BufferFromPixmap`, `FDFromFence`, `BuffersFromPixmap` — are not wired: a
+descriptor arriving on the connection aborts the Node process before any JS
+runs (the libuv abort described in `lib/fdpass.js`), so they report an error
+instead of touching the wire. In practice none of them is needed:
+
+- instead of `Open` (get a DRM device fd from the server), open a **render
+  node** directly — `fs.openSync('/dev/dri/renderD128', 'r+')` — which
+  requires no X-side authentication at all. On multi-GPU machines probe each
+  `/dev/dri/renderD*`: import a small test buffer with
+  `PixmapFromBuffer(..., cb)` and use the device whose import succeeds.
+- instead of `BufferFromPixmap`/`BuffersFromPixmap` (export server pixmaps),
+  create the buffers client-side and import them.
+
+`DRI3.fdCapable` tells whether this connection can send descriptors at all
+(false on TCP or on a transport without the fd-capable socket).
+
+## Requests
+
+### QueryVersion(clientMajor, clientMinor, cb)
+Negotiates the protocol version; `cb(err, [major, minor])`. Called
+automatically while requiring (announcing 1.4); the result is cached on
+`DRI3.major` / `DRI3.minor`. Gate 1.2+/1.3+/1.4+ requests on `DRI3.minor`.
+
+### PixmapFromBuffer(pixmap, drawable, opts, cb?)
+Creates `pixmap` (a fresh XID) on `drawable`'s screen from a dma-buf.
+`opts` is `{fd, width, height, stride, depth, bpp, size?}` — `stride` in
+bytes as the buffer's producer reports it, `size` defaulting to
+`stride * height`. The `fd` is consumed. Void; with `cb` a round trip is
+forced and `cb(err|null)` reports whether the server accepted the import — a
+server on an incompatible device answers `BadValue`/`BadMatch`/`BadAlloc`,
+which is also the sanctioned way to probe device compatibility. The buffer's
+layout is the driver-negotiated ("implicit") one; use `PixmapFromBuffers` to
+state it explicitly.
+
+### PixmapFromBuffers(pixmap, window, opts, cb?) — DRI3 ≥ 1.2
+Multi-planar, modifier-aware variant. `opts` is `{width, height, depth, bpp,
+modifier, planes}` with `planes` an array of 1–4 `{fd, stride, offset}` and
+`modifier` a `DRM_FORMAT_MOD_*` value as **BigInt** (or number; see
+constants below). All plane fds are consumed. `cb` as above.
+
+### GetSupportedModifiers(window, depth, bpp, cb) — DRI3 ≥ 1.2
+`cb(err, { windowModifiers, screenModifiers })`, both arrays of **BigInt**
+format modifiers the server can import for that window/screen at this
+depth/bpp. Empty arrays mean "implicit only" — use `PixmapFromBuffer`.
+
+### FenceFromFD(drawable, fence, initiallyTriggered, fd, cb?)
+Creates SYNC fence `fence` (fresh XID) from a client-supplied fence fd, for
+use as `waitFence`/`idleFence` in `Present.Pixmap`. The fd is consumed.
+
+### SetDRMDeviceInUse(window, drmMajor, drmMinor, cb?) — DRI3 ≥ 1.3
+Hint: this window's buffers will come from the DRM device with that
+major/minor (`fs.fstatSync(fd).rdev` decoded). Void.
+
+### ImportSyncobj(syncobj, drawable, fd, cb?) / FreeSyncobj(syncobj, cb?) — DRI3 ≥ 1.4
+Imports (and frees) a DRM timeline syncobj for explicit synchronization with
+Present 1.4 servers. The fd is consumed.
+
+### Open / BufferFromPixmap / FDFromFence / BuffersFromPixmap
+Refused with an explanatory error — their replies carry descriptors (see
+above).
+
+## Constants
+
+- `DRI3.FormatModifier.Invalid` — `DRM_FORMAT_MOD_INVALID` (2⁵⁶−1), "layout
+  is implicit, negotiated by the drivers".
+- `DRI3.FormatModifier.Linear` — `DRM_FORMAT_MOD_LINEAR` (0n), plain
+  row-major.
+
+Modifiers use the full 64-bit range (vendor code in the top byte), beyond
+`Number`'s 53-bit exactness — hence BigInt on this API.
+
+## Errors
+
+DRI3 defines no errors of its own; imports fail with core `BadValue`,
+`BadMatch` or `BadAlloc` on the `PixmapFromBuffer(s)` sequence number.

--- a/docs/ext/glx.md
+++ b/docs/ext/glx.md
@@ -1,6 +1,11 @@
 # GLX extension
 
-OpenGL rendering over the X protocol (indirect rendering). The module covers
+OpenGL rendering over the X protocol (indirect rendering). This is the
+legacy path — every GL call is serialized through the server and capped at
+GL 1.x; modern servers only enable it when started with `+iglx`. For the
+modern path (client-side GPU rendering, dma-buf pixmaps, vsync'd
+presentation) see [DRI3](dri3.md) + [Present](present.md) and
+`examples/dri3/cube.js`. The module covers
 the full GLX 1.4 core request set (context, drawable and pbuffer management,
 single-op GL queries, `Render`/`RenderLarge` command batching), the
 `GLX_ARB_create_context` requests, and the vendor-private requests of the

--- a/docs/ext/shm.md
+++ b/docs/ext/shm.md
@@ -177,10 +177,10 @@ server has processed it or `cb(err)` if it failed (an attach can raise
 
 ### AttachFd(shmseg, fd, readOnly, cb?)
 Like `Attach`, but hands the server the open file descriptor `fd` (a regular
-file or memfd you keep owning) instead of a SysV id. Needs `fdCapable`. Because
-the descriptor is written out of band, **no other request may be issued between
-`AttachFd(...)` and its callback** — `createSegment` observes this for you. Void;
-`cb` as for `Attach`. (SHM 1.2.)
+file or memfd you keep owning — what actually travels is a self-dup made
+through `/proc/self/fd`) instead of a SysV id. Needs `fdCapable`. The request
+rides the ordinary output queue like any other, so it may be freely mixed with
+other requests. Void; `cb` as for `Attach`. (SHM 1.2.)
 
 ### Detach(shmseg, cb?)
 Detaches the segment from the server; the SEG XID becomes invalid. Void, `cb` as

--- a/examples/dri3/.gitignore
+++ b/examples/dri3/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/examples/dri3/README.md
+++ b/examples/dri3/README.md
@@ -1,0 +1,60 @@
+# Direct rendering: X11 window + GPU OpenGL through DRI3 + Present
+
+A spinning cube, rendered with OpenGL ES 2 **on the GPU** and shown in an
+ordinary X11 window — the modern path Mesa uses under every GL app, spoken
+here from Node: the window, events and presentation are the pure-JS
+[`x11`](https://github.com/sidorares/node-x11) package (DRI3 + Present
+extensions over the ordinary unix socket, descriptors and all), the GL
+context and dma-buf export are the small native companion
+[`x11-dri`](https://github.com/sidorares/node-x11-dri).
+
+```
+GPU (render node)                        X server
+-----------------                        --------
+glDraw... into a GBM buffer
+swap() -> dma-buf fd  ---- fd over unix socket (DRI3) --->  pixmap
+Present.Pixmap(window, pixmap)  ------ vsync'd flip/copy --> on screen
+                     <---- PresentCompleteNotify  (paces the next frame)
+                     <---- PresentIdleNotify      (buffer reusable)
+```
+
+No pixel data ever crosses the socket. Compare `../opengl/glxgears.js` —
+indirect GLX, where every GL call is serialized through the server and GL is
+capped at 1.x.
+
+## Run it
+
+```sh
+npm install     # x11 from this repo, x11-dri built by node-gyp (no headers needed)
+npm start       # the cube, vsync-paced
+```
+
+Also:
+
+```sh
+npm run start:async   # unthrottled presents (vblank_mode=0 flavor), prints fps
+npm run software      # no GPU: CPU-rasterized 3D through udmabuf, same path
+```
+
+`q` / `Escape` quits. Resize the window — the swapchain follows.
+
+## Requirements
+
+- Linux, a DRM render node (`/dev/dri/renderD*`) readable by you, and a
+  server with DRI3 + Present: Xorg with glamor, or Xwayland. (Xvfb and
+  Xephyr have no DRI3 — the example says so and exits.)
+- `npm install` builds `x11-dri` with node-gyp: a C toolchain is all it
+  takes; Mesa's libgbm/libEGL/libGLESv2 are dlopen'd at runtime.
+
+## If something looks off
+
+- **~1 fps and `(Copy, msc …)` creeping**: the compositor is throttling
+  frame callbacks (headless/idle sessions do this — Xwayland then falls back
+  to a 1 Hz timer). The pipeline is fine; `npm run start:async` will show
+  the real throughput.
+- **`server could not import the GPU buffer`**: client and server sit on
+  different DRM devices. Set `devicePath` in `new dri.Gpu({...})` to another
+  `/dev/dri/renderD*`, or create the surface with `dri.GBM_USE.LINEAR`.
+- **`software.js` reports the server cannot import CPU dma-bufs**: typical
+  on virtualized GPUs (virgl) — the driver cannot wrap guest RAM. On real
+  hardware (Intel/AMD, Xorg+glamor or Xwayland) it runs.

--- a/examples/dri3/cube.js
+++ b/examples/dri3/cube.js
@@ -1,0 +1,467 @@
+// Direct rendering, the modern way: a spinning cube drawn with OpenGL ES 2
+// on the GPU and shown through DRI3 + Present — the same path Mesa's own
+// EGL/X11 backend uses, reimplemented in JavaScript.
+//
+// How it works, per frame:
+//
+//   GPU (render node)                      X server
+//   -----------------                      --------
+//   glDraw... into a GBM buffer
+//   swap() -> dma-buf fd  ---- fd over unix socket (DRI3) ---> pixmap
+//   Present.Pixmap(window, pixmap)  ------ vsync'd flip/copy -> on screen
+//                       <---- PresentCompleteNotify (pace the next frame)
+//                       <---- PresentIdleNotify     (buffer reusable)
+//
+// No pixel data ever crosses the socket — only descriptors and 32-byte
+// events. Compare examples/opengl/glxgears.js (indirect GLX: every GL call
+// serialized through the server, GL 1.x only) with this file (any GLES the
+// GPU speaks, zero-copy).
+//
+// Needs: a Linux host with a DRM render node (/dev/dri/renderD*) and a
+// server with DRI3+Present (Xorg with glamor, or Xwayland). Run it from this
+// folder — see README.md:
+//
+//     npm install && npm start
+//
+// Keys: q / Escape quit.
+//
+// By default frames are paced by the server (PresentCompleteNotify at the
+// display's refresh — or slower on a throttled/headless compositor). Run with
+// --async to present unthrottled (Present.Option.Async), the vblank_mode=0
+// of this world.
+
+const x11 = require('x11');
+
+let dri;
+try {
+    dri = require('x11-dri');
+} catch (e) {
+    console.error('The native companion is not installed. Run `npm install` in this folder.');
+    console.error('(x11-dri: https://github.com/sidorares/node-x11-dri — builds anywhere with a C toolchain)');
+    console.error(`(${e.message})`);
+    process.exit(1);
+}
+
+const START_W = 480;
+const START_H = 360;
+const ASYNC = process.argv.includes('--async');
+
+// ---------------------------------------------------------------------------
+// Tiny column-major mat4 (just enough for one cube)
+// ---------------------------------------------------------------------------
+
+const mat4 = {
+    perspective(fovy, aspect, near, far) {
+        const f = 1 / Math.tan(fovy / 2);
+        const nf = 1 / (near - far);
+        return new Float32Array([
+            f / aspect, 0, 0, 0,
+            0, f, 0, 0,
+            0, 0, (far + near) * nf, -1,
+            0, 0, 2 * far * near * nf, 0
+        ]);
+    },
+    multiply(a, b) { // a * b
+        const out = new Float32Array(16);
+        for (let c = 0; c < 4; c++)
+            for (let r = 0; r < 4; r++)
+                out[c * 4 + r] =
+                    a[r] * b[c * 4] + a[4 + r] * b[c * 4 + 1] +
+                    a[8 + r] * b[c * 4 + 2] + a[12 + r] * b[c * 4 + 3];
+        return out;
+    },
+    rotateXY(ax, ay) {
+        const cx = Math.cos(ax), sx = Math.sin(ax);
+        const cy = Math.cos(ay), sy = Math.sin(ay);
+        // Ry * Rx
+        return new Float32Array([
+            cy, 0, -sy, 0,
+            sx * sy, cx, sx * cy, 0,
+            cx * sy, -sx, cx * cy, 0,
+            0, 0, 0, 1
+        ]);
+    },
+    translateZ(z) {
+        const out = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, z, 1]);
+        return out;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Cube geometry: 24 vertices (x,y,z,r,g,b), 36 indices
+// ---------------------------------------------------------------------------
+
+function cubeGeometry() {
+    const faces = [
+        // normal axis, sign, color
+        { axis: 2, sign: 1, color: [0.90, 0.30, 0.24] },  // +z red
+        { axis: 2, sign: -1, color: [0.20, 0.60, 0.86] }, // -z blue
+        { axis: 0, sign: 1, color: [0.18, 0.80, 0.44] },  // +x green
+        { axis: 0, sign: -1, color: [0.95, 0.77, 0.06] }, // -x yellow
+        { axis: 1, sign: 1, color: [0.61, 0.35, 0.71] },  // +y purple
+        { axis: 1, sign: -1, color: [0.90, 0.49, 0.13] }  // -y orange
+    ];
+    const verts = [];
+    const idx = [];
+    faces.forEach((f, fi) => {
+        const corners = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+        corners.forEach(([u, v]) => {
+            const p = [0, 0, 0];
+            p[f.axis] = f.sign;
+            p[(f.axis + 1) % 3] = f.sign > 0 ? u : -u; // keep faces CCW from outside
+            p[(f.axis + 2) % 3] = v;
+            verts.push(p[0], p[1], p[2], f.color[0], f.color[1], f.color[2]);
+        });
+        const b = fi * 4;
+        idx.push(b, b + 1, b + 2, b, b + 2, b + 3);
+    });
+    return { verts: new Float32Array(verts), idx: new Uint16Array(idx) };
+}
+
+// ---------------------------------------------------------------------------
+
+x11.createClient((err, display) => {
+    if (err) throw err;
+    const X = display.client;
+    const screen = display.screen[0];
+    const root = screen.root;
+    const depth = screen.root_depth;
+
+    if (depth !== 24 && depth !== 32) {
+        console.error(`root depth ${depth} — this example expects a 24/32-bit screen`);
+        return X.terminate();
+    }
+
+    X.require('dri3', (err, DRI3) => {
+        if (err) {
+            console.error('DRI3 not available:', err.message);
+            console.error('(Xvfb/Xephyr have no DRI3; run under Xorg or Xwayland.)');
+            return X.terminate();
+        }
+        if (!DRI3.fdCapable) {
+            console.error('connection cannot pass descriptors (remote/TCP display?)');
+            return X.terminate();
+        }
+        X.require('present', (err, Present) => {
+            if (err) throw err;
+            start(X, screen, root, depth, DRI3, Present);
+        });
+    });
+}).on('error', err => {
+    // window killed by the WM, server gone, etc.
+    console.error('X connection:', err.message || err);
+    process.exit(0);
+});
+
+function start(X, screen, root, depth, DRI3, Present) {
+    // --- GPU ---------------------------------------------------------------
+    let gpu;
+    try {
+        gpu = new dri.Gpu({
+            format: depth === 32 ? dri.FORMAT.ARGB8888 : dri.FORMAT.XRGB8888
+        });
+    } catch (e) {
+        console.error('no usable GPU:', e.message);
+        console.error('(try the CPU variant: software.js in this folder)');
+        return X.terminate();
+    }
+    const gl = gpu.gl;
+
+    // --- window ------------------------------------------------------------
+    const wid = X.AllocID();
+    const eid = X.AllocID();
+    X.CreateWindow(wid, root, 0, 0, START_W, START_H, 0, depth, 1, 0, {
+        backgroundPixel: screen.black_pixel,
+        eventMask: x11.eventMask.StructureNotify | x11.eventMask.KeyPress
+    });
+    const title = Buffer.from('DRI3 cube - node-x11', 'latin1');
+    X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, title);
+    X.MapWindow(wid);
+
+    Present.SelectInput(eid, wid,
+        Present.EventMask.CompleteNotify | Present.EventMask.IdleNotify);
+
+    // --- swapchain ---------------------------------------------------------
+    // Buffers cycle through: rendered -> presented -> idle -> rendered again.
+    // A "generation" is one window size; resizing retires the old surface
+    // once the server has idled all of its buffers.
+    let generation = null;
+    const retiring = [];
+    let serial = 0;
+    let frames = 0;
+    let mode = '?';
+    let statT = Date.now();
+    let needBuffer = false;
+    let closing = false;
+
+    // Buffer states: 'busy' — presented, the server still reads it (its GBM
+    // buffer is locked on our side); 'free' — IdleNotify arrived, the GBM
+    // buffer went back to the surface's pool (the pixmap stays valid: it
+    // references the same GPU memory and is simply presented again the next
+    // time the GPU hands us that buffer).
+    function makeGeneration(w, h) {
+        const surface = gpu.createSurface(w, h);
+        gpu.makeCurrent(surface);
+        return {
+            surface,
+            width: w,
+            height: h,
+            buffers: new Map(),  // bo key -> { pixmap, state }
+            byPixmap: new Map(), // pixmap -> bo key
+            inFlight: 0          // presents not yet idled
+        };
+    }
+
+    function dropBuffer(gen, key, buf) {
+        X.FreePixmap(buf.pixmap);
+        gen.buffers.delete(key);
+        gen.byPixmap.delete(buf.pixmap);
+        if (gen.buffers.size === 0) {
+            gen.surface.destroy();
+            const i = retiring.indexOf(gen);
+            if (i !== -1)
+                retiring.splice(i, 1);
+            return true;
+        }
+        return false;
+    }
+
+    function retire(gen) {
+        // free-state buffers can go now; busy ones go as their IdleNotify
+        // arrives (see the PresentIdleNotify handler)
+        for (const [key, buf] of [...gen.buffers]) {
+            if (buf.state === 'free')
+                dropBuffer(gen, key, buf);
+        }
+        if (gen.buffers.size > 0)
+            retiring.push(gen);
+    }
+
+    // --- GL scene (survives resize: it lives in the context) ---------------
+    generation = makeGeneration(START_W, START_H); // also makes the context current
+    const prog = buildProgram(gl, `
+        attribute vec3 aPos;
+        attribute vec3 aColor;
+        uniform mat4 uMVP;
+        varying vec3 vColor;
+        void main() {
+            gl_Position = uMVP * vec4(aPos, 1.0);
+            vColor = aColor;
+        }
+    `, `
+        precision mediump float;
+        varying vec3 vColor;
+        void main() {
+            gl_FragColor = vec4(vColor, 1.0);
+        }
+    `);
+    const geo = cubeGeometry();
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, geo.verts, gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, geo.idx, gl.STATIC_DRAW);
+    const aPos = gl.getAttribLocation(prog, 'aPos');
+    const aColor = gl.getAttribLocation(prog, 'aColor');
+    const uMVP = gl.getUniformLocation(prog, 'uMVP');
+    gl.enable(gl.DEPTH_TEST);
+    gl.enable(gl.CULL_FACE);
+
+    const t0 = Date.now();
+
+    function drawScene(w, h) {
+        gl.viewport(0, 0, w, h);
+        gl.clearColor(0.09, 0.09, 0.12, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.useProgram(prog);
+        gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+        gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 24, 0);
+        gl.enableVertexAttribArray(aPos);
+        gl.vertexAttribPointer(aColor, 3, gl.FLOAT, false, 24, 12);
+        gl.enableVertexAttribArray(aColor);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+
+        const t = (Date.now() - t0) / 1000;
+        const proj = mat4.perspective(Math.PI / 4, w / h, 0.1, 100);
+        const mv = mat4.multiply(mat4.translateZ(-6), mat4.rotateXY(t * 0.9, t * 1.3));
+        gl.uniformMatrix4fv(uMVP, false, mat4.multiply(proj, mv));
+        gl.drawElements(gl.TRIANGLES, 36, gl.UNSIGNED_SHORT, 0);
+    }
+
+    // --- frame loop, paced by PresentCompleteNotify -------------------------
+    // At most 2 presents outstanding: enough to keep the pipe full, small
+    // enough that the ~4-buffer GBM surface never starves the renderer.
+    const MAX_IN_FLIGHT = 2;
+
+    function renderFrame(targetMsc) {
+        if (closing || !generation)
+            return;
+        const gen = generation;
+        if (gen.inFlight >= MAX_IN_FLIGHT) {
+            needBuffer = true; // resumed by the next IdleNotify
+            return;
+        }
+        drawScene(gen.width, gen.height);
+
+        const out = gen.surface.swap();
+        if (out === null) {
+            // every buffer is still with the server — wait for an IdleNotify,
+            // then draw again (the failed swap's frame was not kept)
+            needBuffer = true;
+            return;
+        }
+
+        const present = () => {
+            if (closing || gen !== generation)
+                return;
+            serial = (serial + 1) >>> 0;
+            const buf = gen.buffers.get(out.key);
+            buf.state = 'busy';
+            gen.inFlight++;
+            Present.Pixmap(wid, buf.pixmap, {
+                serial,
+                options: ASYNC ? Present.Option.Async : Present.Option.None,
+                targetMsc: ASYNC ? 0 : (targetMsc || 0)
+            });
+            X.flush();
+        };
+
+        if (out.isNew) {
+            // first time this GBM buffer surfaces: wrap its dma-buf in a pixmap
+            const pixmap = X.AllocID();
+            gen.buffers.set(out.key, { pixmap, state: 'busy' });
+            gen.byPixmap.set(pixmap, out.key);
+            DRI3.PixmapFromBuffer(pixmap, wid, {
+                fd: out.fd,
+                width: out.width,
+                height: out.height,
+                stride: out.stride,
+                depth,
+                bpp: 32
+            }, impErr => {
+                if (impErr) {
+                    console.error('server could not import the GPU buffer:', impErr.message);
+                    console.error('(cross-device setup? try GBM_USE.LINEAR, or the software variant)');
+                    return shutdown(1);
+                }
+                present();
+            });
+        } else {
+            present();
+        }
+    }
+
+    // --- events --------------------------------------------------------------
+    X.on('event', ev => {
+        switch (ev.name) {
+        case 'PresentCompleteNotify':
+            if (ev.kind === Present.CompleteKind.Pixmap) {
+                frames++;
+                mode = ['Copy', 'Flip', 'Skip', 'SuboptimalCopy'][ev.mode] || ev.mode;
+                const now = Date.now();
+                if (now - statT >= 2000) {
+                    console.log(`${(frames * 1000 / (now - statT)).toFixed(1)} fps (${mode}, msc ${ev.msc})`);
+                    frames = 0;
+                    statT = now;
+                }
+                renderFrame(ev.msc + 1);
+            }
+            break;
+
+        case 'PresentIdleNotify': {
+            const gen = generation && generation.byPixmap.has(ev.pixmap)
+                ? generation
+                : retiring.find(g => g.byPixmap.has(ev.pixmap));
+            if (!gen)
+                break;
+            const key = gen.byPixmap.get(ev.pixmap);
+            const buf = gen.buffers.get(key);
+            gen.inFlight = Math.max(0, gen.inFlight - 1);
+            if (buf.state === 'busy') {
+                buf.state = 'free';
+                gen.surface.release(key); // GBM may hand it to the GPU again
+            }
+            if (gen === generation) {
+                if (needBuffer) {
+                    needBuffer = false;
+                    renderFrame(0);
+                }
+            } else {
+                dropBuffer(gen, key, buf); // retiring after a resize
+            }
+            break;
+        }
+
+        case 'ConfigureNotify':
+            if (ev.wid === wid && generation &&
+                (ev.width !== generation.width || ev.height !== generation.height)) {
+                retire(generation);
+                generation = makeGeneration(ev.width, ev.height);
+                needBuffer = false;
+                renderFrame(0);
+            }
+            break;
+
+        case 'KeyPress':
+            if (ev.keycode === 9 || ev.keycode === 24) // Esc, q (pc105)
+                shutdown(0);
+            break;
+
+        case 'DestroyNotify':
+            if (ev.wid === wid)
+                shutdown(0);
+            break;
+        }
+    });
+
+    function shutdown(code) {
+        if (closing) return;
+        closing = true;
+        try {
+            const gens = generation ? [generation, ...retiring] : [...retiring];
+            generation = null;
+            retiring.length = 0;
+            for (const gen of gens) {
+                for (const buf of gen.buffers.values())
+                    X.FreePixmap(buf.pixmap);
+                gen.surface.destroy(); // releases still-locked buffers itself
+            }
+            gpu.destroy();
+            X.DestroyWindow(wid);
+        } finally {
+            X.terminate();
+            process.exitCode = code;
+        }
+    }
+    process.on('SIGINT', () => shutdown(0));
+
+    // --- go ------------------------------------------------------------------
+    console.log(`GPU: ${gl.getString(gl.RENDERER)} on ${gpu.devicePath}`);
+    console.log(`DRI3 ${DRI3.major}.${DRI3.minor}, Present ${Present.major}.${Present.minor}` +
+        (ASYNC ? ' (async presents)' : ''));
+    console.log('q or Esc to quit');
+    renderFrame(0);
+}
+
+function buildProgram(gl, vsSource, fsSource) {
+    const compile = (type, source) => {
+        const sh = gl.createShader(type);
+        gl.shaderSource(sh, source);
+        gl.compileShader(sh);
+        if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS))
+            throw new Error(`shader compile failed: ${gl.getShaderInfoLog(sh)}`);
+        return sh;
+    };
+    const vs = compile(gl.VERTEX_SHADER, vsSource);
+    const fs = compile(gl.FRAGMENT_SHADER, fsSource);
+    const prog = gl.createProgram();
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.linkProgram(prog);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS))
+        throw new Error(`program link failed: ${gl.getProgramInfoLog(prog)}`);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+    return prog;
+}

--- a/examples/dri3/package.json
+++ b/examples/dri3/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "x11-example-dri3",
+  "private": true,
+  "version": "0.0.0",
+  "description": "node-x11 direct rendering demo: X11 window + GPU OpenGL ES cube shown through DRI3 + Present (zero-copy dma-buf pixmaps)",
+  "license": "MIT",
+  "dependencies": {
+    "x11": "file:../..",
+    "x11-dri": "github:sidorares/node-x11-dri"
+  },
+  "scripts": {
+    "start": "node cube.js",
+    "start:async": "node cube.js --async",
+    "software": "node software.js"
+  }
+}

--- a/examples/dri3/software.js
+++ b/examples/dri3/software.js
@@ -1,0 +1,222 @@
+// DRI3 + Present without a GPU: the pixels are computed in JavaScript, but
+// they still reach the X server as a dma-buf — CPU memory turned into one by
+// the kernel's udmabuf device — so the presentation path is byte-for-byte the
+// modern one (no PutImage, no MIT-SHM, no pixel copies over the socket).
+//
+//   memfd (plain RAM, mapped into JS as an ArrayBuffer)
+//     -> /dev/udmabuf  ->  dma-buf fd  ->  DRI3 PixmapFromBuffer
+//     -> Present.Pixmap, paced by CompleteNotify, double buffered
+//
+// This is the same trick Xwayland itself uses to run GPU-less while speaking
+// a dma-buf protocol. It needs: /dev/udmabuf accessible, and a server whose
+// driver can import CPU dma-bufs (Xorg+glamor and Xwayland on real hardware
+// can; a virtualized GPU usually refuses, which this example reports and
+// exits — the GPU variant cube.js in this folder is the main show).
+//
+// The 3D content is an old-school wireframe cube, rasterized by hand.
+
+const x11 = require('x11');
+
+let dri;
+try {
+    dri = require('x11-dri');
+} catch (e) {
+    console.error('The native companion is not installed. Run `npm install` in this folder.');
+    console.error('(x11-dri: https://github.com/sidorares/node-x11-dri — builds anywhere with a C toolchain)');
+    console.error(`(${e.message})`);
+    process.exit(1);
+}
+
+const W = 480;
+const H = 360;
+
+x11.createClient((err, display) => {
+    if (err) throw err;
+    const X = display.client;
+    const screen = display.screen[0];
+    const depth = screen.root_depth;
+
+    X.require('dri3', (err, DRI3) => {
+        if (err) {
+            console.error('DRI3 not available:', err.message);
+            return X.terminate();
+        }
+        X.require('present', (err, Present) => {
+            if (err) throw err;
+            start(X, screen, depth, DRI3, Present);
+        });
+    });
+}).on('error', err => {
+    console.error('X connection:', err.message || err);
+    process.exit(0);
+});
+
+function start(X, screen, depth, DRI3, Present) {
+    // two CPU dma-bufs, presented in alternation
+    let bufs;
+    try {
+        bufs = [0, 1].map(() => {
+            const b = dri.createUdmabuf(W * H * 4);
+            b.px = new Uint32Array(b.buffer);
+            b.busy = false;
+            return b;
+        });
+    } catch (e) {
+        console.error('no udmabuf:', e.message);
+        console.error('(needs /dev/udmabuf; modprobe udmabuf, and rw access)');
+        return X.terminate();
+    }
+
+    const wid = X.AllocID();
+    const eid = X.AllocID();
+    X.CreateWindow(wid, screen.root, 0, 0, W, H, 0, depth, 1, 0, {
+        backgroundPixel: screen.black_pixel,
+        eventMask: x11.eventMask.StructureNotify | x11.eventMask.KeyPress
+    });
+    X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8,
+        Buffer.from('DRI3 software cube - node-x11', 'latin1'));
+    X.MapWindow(wid);
+    Present.SelectInput(eid, wid,
+        Present.EventMask.CompleteNotify | Present.EventMask.IdleNotify);
+
+    // wrap each dma-buf in a pixmap; the first import tells us whether this
+    // server can take CPU dma-bufs at all
+    let imported = 0;
+    bufs.forEach(b => {
+        b.pixmap = X.AllocID();
+        // the fd is consumed by the send; pixels keep flowing through the
+        // memfd mapping (b.px), which aliases the same pages
+        DRI3.PixmapFromBuffer(b.pixmap, wid, {
+            fd: b.fd, width: W, height: H, stride: W * 4, depth, bpp: 32
+        }, impErr => {
+            if (closing)
+                return;
+            if (impErr) {
+                console.error('this server/driver cannot import CPU dma-bufs:', impErr.message);
+                console.error('(typical on virtualized GPUs; on real hardware Xorg+glamor and');
+                console.error(' Xwayland accept them. See cube.js in this folder for the');
+                console.error(' GPU path, or examples/* MIT-SHM demos for the classic one.)');
+                return shutdown(1);
+            }
+            b.imported = true;
+            if (++imported === bufs.length)
+                renderFrame(0); // both pixmaps live: go
+        });
+    });
+
+    // --- hand-rolled 3D: project cube edges, Bresenham them into the buffer
+    const corners = [];
+    for (let i = 0; i < 8; i++)
+        corners.push([(i & 1) * 2 - 1, ((i >> 1) & 1) * 2 - 1, ((i >> 2) & 1) * 2 - 1]);
+    const edges = [];
+    for (let a = 0; a < 8; a++)
+        for (let b = a + 1; b < 8; b++) {
+            const d = (a ^ b);
+            if (d === 1 || d === 2 || d === 4) edges.push([a, b]);
+        }
+
+    function line(px, x0, y0, x1, y1, color) {
+        x0 |= 0; y0 |= 0; x1 |= 0; y1 |= 0;
+        const dx = Math.abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+        const dy = -Math.abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+        let e = dx + dy;
+        for (;;) {
+            if (x0 >= 0 && x0 < W && y0 >= 0 && y0 < H) {
+                px[y0 * W + x0] = color;
+                if (x0 + 1 < W) px[y0 * W + x0 + 1] = color; // chunky 2px lines
+            }
+            if (x0 === x1 && y0 === y1) break;
+            const e2 = 2 * e;
+            if (e2 >= dy) { e += dy; x0 += sx; }
+            if (e2 <= dx) { e += dx; y0 += sy; }
+        }
+    }
+
+    const t0 = Date.now();
+    function paint(px) {
+        const t = (Date.now() - t0) / 1000;
+        // background: vertical fade
+        for (let y = 0; y < H; y++) {
+            const shade = 0xff000000 + ((16 + y * 24 / H) << 16 | (16 + y * 16 / H) << 8 | (28 + y * 40 / H)) >>> 0;
+            px.fill(shade, y * W, (y + 1) * W);
+        }
+        // spin, project, draw
+        const cx = Math.cos(t * 0.9), sx = Math.sin(t * 0.9);
+        const cy = Math.cos(t * 1.3), sy = Math.sin(t * 1.3);
+        const pts = corners.map(([x, y, z]) => {
+            const X1 = x * cy - z * sy, Z1 = x * sy + z * cy;
+            const Y1 = y * cx - Z1 * sx, Z2 = y * sx + Z1 * cx;
+            const s = 160 / (Z2 + 4);
+            return [W / 2 + X1 * s * 1.4, H / 2 + Y1 * s];
+        });
+        edges.forEach(([a, b], i) => {
+            const hue = [0xffe74c3c, 0xff2ecc71, 0xff3498db, 0xfff1c40f][i & 3];
+            line(px, pts[a][0], pts[a][1], pts[b][0], pts[b][1], hue);
+        });
+    }
+
+    // --- present loop --------------------------------------------------------
+    let serial = 0;
+    let frames = 0;
+    let statT = Date.now();
+    let stalled = false;
+    let closing = false;
+
+    function renderFrame(targetMsc) {
+        if (closing) return;
+        const b = bufs.find(x => !x.busy);
+        if (!b) { stalled = true; return; } // resumed on IdleNotify
+        b.sync(dri.DMABUF_SYNC.START | dri.DMABUF_SYNC.WRITE);
+        paint(b.px);
+        b.sync(dri.DMABUF_SYNC.END | dri.DMABUF_SYNC.WRITE);
+        b.busy = true;
+        serial = (serial + 1) >>> 0;
+        Present.Pixmap(wid, b.pixmap, { serial, targetMsc: targetMsc || 0 });
+        X.flush();
+    }
+
+    X.on('event', ev => {
+        switch (ev.name) {
+        case 'PresentCompleteNotify':
+            if (ev.kind === Present.CompleteKind.Pixmap) {
+                frames++;
+                const now = Date.now();
+                if (now - statT >= 2000) {
+                    console.log(`${(frames * 1000 / (now - statT)).toFixed(1)} fps (msc ${ev.msc})`);
+                    frames = 0;
+                    statT = now;
+                }
+                renderFrame(ev.msc + 1);
+            }
+            break;
+        case 'PresentIdleNotify': {
+            const b = bufs.find(x => x.pixmap === ev.pixmap);
+            if (b) b.busy = false;
+            if (stalled) { stalled = false; renderFrame(0); }
+            break;
+        }
+        case 'KeyPress':
+            if (ev.keycode === 9 || ev.keycode === 24) shutdown(0); // Esc, q
+            break;
+        case 'DestroyNotify':
+            if (ev.wid === wid) shutdown(0);
+            break;
+        }
+    });
+
+    function shutdown(code) {
+        if (closing) return;
+        closing = true;
+        bufs.forEach(b => {
+            if (b.imported) X.FreePixmap(b.pixmap);
+            b.close();
+        });
+        X.DestroyWindow(wid);
+        X.terminate();
+        process.exitCode = code;
+    }
+    process.on('SIGINT', () => shutdown(0));
+
+    console.log('software 3D via udmabuf -> DRI3 -> Present; q or Esc to quit');
+    // rendering starts once both imports are confirmed (see above)
+}

--- a/lib/ext/dri3.js
+++ b/lib/ext/dri3.js
@@ -1,0 +1,292 @@
+// DRI3 extension
+// spec: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/dri3proto.txt
+// wire structs: <X11/extensions/dri3proto.h> (xorgproto)
+//
+// DRI3 is the descriptor-passing half of the modern direct-rendering path:
+// the client renders on the GPU itself (EGL/GBM/Vulkan — entirely outside the
+// X protocol), exports each finished buffer as a dma-buf file descriptor,
+// wraps it into an X pixmap with PixmapFromBuffer(s), and puts it on screen
+// with the Present extension (lib/ext/present.js). No pixel data ever crosses
+// the socket; the server imports the same GPU memory the client rendered to.
+//
+// Descriptor direction is asymmetric here, on purpose:
+//
+//   client -> server — PixmapFromBuffer, PixmapFromBuffers, FenceFromFD,
+//   ImportSyncobj — works on an fd-capable local connection (the default for
+//   unix-socket displays; lib/fdpass.js). The descriptors are CONSUMED:
+//   closed once written, whether the write succeeded or not. That matches how
+//   they are produced (gbm_bo_get_fd/eglExportDMABUFImageMESA return a fresh
+//   fd whose only purpose is this send, while the GPU buffer object keeps its
+//   own reference).
+//
+//   server -> client — Open, BufferFromPixmap, FDFromFence, BuffersFromPixmap
+//   — is NOT wired: a descriptor arriving on the connection aborts the Node
+//   process before any JS runs (see lib/fdpass.js). These four requests are
+//   never put on the wire; they report an error instead. The standard
+//   substitute for Open is opening a render node directly —
+//   fs.openSync('/dev/dri/renderD128', 'r+') — which needs no X-side
+//   authentication at all. On multi-GPU machines, probe each
+//   /dev/dri/renderD* by importing a small test buffer with PixmapFromBuffer
+//   until one succeeds.
+
+const fs = require('fs');
+
+// 64-bit format modifiers use the full 64-bit range (vendor code in the top
+// byte; DRM_FORMAT_MOD_INVALID is 2^56 - 1), beyond Number's 53-bit exactness,
+// so modifiers are BigInt on this API. Plain numbers are accepted on input.
+const toBigUInt64 = v => (typeof v === 'bigint' ? v : BigInt(v || 0)) & 0xffffffffffffffffn;
+
+exports.requireExt = (display, callback) => {
+    const X = display.client;
+    X.QueryExtension('DRI3', (err, ext) => {
+
+        if (!ext.present)
+            return callback(new Error('extension not available'));
+
+        // drm_fourcc.h values needed to talk about buffer layout
+        ext.FormatModifier = {
+            Linear: 0n,
+            Invalid: (1n << 56n) - 1n   // DRM_FORMAT_MOD_INVALID: "implicit, driver-negotiated"
+        };
+
+        const closeAll = fds =>
+            fds.forEach(fd => { try { fs.closeSync(fd); } catch { /* ignore */ } });
+
+        // Requests that make the server send a descriptor back are refused
+        // here (fds are unreceivable — see the header). Errors, not throws,
+        // when a callback is given, so probing code can fall back cleanly.
+        const unreceivable = (what, hint, cb) => {
+            const err = new Error(`DRI3: ${what} makes the server return a file descriptor, ` +
+                'and receiving one would abort the Node process (see lib/fdpass.js). ' + hint);
+            if (cb) return process.nextTick(() => cb(err));
+            throw err;
+        };
+
+        // Shared tail of every descriptor-carrying request. The descriptors
+        // ride the output queue with their request bytes (putWithFds), so the
+        // request keeps its place in wire order no matter what else is issued
+        // around it, and behaves like any other void request: with `cb` a
+        // round trip is forced and cb(err|null) reports whether the server
+        // accepted it. The fds are consumed in all cases.
+        const sendWithFds = (b, fds, what, cb) => {
+            const socket = X.stream;
+            if (!socket || !socket._fdCapable || typeof socket.sendFds !== 'function') {
+                closeAll(fds);
+                const err = new Error(`DRI3: ${what} passes file descriptors and needs ` +
+                    'an fd-capable local connection (unix-socket display; see lib/fdpass.js)');
+                if (cb) return process.nextTick(() => cb(err));
+                throw err;
+            }
+            X.seq_num++;
+            const seq = X.seq_num;
+            if (cb) {
+                X.replies[seq] = [null, e => { cb(e || null); return true; }];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.putWithFds(b, fds);
+            X.pack_stream.submit();
+        };
+
+        ext.QueryVersion = (clientMaj, clientMin, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(0, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(clientMaj >>> 0, 4);
+            b.writeUInt32LE(clientMin >>> 0, 8);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => [buf.readUInt32LE(0), buf.readUInt32LE(4)],
+                cb
+            ];
+            X.pack_stream.submit(true);
+        }
+
+        // The reply carries the DRM device fd — unreceivable (see header).
+        ext.Open = (drawable, provider, cb) =>
+            unreceivable('Open', 'Open a render node directly instead: ' +
+                "fs.openSync('/dev/dri/renderD128', 'r+').", cb);
+
+        // Turn a dma-buf into `pixmap` (a fresh XID) on `drawable`'s screen.
+        // opts: { fd, width, height, stride, depth, bpp, size? } — size
+        // defaults to stride * height. The fd is consumed. With `cb` the
+        // creation is confirmed by a round trip (cb(err|null)): a server that
+        // cannot import the buffer answers with a BadValue/BadMatch/BadAlloc
+        // error, so probing "does this device's buffers import?" is exactly
+        // PixmapFromBuffer with a callback.
+        ext.PixmapFromBuffer = (pixmap, drawable, opts, cb) => {
+            const b = Buffer.alloc(24);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(2, 1);
+            b.writeUInt16LE(6, 2);
+            b.writeUInt32LE(pixmap >>> 0, 4);
+            b.writeUInt32LE(drawable >>> 0, 8);
+            b.writeUInt32LE((opts.size != null ? opts.size : opts.stride * opts.height) >>> 0, 12);
+            b.writeUInt16LE(opts.width, 16);
+            b.writeUInt16LE(opts.height, 18);
+            b.writeUInt16LE(opts.stride, 20);
+            b.writeUInt8(opts.depth, 22);
+            b.writeUInt8(opts.bpp, 23);
+            sendWithFds(b, [opts.fd], 'PixmapFromBuffer', cb);
+        }
+
+        // The reply carries the buffer's dma-buf fd — unreceivable.
+        ext.BufferFromPixmap = (pixmap, cb) =>
+            unreceivable('BufferFromPixmap',
+                'Keep the buffer on the client side instead: create it yourself and ' +
+                'import it with PixmapFromBuffer.', cb);
+
+        // Create SYNC fence `fence` (a fresh XID) on `drawable`'s screen from
+        // a poll-able fence fd (SyncFD). The fd is consumed.
+        ext.FenceFromFD = (drawable, fence, initiallyTriggered, fd, cb) => {
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(4, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeUInt32LE(fence >>> 0, 8);
+            b.writeUInt8(initiallyTriggered ? 1 : 0, 12);
+            // bytes 13..15 pad
+            sendWithFds(b, [fd], 'FenceFromFD', cb);
+        }
+
+        ext.FDFromFence = (drawable, fence, cb) =>
+            unreceivable('FDFromFence',
+                'Create the fence from a client-side fd with FenceFromFD instead.', cb);
+
+        // DRI3 1.2: which format modifiers the server can import for this
+        // window (and for its screen as a whole) at depth/bpp.
+        // cb(err, { windowModifiers: [BigInt], screenModifiers: [BigInt] })
+        ext.GetSupportedModifiers = (window, depth, bpp, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(6, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt8(depth, 8);
+            b.writeUInt8(bpp, 9);
+            // bytes 10..11 pad
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const nWindow = buf.readUInt32LE(0);
+                    const nScreen = buf.readUInt32LE(4);
+                    const windowModifiers = [];
+                    const screenModifiers = [];
+                    let off = 24; // modifier lists start at byte 32 of the reply
+                    for (let i = 0; i < nWindow; i++, off += 8)
+                        windowModifiers.push(buf.readBigUInt64LE(off));
+                    for (let i = 0; i < nScreen; i++, off += 8)
+                        screenModifiers.push(buf.readBigUInt64LE(off));
+                    return { windowModifiers, screenModifiers };
+                },
+                cb
+            ];
+            X.pack_stream.submit(true);
+        }
+
+        // DRI3 1.2: multi-planar/modifier-aware PixmapFromBuffer.
+        // opts: { width, height, depth, bpp, modifier (BigInt|number),
+        //         planes: [{ fd, stride, offset }] (1..4) }.
+        // All plane fds are consumed. Use modifier ext.FormatModifier.Invalid
+        // with a single plane for driver-negotiated ("implicit") layout.
+        ext.PixmapFromBuffers = (pixmap, window, opts, cb) => {
+            const planes = opts.planes;
+            if (!planes || planes.length < 1 || planes.length > 4) {
+                const err = new Error('DRI3: PixmapFromBuffers takes 1 to 4 planes');
+                if (cb) return process.nextTick(() => cb(err));
+                throw err;
+            }
+            const b = Buffer.alloc(64);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(7, 1);
+            b.writeUInt16LE(16, 2);
+            b.writeUInt32LE(pixmap >>> 0, 4);
+            b.writeUInt32LE(window >>> 0, 8);
+            b.writeUInt8(planes.length, 12);
+            // bytes 13..15 pad
+            b.writeUInt16LE(opts.width, 16);
+            b.writeUInt16LE(opts.height, 18);
+            for (let i = 0; i < 4; i++) {
+                const p = planes[i];
+                b.writeUInt32LE(p ? p.stride >>> 0 : 0, 20 + i * 8);
+                b.writeUInt32LE(p ? (p.offset || 0) >>> 0 : 0, 24 + i * 8);
+            }
+            b.writeUInt8(opts.depth, 52);
+            b.writeUInt8(opts.bpp, 53);
+            // bytes 54..55 pad
+            b.writeBigUInt64LE(toBigUInt64(opts.modifier), 56);
+            sendWithFds(b, planes.map(p => p.fd), 'PixmapFromBuffers', cb);
+        }
+
+        ext.BuffersFromPixmap = (pixmap, cb) =>
+            unreceivable('BuffersFromPixmap',
+                'Keep the buffers on the client side instead: create them yourself and ' +
+                'import them with PixmapFromBuffers.', cb);
+
+        // DRI3 1.3: tell the server which DRM device (by dev_t major/minor)
+        // this window's buffers will come from, so multi-GPU servers pick the
+        // right import path. Void; check ext.minor >= 3 before using.
+        ext.SetDRMDeviceInUse = (window, drmMajor, drmMinor, cb) => {
+            X.seq_num++;
+            const seq = X.seq_num;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(9, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(window >>> 0, 4);
+            b.writeUInt32LE(drmMajor >>> 0, 8);
+            b.writeUInt32LE(drmMinor >>> 0, 12);
+            if (cb) {
+                X.replies[seq] = [null, e => { cb(e || null); return true; }];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.submit();
+        }
+
+        // DRI3 1.4: import a DRM timeline syncobj (fd consumed) under a fresh
+        // XID for explicit sync with Present; check ext.minor >= 4.
+        ext.ImportSyncobj = (syncobj, drawable, fd, cb) => {
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(10, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(syncobj >>> 0, 4);
+            b.writeUInt32LE(drawable >>> 0, 8);
+            sendWithFds(b, [fd], 'ImportSyncobj', cb);
+        }
+
+        ext.FreeSyncobj = (syncobj, cb) => {
+            X.seq_num++;
+            const seq = X.seq_num;
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(11, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(syncobj >>> 0, 4);
+            if (cb) {
+                X.replies[seq] = [null, e => { cb(e || null); return true; }];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.submit();
+        }
+
+        // Whether this connection can put descriptor-carrying requests on the
+        // wire at all (local unix socket with the fd-capable transport).
+        ext.fdCapable = !!(X.stream && X.stream._fdCapable &&
+            typeof X.stream.sendFds === 'function');
+
+        // the spec requires clients to negotiate the version before use
+        ext.QueryVersion(1, 4, (e, vers) => {
+            if (e)
+                return callback(e);
+            ext.major = vers[0];
+            ext.minor = vers[1];
+            callback(null, ext);
+        });
+    });
+}

--- a/lib/ext/shm.js
+++ b/lib/ext/shm.js
@@ -178,18 +178,25 @@ exports.requireExt = (display, callback) => {
         // SCM_RIGHTS ancillary data, not in the request body, so it needs an
         // fd-capable connection (a local unix socket built through
         // lib/fdpass.js). `fd` must be a regular-file/memfd descriptor the
-        // caller keeps owning.
+        // caller keeps owning: what actually travels (and is consumed by the
+        // transport) is a self-dup made through /proc/self/fd, 'r+' so the
+        // server can map it read-write.
         //
-        // Ordering matters: this writes out of band, past the request buffer,
-        // so it must be issued at a quiescent point — no other request may be
-        // issued between AttachFd(...) and its callback, or wire order and
-        // sequence numbers would disagree. `createSegment` below observes this.
-        // The reverse-direction CreateSegment (opcode 7) is deliberately absent
-        // — see the note at the top of this file.
+        // The request rides the ordinary output queue (putWithFds), so it
+        // keeps its place in wire order like any other request. The
+        // reverse-direction CreateSegment (opcode 7) is deliberately absent —
+        // see the note at the top of this file.
         ext.AttachFd = (shmseg, fd, readOnly, cb) => {
             const socket = X.stream;
-            if (!socket || !socket._fdCapable || typeof socket.sendFd !== 'function') {
+            if (!socket || !socket._fdCapable || typeof socket.sendFds !== 'function') {
                 const err = new Error('MIT-SHM: AttachFd needs an fd-capable local connection');
+                if (cb) return process.nextTick(() => cb(err));
+                throw err;
+            }
+            let dupFd;
+            try {
+                dupFd = require('fs').openSync(`/proc/self/fd/${fd}`, 'r+');
+            } catch (err) {
                 if (cb) return process.nextTick(() => cb(err));
                 throw err;
             }
@@ -200,49 +207,16 @@ exports.requireExt = (display, callback) => {
             b.writeUInt32LE(shmseg >>> 0, 4);
             b.writeUInt8(readOnly ? 1 : 0, 8);
             // bytes 9..11 are pad (already zero)
-            // Both steps below are asynchronous, and the connection can start
-            // closing while they are in flight — a segment warmed in the
-            // background outliving the app's close() is ordinary, not a corner
-            // case. Issuing a request on a closing client throws, so check
-            // before each step and report it on the callback instead.
-            const gone = () =>
-                X._closing || !X.stream || X.stream.writableEnded || X.stream.destroyed;
-            // Flush queued requests to the wire first, then hand the fd to the
-            // same socket handle so it is ordered strictly after them.
-            X.flush(() => {
-                if (gone()) {
-                    if (cb) cb(new Error('MIT-SHM: connection closed before AttachFd was sent'));
-                    return;
-                }
-                // The sequence number is reserved here, immediately before the
-                // write, and not when the request was built: a number reserved
-                // and then never sent leaves the client one ahead of the server
-                // for the rest of the connection, and every later reply goes to
-                // the wrong callback.
-                X.seq_num++;
-                const seq = X.seq_num;
-                if (cb)
-                    X.replies[seq] = [null, cb];
-                socket.sendFd(b, fd, sendErr => {
-                    if (sendErr) {
-                        delete X.replies[seq];
-                        if (cb) cb(sendErr);
-                        return;
-                    }
-                    if (!cb)
-                        return;
-                    if (gone()) {
-                        // the request did reach the socket, so the sequence
-                        // number is spent; only the confirmation is lost
-                        delete X.replies[seq];
-                        cb(new Error('MIT-SHM: connection closed before the segment was attached'));
-                        return;
-                    }
-                    // AttachFd is void: force a round trip so a success is
-                    // confirmed and any error has arrived before cb fires.
-                    X.GetInputFocus(() => true);
-                });
-            });
+            X.seq_num++;
+            const seq = X.seq_num;
+            if (cb) {
+                // void request: schedule a round trip so a success is
+                // confirmed and any error has arrived before cb fires
+                X.replies[seq] = [null, cb];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.putWithFds(b, [dupFd]);
+            X.pack_stream.submit();
         }
 
         ext.events = {

--- a/lib/fdpass.js
+++ b/lib/fdpass.js
@@ -16,9 +16,22 @@
 // core PutImage) rather than throwing out of connection setup.
 //
 // SEND ONLY. Never wire the reverse direction (receiving an fd, i.e. MIT-SHM
-// ShmCreateSegment): a regular-file fd arriving on a libuv-read socket aborts
-// the process with SIGABRT. See ~/NODE_BUG_ANDREY_TO_FIX.md and the note in
-// lib/ext/shm.js.
+// ShmCreateSegment or DRI3 Open/BufferFromPixmap): a regular-file fd arriving
+// on a libuv-read socket aborts the process with SIGABRT. See
+// ~/NODE_BUG_ANDREY_TO_FIX.md and the notes in lib/ext/shm.js, lib/ext/dri3.js.
+//
+// One send primitive: sendFds(req, fds, cb). The descriptors are CONSUMED —
+// handed to libuv and closed once written, success or not. That is the only
+// ownership model that works for every descriptor kind (dma-bufs are
+// anonymous inodes that procfs cannot reopen, so no pure-JS dup exists), and
+// it matches how they are produced: gbm_bo_get_fd() returns a fresh fd whose
+// only purpose is this send. A caller that wants to keep its descriptor dups
+// it first (regular files/memfds reopen via /proc/self/fd — see MIT-SHM
+// AttachFd in lib/ext/shm.js).
+//
+// Extensions do not call sendFds directly; they queue the request with
+// pack_stream.putWithFds(buf, fds) so the bytes keep their place in the
+// output queue (lib/framebuffer.js) and sequence numbers stay honest.
 
 let bindings = null;      // { Pipe, PipeConnectWrap, WriteWrap, PipeConstants }
 let bindingsProbed = false;
@@ -52,45 +65,72 @@ function available() {
     return loadBindings() !== null;
 }
 
-// Attach a `sendFd(reqBuffer, fd, cb)` method to a connected fd-capable socket.
-// `fd` must be a regular-file descriptor the caller keeps owning: a short-lived
-// self-dup (via /proc/self/fd) is handed to libuv so closing the carrier never
-// touches the caller's fd.
+// Attach a `sendFds(reqBuffer, fds, cb)` method to a connected fd-capable
+// socket (ownership contract: see file header).
 function attachSender(socket, b) {
     const fs = require('fs');
     socket._fdCapable = true;
-    socket.sendFd = function sendFd(reqBuffer, fd, cb) {
+
+    // One chunk of request bytes with one descriptor as ancillary data.
+    // `ownedFd` is consumed: it is closed when the write completes, fails to
+    // queue, or cannot be wrapped. cb(err|null) exactly once.
+    const writeChunk = (chunk, ownedFd, cb) => {
         const handle = socket._handle;
         if (!handle || typeof handle.writeBuffer !== 'function') {
-            if (cb) cb(new Error('connection is not fd-capable or already closed'));
-            return;
-        }
-        let dupFd;
-        try {
-            // Reopen the same inode through the magic symlink to get an
-            // independent descriptor. Works for unlinked files and memfds.
-            // 'r+' so the server can map it read-write.
-            dupFd = fs.openSync(`/proc/self/fd/${fd}`, 'r+');
-        } catch (err) {
-            if (cb) cb(err);
+            try { fs.closeSync(ownedFd); } catch { /* ignore */ }
+            cb(new Error('connection is not fd-capable or already closed'));
             return;
         }
         const carrier = new b.Pipe(b.PipeConstants.SOCKET);
-        if (carrier.open(dupFd) !== 0) {
-            try { fs.closeSync(dupFd); } catch { /* ignore */ }
-            if (cb) cb(new Error('could not wrap descriptor for passing'));
+        if (carrier.open(ownedFd) !== 0) {
+            try { fs.closeSync(ownedFd); } catch { /* ignore */ }
+            cb(new Error('could not wrap descriptor for passing'));
             return;
         }
         const wr = new b.WriteWrap();
         wr.handle = handle;
         wr.oncomplete = status => {
-            carrier.close(); // closes only the /proc self-dup
-            if (cb) cb(status ? new Error(`fd write failed (uv ${status})`) : null);
+            carrier.close(); // closes ownedFd
+            cb(status ? new Error(`fd write failed (uv ${status})`) : null);
         };
-        const rc = handle.writeBuffer(wr, reqBuffer, carrier);
+        const rc = handle.writeBuffer(wr, chunk, carrier);
         if (rc !== 0) {
             carrier.close();
-            if (cb) cb(new Error(`fd write could not be queued (uv ${rc})`));
+            cb(new Error(`fd write could not be queued (uv ${rc})`));
+        }
+    };
+
+    // The descriptors in `fds` are consumed (closed after the write) whether
+    // the write succeeds or not. libuv attaches exactly one descriptor per
+    // write (uv_write2), so a request carrying N > 1 fds is split into N
+    // back-to-back chunks on the same handle. That is invisible to the X
+    // server: descriptors are associated with requests by arrival order on
+    // the byte stream, not by message boundary (the server queues incoming
+    // fds and pops as many as the request being executed declares).
+    socket.sendFds = function sendFds(reqBuffer, fds, cb) {
+        const n = fds.length;
+        if (n === 0) {
+            if (cb) process.nextTick(() => cb(new Error('sendFds: no descriptors given')));
+            return;
+        }
+        if (reqBuffer.length < n) {
+            fds.forEach(fd => { try { fs.closeSync(fd); } catch { /* ignore */ } });
+            if (cb) process.nextTick(() => cb(new Error('sendFds: request too short to chunk')));
+            return;
+        }
+        let firstErr = null;
+        let pending = n;
+        const done = err => {
+            if (err && !firstErr) firstErr = err;
+            if (--pending === 0 && cb) cb(firstErr);
+        };
+        // A failed queueing leaves the connection poisoned like any failed
+        // write on the X socket would; later chunks then fail the same way.
+        const headLen = reqBuffer.length - (n - 1);
+        for (let i = 0; i < n; i++) {
+            const chunk = i === 0 ? reqBuffer.subarray(0, headLen)
+                : reqBuffer.subarray(headLen + i - 1, headLen + i);
+            writeChunk(chunk, fds[i], done);
         }
     };
 }

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -232,6 +232,48 @@ FrameBuffer.prototype.put = function(buf) {
 };
 
 /**
+ * Queue an outbound packet whose descriptors must travel as ancillary data
+ * with its bytes (DRI3 PixmapFromBuffer, MIT-SHM AttachFd). The packet takes
+ * the same ordered path through the queue as everything else — that is the
+ * point: sequence numbers stay correct no matter what other requests are
+ * issued around it. It is never merged into a batch buffer, because it must
+ * reach the transport through sendFds() (one write per descriptor), not
+ * write(). The descriptors are consumed by the transport once written.
+ */
+FrameBuffer.prototype.putWithFds = function(buf, fds) {
+    if (!Buffer.isBuffer(buf))
+        throw new TypeError('FrameBuffer.putWithFds expects a Buffer');
+    this.stats.packets++;
+    this.stats.bytes += buf.length;
+    this._seal(); // bytes queued so far must stay ahead of this packet
+    this.write_queue.push({ fdBuf: buf, fds });
+    return this;
+};
+
+FrameBuffer.prototype._writeFdChunk = function(item) {
+    this.stats.writes++;
+    const sock = this._socket;
+    const alive = () => !sock.destroyed && !sock.writableEnded;
+    if (typeof sock.sendFds !== 'function') {
+        // checked by the extension before queueing; can only happen when the
+        // transport was swapped mid-flight. Honor the consumed-fds contract.
+        const fs = require('fs');
+        for (const fd of item.fds) {
+            try { fs.closeSync(fd); } catch { /* ignore */ }
+        }
+        if (alive())
+            sock.emit('error', new Error('transport cannot pass file descriptors'));
+        return;
+    }
+    sock.sendFds(item.fdBuf, item.fds, err => {
+        // a failed descriptor write poisons the connection like any failed
+        // socket write; surface it there unless we are already tearing down
+        if (err && alive())
+            sock.emit('error', err);
+    });
+};
+
+/**
  * A complete request has been put(): send it, now or with the packets around
  * it. Returns false when the socket applied backpressure — the caller should
  * stop producing until the client emits 'drain'.
@@ -319,8 +361,13 @@ FrameBuffer.prototype._notify = function(cb) {
 // Write queued items in order; returns false if the socket backed up.
 FrameBuffer.prototype._drainQueue = function() {
     while (this.write_queue.length > 0) {
-        if (typeof this.write_queue[0] === 'function') {
+        const head = this.write_queue[0];
+        if (typeof head === 'function') {
             this._notify(this.write_queue.shift());
+            continue;
+        }
+        if (!Buffer.isBuffer(head)) { // fd-carrying packet from putWithFds
+            this._writeFdChunk(this.write_queue.shift());
             continue;
         }
         if (!this._writeChunk(this.write_queue.shift()))
@@ -339,14 +386,17 @@ FrameBuffer.prototype.flush = function(doneCb) {
         throw new TypeError('FrameBuffer.flush expects a callback function');
 
     if (!this._socket) {
-        // detached: hand everything to 'data' listeners in order
+        // detached: hand everything to 'data' listeners in order (an
+        // fd-carrying packet passes its descriptors as a second argument)
         this._seal();
         while (this.write_queue.length > 0) {
             const item = this.write_queue.shift();
             if (typeof item === 'function')
                 queueMicrotask(item);
-            else
+            else if (Buffer.isBuffer(item))
                 this.emit('data', item);
+            else
+                this.emit('data', item.fdBuf, item.fds);
         }
         if (doneCb)
             queueMicrotask(doneCb);

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -21,6 +21,7 @@ const extensionModules = {
     'damage': () => require('./ext/damage'),
     'dbe': () => require('./ext/dbe'),
     'dpms': () => require('./ext/dpms'),
+    'dri3': () => require('./ext/dri3'),
     'fixes': () => require('./ext/fixes'),
     'ge': () => require('./ext/ge'),
     'glx': () => require('./ext/glx'),

--- a/test-runner.js
+++ b/test-runner.js
@@ -15,6 +15,7 @@ const extensionTests = {
     'damage.js': 'DAMAGE',
     'dbe.js': 'DOUBLE-BUFFER',
     'dpms.js': 'DPMS',
+    'dri3-live.js': 'DRI3',
     'fixes.js': 'XFIXES',
     'ge.js': 'Generic Event Extension',
     'glx.js': 'GLX',

--- a/test/dri3-live.js
+++ b/test/dri3-live.js
@@ -1,0 +1,187 @@
+// DRI3 against a real server (test-runner only adds this file when the
+// server advertises DRI3 — Xorg with glamor or Xwayland; Xvfb never does).
+// Also needs the optional native companion installed (`npm install x11-dri`,
+// https://github.com/sidorares/node-x11-dri) and a usable render node; each
+// prerequisite that is missing skips instead of failing, so the suite stays
+// green on machines that simply lack a GPU.
+//
+// What is covered when everything is present: the full modern path —
+// render on the GPU, export a dma-buf, pass the descriptor with
+// PixmapFromBuffer, read the pixels back out of the server-side pixmap —
+// then a Present of that pixmap through CompleteNotify/IdleNotify.
+const should = require('should');
+const x11 = require('../lib');
+
+describe('DRI3 extension (live server)', () => {
+
+    const W = 32;
+    const H = 32;
+
+    let display;
+    let X;
+    let root;
+    let depth;
+    let DRI3;
+    let Present;
+    let dri = null;
+    let gpu = null;
+    let surface = null;
+    let gpuUsable = false;      // GPU context + server-side import both work
+    const pixmaps = new Map();  // bo key -> pixmap XID (alive as long as the bo)
+
+    before(function(done) {
+        try {
+            dri = require('x11-dri');
+        } catch (e) {
+            this.skip(); // native companion not installed
+            return;
+        }
+        const client = x11.createClient((err, dpy) => {
+            if (err)
+                return done(err);
+            display = dpy;
+            X = display.client;
+            root = display.screen[0].root;
+            depth = display.screen[0].root_depth;
+            X.require('dri3', (err, ext) => {
+                should.not.exist(err);
+                DRI3 = ext;
+                X.require('present', (err2, p) => {
+                    should.not.exist(err2);
+                    Present = p;
+                    done();
+                });
+            });
+        });
+        client.on('error', done);
+    });
+
+    after(done => {
+        if (X) {
+            for (const pixmap of pixmaps.values())
+                X.FreePixmap(pixmap);
+        }
+        if (surface) surface.destroy();
+        if (gpu) gpu.destroy();
+        if (!X) return done();
+        X.terminate();
+        X.on('end', done);
+    });
+
+    // create-or-reuse the pixmap wrapping a swapped-out buffer;
+    // cb(err, pixmap)
+    function ensurePixmap(out, drawable, cb) {
+        if (!out.isNew)
+            return cb(null, pixmaps.get(out.key));
+        const pixmap = X.AllocID();
+        DRI3.PixmapFromBuffer(pixmap, drawable, {
+            fd: out.fd,
+            width: out.width,
+            height: out.height,
+            stride: out.stride,
+            depth,
+            bpp: 32
+        }, impErr => {
+            if (impErr)
+                return cb(impErr);
+            pixmaps.set(out.key, pixmap);
+            cb(null, pixmap);
+        });
+    }
+
+    it('negotiates at least version 1.0', () => {
+        DRI3.major.should.be.aboveOrEqual(1);
+        DRI3.fdCapable.should.equal(true, 'unix-socket connections are fd-capable by default');
+    });
+
+    it('lists supported modifiers for the root window', done => {
+        DRI3.GetSupportedModifiers(root, depth, 32, (err, mods) => {
+            should.not.exist(err);
+            mods.windowModifiers.should.be.an.Array();
+            mods.screenModifiers.should.be.an.Array();
+            mods.windowModifiers.forEach(m => (typeof m).should.equal('bigint'));
+            done();
+        });
+    });
+
+    it('imports a GPU-rendered dma-buf and the server sees the exact pixels', function(done) {
+        if (depth !== 24 && depth !== 32)
+            return this.skip();
+        try {
+            gpu = new dri.Gpu({ format: depth === 32 ? dri.FORMAT.ARGB8888 : dri.FORMAT.XRGB8888 });
+            surface = gpu.createSurface(W, H);
+            gpu.makeCurrent(surface);
+        } catch (e) {
+            return this.skip(); // no render node / no GL stack on this machine
+        }
+        const gl = gpu.gl;
+        gl.viewport(0, 0, W, H);
+        gl.clearColor(1, 0.5, 0, 1); // 0xff8000
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        const out = surface.swap();
+        out.isNew.should.equal(true);
+        (typeof out.modifier).should.equal('bigint');
+
+        ensurePixmap(out, root, (impErr, pixmap) => {
+            if (impErr) {
+                // a server rendering on another DRM device may refuse the
+                // import; a real configuration, not a protocol failure
+                console.log('        (server refused the import: ' + impErr.message + ' — skipping)');
+                surface.release(out.key);
+                return done();
+            }
+            gpuUsable = true;
+            X.GetImage(2, pixmap, 0, 0, W, H, 0xffffffff, (err, img) => {
+                should.not.exist(err);
+                for (const at of [0, (H / 2 * W + W / 2) * 4, (W * H - 1) * 4])
+                    (img.data.readUInt32LE(at) & 0xffffff).should.equal(0xff8000);
+                surface.release(out.key);
+                done();
+            });
+        });
+    });
+
+    it('presents a dma-buf pixmap: CompleteNotify and IdleNotify arrive', function(done) {
+        if (!gpuUsable)
+            return this.skip();
+        this.timeout(8000);
+        const gl = gpu.gl;
+        const wid = X.AllocID();
+        const eid = X.AllocID();
+        X.CreateWindow(wid, root, 0, 0, W, H, 0, depth, 1, 0,
+            { backgroundPixel: display.screen[0].black_pixel });
+        X.MapWindow(wid);
+        Present.SelectInput(eid, wid,
+            Present.EventMask.CompleteNotify | Present.EventMask.IdleNotify);
+
+        gl.clearColor(0, 0, 1, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        const out = surface.swap();
+
+        let complete = false;
+        let idle = false;
+        const onEvent = ev => {
+            if (ev.name === 'PresentCompleteNotify' && ev.serial === 7) {
+                ev.kind.should.equal(Present.CompleteKind.Pixmap);
+                complete = true;
+            } else if (ev.name === 'PresentIdleNotify' && ev.serial === 7) {
+                surface.release(out.key);
+                idle = true;
+            }
+            if (complete && idle) {
+                X.removeListener('event', onEvent);
+                X.DestroyWindow(wid);
+                done();
+            }
+        };
+        X.on('event', onEvent);
+
+        ensurePixmap(out, wid, (impErr, pixmap) => {
+            should.not.exist(impErr); // it imported for the same device above
+            // Async: complete immediately, not at a vblank that a headless
+            // or throttled server may never deliver
+            Present.Pixmap(wid, pixmap, { serial: 7, options: Present.Option.Async });
+            X.flush();
+        });
+    });
+});

--- a/test/dri3.js
+++ b/test/dri3.js
@@ -1,0 +1,311 @@
+// DRI3 request encoding and reply parsing, validated against the wire
+// layouts in <X11/extensions/dri3proto.h> (xorgproto). Unit-level: the
+// extension is driven with a fake client and a detached FrameBuffer, so no
+// server, no GPU and no real descriptors-over-socket are involved — those
+// live in test/dri3-live.js (needs a DRI3 server) and in the examples.
+const should = require('should');
+const fs = require('fs');
+const FrameBuffer = require('../lib/framebuffer');
+const dri3 = require('../lib/ext/dri3');
+
+const OPCODE = 200; // fake major opcode assigned by the fake QueryExtension
+
+// A client just real enough for lib/ext/dri3.js: requests captured off a
+// detached FrameBuffer ('data' fires synchronously on submit), replies
+// resolved by hand through X.replies like lib/xcore.js would.
+function fakeClient(streamOverride) {
+    const pack_stream = new FrameBuffer(false);
+    const sent = []; // { buf, fds } in wire order
+    pack_stream.on('data', (buf, fds) => sent.push({ buf, fds: fds || null }));
+    const X = {
+        seq_num: 0,
+        replies: {},
+        pack_stream,
+        stream: streamOverride !== undefined ? streamOverride
+            : { _fdCapable: true, sendFds: () => {} },
+        _voidSyncs: [],
+        _scheduleVoidSync(seq) { this._voidSyncs.push(seq); },
+        QueryExtension(name, cb) {
+            name.should.equal('DRI3');
+            cb(null, { present: 1, majorOpcode: OPCODE, firstEvent: 0, firstError: 0 });
+        }
+    };
+    // resolve the pending reply for `seq` the way xcore.js does: parser gets
+    // the body from byte 8 on, plus the header's data byte
+    const respond = (seq, body, opt) => {
+        const handler = X.replies[seq];
+        should.exist(handler, `no reply handler registered for seq ${seq}`);
+        delete X.replies[seq];
+        handler[1](null, handler[0].call(X, body, opt));
+    };
+    return { X, sent, respond };
+}
+
+function requireDri3(harness, cb) {
+    dri3.requireExt({ client: harness.X }, (err, ext) => {
+        should.not.exist(err);
+        cb(ext);
+    });
+    // answer the automatic QueryVersion(1, 4) so requireExt completes
+    const body = Buffer.alloc(24);
+    body.writeUInt32LE(1, 0);
+    body.writeUInt32LE(4, 4);
+    harness.respond(harness.X.seq_num, body, 0);
+}
+
+describe('DRI3 extension (encoding)', () => {
+
+    let h;
+    let DRI3;
+
+    beforeEach(done => {
+        h = fakeClient();
+        requireDri3(h, ext => {
+            DRI3 = ext;
+            h.sent.length = 0; // drop the QueryVersion request
+            done();
+        });
+    });
+
+    it('negotiates version 1.4 while requiring', () => {
+        DRI3.major.should.equal(1);
+        DRI3.minor.should.equal(4);
+        DRI3.fdCapable.should.equal(true);
+    });
+
+    it('encodes QueryVersion per dri3proto', done => {
+        DRI3.QueryVersion(1, 2, (err, vers) => {
+            should.not.exist(err);
+            vers.should.eql([1, 2]);
+            done();
+        });
+        const { buf, fds } = h.sent[0];
+        should.not.exist(fds);
+        buf.length.should.equal(12);           // sz_xDRI3QueryVersionReq
+        buf.readUInt8(0).should.equal(OPCODE);
+        buf.readUInt8(1).should.equal(0);      // minor opcode
+        buf.readUInt16LE(2).should.equal(3);   // length in 4-byte units
+        buf.readUInt32LE(4).should.equal(1);
+        buf.readUInt32LE(8).should.equal(2);
+        const body = Buffer.alloc(24);
+        body.writeUInt32LE(1, 0);
+        body.writeUInt32LE(2, 4);
+        h.respond(h.X.seq_num, body, 0);
+    });
+
+    it('encodes PixmapFromBuffer and carries its descriptor', () => {
+        const fd = fs.openSync('/dev/null', 'r');
+        DRI3.PixmapFromBuffer(0x600001, 0x123, {
+            fd, width: 64, height: 32, stride: 256, depth: 24, bpp: 32
+        });
+        const { buf, fds } = h.sent[0];
+        fds.should.eql([fd]);
+        buf.length.should.equal(24);           // sz_xDRI3PixmapFromBufferReq
+        buf.readUInt8(1).should.equal(2);
+        buf.readUInt16LE(2).should.equal(6);
+        buf.readUInt32LE(4).should.equal(0x600001);
+        buf.readUInt32LE(8).should.equal(0x123);
+        buf.readUInt32LE(12).should.equal(256 * 32); // size defaults to stride*height
+        buf.readUInt16LE(16).should.equal(64);
+        buf.readUInt16LE(18).should.equal(32);
+        buf.readUInt16LE(20).should.equal(256);
+        buf.readUInt8(22).should.equal(24);
+        buf.readUInt8(23).should.equal(32);
+        fs.closeSync(fd);
+    });
+
+    it('honors an explicit size in PixmapFromBuffer', () => {
+        const fd = fs.openSync('/dev/null', 'r');
+        DRI3.PixmapFromBuffer(1, 2, {
+            fd, width: 4, height: 4, stride: 16, depth: 24, bpp: 32, size: 4096
+        });
+        h.sent[0].buf.readUInt32LE(12).should.equal(4096);
+        fs.closeSync(fd);
+    });
+
+    it('confirms PixmapFromBuffer through a void round trip when given a callback', () => {
+        const fd = fs.openSync('/dev/null', 'r');
+        let called = 'not yet';
+        DRI3.PixmapFromBuffer(1, 2, {
+            fd, width: 4, height: 4, stride: 16, depth: 24, bpp: 32
+        }, err => { called = err; });
+        const seq = h.X.seq_num;
+        h.X._voidSyncs.should.eql([seq]);
+        // no error arrives; the sweep resolves it with null like xcore does
+        h.X.replies[seq][1](null).should.be.true();
+        should.equal(called, null);
+        // an error resolves it too, and reports handled
+        fs.closeSync(fd);
+    });
+
+    it('encodes PixmapFromBuffers (DRI3 1.2) with modifier and planes', () => {
+        const fd0 = fs.openSync('/dev/null', 'r');
+        const fd1 = fs.openSync('/dev/null', 'r');
+        DRI3.PixmapFromBuffers(0xAB, 0xCD, {
+            width: 128, height: 64, depth: 24, bpp: 32,
+            modifier: DRI3.FormatModifier.Invalid,
+            planes: [
+                { fd: fd0, stride: 512, offset: 0 },
+                { fd: fd1, stride: 256, offset: 32768 }
+            ]
+        });
+        const { buf, fds } = h.sent[0];
+        fds.should.eql([fd0, fd1]);
+        buf.length.should.equal(64);           // sz_xDRI3PixmapFromBuffersReq
+        buf.readUInt8(1).should.equal(7);
+        buf.readUInt16LE(2).should.equal(16);
+        buf.readUInt32LE(4).should.equal(0xAB);
+        buf.readUInt32LE(8).should.equal(0xCD);
+        buf.readUInt8(12).should.equal(2);     // num_buffers
+        buf.readUInt16LE(16).should.equal(128);
+        buf.readUInt16LE(18).should.equal(64);
+        buf.readUInt32LE(20).should.equal(512);   // stride0
+        buf.readUInt32LE(24).should.equal(0);     // offset0
+        buf.readUInt32LE(28).should.equal(256);   // stride1
+        buf.readUInt32LE(32).should.equal(32768); // offset1
+        buf.readUInt32LE(36).should.equal(0);     // stride2 unused
+        buf.readUInt8(52).should.equal(24);
+        buf.readUInt8(53).should.equal(32);
+        buf.readBigUInt64LE(56).should.equal((1n << 56n) - 1n);
+        fs.closeSync(fd0);
+        fs.closeSync(fd1);
+    });
+
+    it('rejects PixmapFromBuffers with 0 or more than 4 planes', done => {
+        DRI3.PixmapFromBuffers(1, 2, { width: 1, height: 1, depth: 24, bpp: 32, planes: [] }, err => {
+            should.exist(err);
+            h.sent.length.should.equal(0);
+            done();
+        });
+    });
+
+    it('encodes GetSupportedModifiers and parses 64-bit modifiers exactly', done => {
+        DRI3.GetSupportedModifiers(0x321, 24, 32, (err, mods) => {
+            should.not.exist(err);
+            mods.windowModifiers.should.eql([0n, 0x0100000000000001n]);
+            mods.screenModifiers.should.eql([(1n << 56n) - 1n]);
+            done();
+        });
+        const { buf } = h.sent[0];
+        buf.length.should.equal(12);           // sz_xDRI3GetSupportedModifiersReq
+        buf.readUInt8(1).should.equal(6);
+        buf.readUInt32LE(4).should.equal(0x321);
+        buf.readUInt8(8).should.equal(24);
+        buf.readUInt8(9).should.equal(32);
+        const body = Buffer.alloc(24 + 3 * 8);
+        body.writeUInt32LE(2, 0);              // numWindowModifiers
+        body.writeUInt32LE(1, 4);              // numScreenModifiers
+        body.writeBigUInt64LE(0n, 24);
+        body.writeBigUInt64LE(0x0100000000000001n, 32); // > 2^53: needs BigInt
+        body.writeBigUInt64LE((1n << 56n) - 1n, 40);
+        h.respond(h.X.seq_num, body, 0);
+    });
+
+    it('encodes FenceFromFD with its descriptor', () => {
+        const fd = fs.openSync('/dev/null', 'r');
+        DRI3.FenceFromFD(0x42, 0x99, true, fd);
+        const { buf, fds } = h.sent[0];
+        fds.should.eql([fd]);
+        buf.length.should.equal(16);           // sz_xDRI3FenceFromFDReq
+        buf.readUInt8(1).should.equal(4);
+        buf.readUInt32LE(4).should.equal(0x42);
+        buf.readUInt32LE(8).should.equal(0x99);
+        buf.readUInt8(12).should.equal(1);
+        fs.closeSync(fd);
+    });
+
+    it('encodes SetDRMDeviceInUse (DRI3 1.3)', () => {
+        DRI3.SetDRMDeviceInUse(0x77, 226, 128);
+        const { buf, fds } = h.sent[0];
+        should.not.exist(fds);
+        buf.length.should.equal(16);           // sz_xDRI3SetDRMDeviceInUseReq
+        buf.readUInt8(1).should.equal(9);
+        buf.readUInt32LE(4).should.equal(0x77);
+        buf.readUInt32LE(8).should.equal(226);
+        buf.readUInt32LE(12).should.equal(128);
+    });
+
+    it('encodes ImportSyncobj / FreeSyncobj (DRI3 1.4)', () => {
+        const fd = fs.openSync('/dev/null', 'r');
+        DRI3.ImportSyncobj(0x11, 0x22, fd);
+        DRI3.FreeSyncobj(0x11);
+        h.sent[0].fds.should.eql([fd]);
+        h.sent[0].buf.length.should.equal(12); // sz_xDRI3ImportSyncobjReq
+        h.sent[0].buf.readUInt8(1).should.equal(10);
+        h.sent[0].buf.readUInt32LE(4).should.equal(0x11);
+        h.sent[0].buf.readUInt32LE(8).should.equal(0x22);
+        h.sent[1].buf.length.should.equal(8);  // sz_xDRI3FreeSyncobjReq
+        h.sent[1].buf.readUInt8(1).should.equal(11);
+        h.sent[1].buf.readUInt32LE(4).should.equal(0x11);
+        should.not.exist(h.sent[1].fds);
+        fs.closeSync(fd);
+    });
+
+    it('refuses the four requests whose replies carry descriptors', done => {
+        const gated = [
+            cb => DRI3.Open(1, 0, cb),
+            cb => DRI3.BufferFromPixmap(1, cb),
+            cb => DRI3.FDFromFence(1, 2, cb),
+            cb => DRI3.BuffersFromPixmap(1, cb)
+        ];
+        let remaining = gated.length;
+        gated.forEach(fn => fn(err => {
+            should.exist(err);
+            err.message.should.match(/file descriptor/);
+            if (--remaining === 0) {
+                h.sent.length.should.equal(0); // nothing reached the wire
+                done();
+            }
+        }));
+    });
+
+    it('fails cleanly and consumes the descriptor when the connection cannot pass fds', done => {
+        const plain = fakeClient({}); // stream without sendFds
+        requireDri3(plain, ext => {
+            const fd = fs.openSync('/dev/null', 'r');
+            ext.fdCapable.should.equal(false);
+            ext.PixmapFromBuffer(1, 2, { fd, width: 4, height: 4, stride: 16, depth: 24, bpp: 32 }, err => {
+                should.exist(err);
+                err.message.should.match(/fd-capable/);
+                should.throws(() => fs.fstatSync(fd)); // closed: consumed contract
+                done();
+            });
+        });
+    });
+});
+
+describe('FrameBuffer putWithFds ordering', () => {
+
+    const collect = fb => {
+        const out = [];
+        fb.on('data', (buf, fds) => out.push({ str: buf.toString(), fds: fds || null }));
+        return out;
+    };
+
+    it('keeps an fd-carrying packet in wire order (unbuffered)', () => {
+        const fb = new FrameBuffer(false);
+        const out = collect(fb);
+        fb.put(Buffer.from('aa'));
+        fb.submit();
+        fb.putWithFds(Buffer.from('bb'), [7, 8]);
+        fb.put(Buffer.from('cc'));
+        fb.submit();
+        out.map(o => o.str).should.eql(['aa', 'bb', 'cc']);
+        out[1].fds.should.eql([7, 8]);
+        should.not.exist(out[0].fds);
+        should.not.exist(out[2].fds);
+    });
+
+    it('keeps an fd-carrying packet in wire order (batching)', () => {
+        const fb = new FrameBuffer(true);
+        const out = collect(fb);
+        fb.put(Buffer.from('aa'));
+        fb.submit();
+        fb.putWithFds(Buffer.from('bb'), [9]);
+        fb.put(Buffer.from('cc'));
+        fb.submit();
+        fb.flush();
+        out.map(o => o.str).should.eql(['aa', 'bb', 'cc']);
+        out[1].fds.should.eql([9]);
+    });
+});


### PR DESCRIPTION
## What this is

node-x11 has spoken indirect GLX for years — GL 1.x serialized through the server, `+iglx` required, and on current Linux servers the GL engine behind it is gone entirely (docs/ext/glx.md). This PR adds the client side of the **modern path**, the one Mesa uses under every GL/Vulkan app on Xorg/Xwayland: render on the GPU yourself, hand the server a dma-buf, let Present flip it onto the window. Everything protocol-side is pure JS — the zero-dependency rule is intact. The GPU half (GL context, dma-buf export, udmabuf) lives in the new companion package [`x11-dri`](https://github.com/sidorares/node-x11-dri), which only the example folder depends on.

```
GPU (render node)                        X server
-----------------                        --------
render into a GBM buffer
export -> dma-buf fd  --- fd over unix socket (DRI3) --->  pixmap
Present.Pixmap(window, pixmap)  ------ vsync'd flip/copy -> on screen
                    <--- PresentCompleteNotify   (pace the next frame)
                    <--- PresentIdleNotify       (buffer reusable)
```

## Try it

```sh
cd examples/dri3 && npm install && npm start        # spinning GLES2 cube
npm run start:async                                 # unthrottled, prints fps
npm run software                                    # GPU-less: CPU pixels via udmabuf
```

The folder is a self-contained package (`x11` from this repo, `x11-dri` from GitHub; the addon builds with node-gyp and **no GL headers** — it dlopens Mesa at runtime). Needs a render node and a DRI3 server (Xorg+glamor or Xwayland; Xvfb/Xephyr have no DRI3 and the demo says so).

## New API

- **`X.require('dri3')`** — DRI3 1.0–1.4: `PixmapFromBuffer`, `PixmapFromBuffers` (multi-plane, modifiers as BigInt — format modifiers use the full 64-bit range, past Number's 53-bit exactness), `GetSupportedModifiers`, `FenceFromFD`, `SetDRMDeviceInUse`, `ImportSyncobj`/`FreeSyncobj`. Documented in docs/ext/dri3.md, including buffer lifecycle and probing.
- **`pack_stream.putWithFds(buf, fds)`** — descriptor-carrying requests now ride the ordinary output queue (the way libxcb keeps its fd queue), so wire order and sequence numbers stay correct no matter what other requests are issued around them. On the fd-capable socket, `sendFds()` **consumes** the descriptors (dma-bufs are anonymous inodes procfs cannot reopen, so no pure-JS dup exists — and consumption matches how `gbm_bo_get_fd` produces them) and splits multi-fd requests into one `uv_write2` per descriptor; the server reassociates by stream order.

## Four requests are refused on purpose

`Open`, `BufferFromPixmap`, `FDFromFence`, `BuffersFromPixmap` make the **server** send a descriptor back, and receiving one aborts the Node process before any JS runs — the same libuv `CHECK_EQ` abort already documented for MIT-SHM `CreateSegment` (lib/fdpass.js). They return an explanatory error without touching the wire. This costs nothing in practice: render nodes (`/dev/dri/renderD*`) need no X-side authentication and replace `Open`; on multi-GPU machines you probe by importing a small test buffer per node with `PixmapFromBuffer(..., cb)` — a failed import reports as a clean X error on that request's sequence number.

## MIT-SHM: ordering footgun removed

`AttachFd` used to write its descriptor out of band and documented that **no other request may be issued between the call and its callback**. It now goes through `putWithFds` like everything else, so the constraint is gone (behavior otherwise unchanged; the caller still keeps its fd — a procfs self-dup travels). docs/ext/shm.md updated.

## Testing

- `test/dri3.js` — every request byte-checked against the `dri3proto.h` layouts, plus reply parsing (BigInt modifiers round-trip values > 2^53) and the FrameBuffer ordering guarantees; runs with no server.
- `test/dri3-live.js` — the real thing against a DRI3 server: GPU-rendered buffer imported with `PixmapFromBuffer` and read back **pixel-exact** with core `GetImage`, then a Present flip with `CompleteNotify`/`IdleNotify`. Extension-gated in test-runner (Xvfb has no DRI3, so CI skips it) and self-skipping when `x11-dri` isn't installed or the machine has no usable GPU.
- Verified end-to-end on Xwayland 24.1 + virgl: the cube sustains 74 fps with `--async`; in vsync mode it honestly follows the compositor's frame callbacks (a headless compositor throttles to ~1 Hz — glxgears behaves identically there). Suite: **445 passing** (run with `test/glx.js` set aside on this machine: ubuntu-24.04's Xvfb segfaults on indirect GLX — the same known breakage ci.yml already works around with bookworm containers).

## Scope limits, stated

- Descriptors flow client → server only, by design, until the Node abort is fixed upstream (tracked in lib/fdpass.js's header).
- The examples use the implicit-modifier path (`PixmapFromBuffer`); `PixmapFromBuffers` + `GetSupportedModifiers` are implemented and unit-tested, but no server in reach advertised explicit modifiers to exercise them live.
- Present fences/syncobjs are exposed but unused by the examples — event pacing is sufficient for the copy/flip paths.
- The software demo's server-side import (`udmabuf` → glamor) is refused by virtualized GPUs (virgl wraps host GL; it cannot texture from guest RAM), so its happy path could not be exercised on this machine — the refusal path is the tested one there; the GPU cube is the primary demo.
