### PR TITLE
fix(framebuffer): drain queued reads without recursing per packet

### DIFF
--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -66,6 +66,7 @@ function FrameBuffer(options) {
     this._length = 0;
     this._offset = 0;
     this._readQueue = [];
+    this._pumping = false;
     this.write_queue = []; // Buffers, and flush-callback sentinels between them
     this._socket = null;
     this._draining = false;
@@ -148,7 +149,31 @@ FrameBuffer.prototype.get = function(length, callback) {
     this._pumpReads();
 };
 
+/**
+ * Serve what the queued reads can be served with, in order.
+ *
+ * Every reader on top of this is a continuation: serving a read runs protocol
+ * code that queues the next one (request header -> body -> next header, reply
+ * header -> body -> next header), so get() lands back here while the drain
+ * below is still running. The guard turns that into a plain enqueue — the
+ * drain in progress picks it up on its next turn — where before it cost a few
+ * stack frames per queued read, and one chunk carrying a few thousand requests
+ * overflowed the stack (#276). Callback order is the same either way; a
+ * callback that throws unwinds the drain, and the reads queued behind it are
+ * served when the next chunk arrives.
+ */
 FrameBuffer.prototype._pumpReads = function() {
+    if (this._pumping)
+        return;
+    this._pumping = true;
+    try {
+        this._drainReads();
+    } finally {
+        this._pumping = false;
+    }
+};
+
+FrameBuffer.prototype._drainReads = function() {
     while (this._readQueue.length > 0) {
         const req = this._readQueue[0];
         if (req.length === 0) {

--- a/test/framebuffer-reads.js
+++ b/test/framebuffer-reads.js
@@ -1,0 +1,106 @@
+const assert = require('assert');
+const FrameBuffer = require('../lib/framebuffer');
+
+// The inbound half of lib/framebuffer.js: exact-length get(n, cb) reads served
+// from the accumulated chunks. Everything on top of it reads as a chain of
+// continuations - the callback that consumes one packet arms the read for the
+// next - so what matters is that one chunk carrying a lot of them is drained
+// by the loop that is already running instead of one nested call per read.
+
+describe('FrameBuffer inbound reads', () => {
+
+    // deep enough that the old recursive path ran out of stack: it gave up
+    // around 1900 chained reads on a default V8 stack (#276)
+    const BURST = 5000;
+
+    function counted(n) {
+        const chunk = Buffer.alloc(n * 4);
+        for (let i = 0; i < n; i++)
+            chunk.writeUInt32LE(i, i * 4);
+        return chunk;
+    }
+
+    it('drains thousands of chained reads from one chunk without nesting', () => {
+        const fb = new FrameBuffer();
+        const seen = [];
+        let depth = 0;
+        let maxDepth = 0;
+
+        // the shape of both readers in the library: lib/xserver/server.js
+        // (request header -> body -> next header) and lib/xcore.js
+        // (packet header -> body -> next header)
+        const arm = () => fb.get(4, buf => {
+            if (++depth > maxDepth)
+                maxDepth = depth;
+            seen.push(buf.readUInt32LE(0));
+            arm();
+            depth--;
+        });
+        arm();
+
+        fb.write(counted(BURST));
+
+        assert.deepStrictEqual(seen, Array.from({ length: BURST }, (_, i) => i));
+        assert.strictEqual(maxDepth, 1,
+            'every read was served by the drain loop, not from inside the previous callback');
+    });
+
+    it('serves reads queued up front in queue order', () => {
+        // the handshake queues a read per pixmap format / depth / visual
+        // before any of them can be served
+        const fb = new FrameBuffer();
+        const seen = [];
+        for (let i = 0; i < BURST; i++)
+            fb.get(4, buf => seen.push(buf.readUInt32LE(0)));
+
+        fb.write(counted(BURST));
+
+        assert.deepStrictEqual(seen, Array.from({ length: BURST }, (_, i) => i));
+    });
+
+    it('runs a read queued from a callback after that callback returns', () => {
+        const fb = new FrameBuffer();
+        const order = [];
+        fb.get(2, () => {
+            order.push('header');
+            fb.get(2, () => order.push('body'));
+            order.push('rest of header callback');
+        });
+
+        fb.write(Buffer.from([1, 2, 3, 4]));
+
+        assert.deepStrictEqual(order, ['header', 'rest of header callback', 'body']);
+    });
+
+    it('picks up data written from inside a callback', () => {
+        const fb = new FrameBuffer();
+        const seen = [];
+        fb.get(1, first => {
+            seen.push(first[0]);
+            fb.get(1, second => seen.push(second[0]));
+            fb.write(Buffer.from([2])); // arrives while the drain is running
+        });
+
+        fb.write(Buffer.from([1]));
+
+        assert.deepStrictEqual(seen, [1, 2]);
+    });
+
+    it('completes a read split across chunks', () => {
+        const fb = new FrameBuffer();
+        let got = null;
+        fb.get(6, buf => got = buf);
+
+        fb.write(Buffer.from([1, 2]));
+        assert.strictEqual(got, null, 'not enough bytes yet');
+        fb.write(Buffer.from([3, 4, 5]));
+        assert.strictEqual(got, null, 'still short by one byte');
+        fb.write(Buffer.from([6, 7]));
+
+        assert.deepStrictEqual(got, Buffer.from([1, 2, 3, 4, 5, 6]));
+
+        let tail = null;
+        fb.get(1, buf => tail = buf);
+        assert.deepStrictEqual(tail, Buffer.from([7]), 'the leftover byte stayed buffered');
+    });
+});

--- a/test/xserver/burst.js
+++ b/test/xserver/burst.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const x11 = require('../../lib');
+const { createServer, createStreamPair } = require('../../lib/xserver');
+const { boot, sync } = require('./boot');
+
+// A frame's worth of requests leaves the client in one flush and arrives at
+// the server as one chunk; a burst of events makes the same trip the other
+// way. Both readers used to recurse once per packet in the chunk and ran out
+// of stack a couple of thousand packets in (#276).
+
+describe('xserver: packet bursts arriving in one chunk', () => {
+
+    // 4-byte requests, 32-byte events: well past where the recursion died,
+    // and small enough that a burst is a few chunks, not a few thousand
+    const BURST = 5000;
+
+    it('handles thousands of requests written as one chunk', done => {
+        // buffering is what puts them all in one write: unbuffered, each
+        // request is its own chunk and nothing queues up behind it
+        boot({ clientOptions: { bufferRequests: true } }, (err, ctx) => {
+            if (err) return done(err);
+            const { server, X } = ctx;
+            const handlerErrors = [];
+            server.on('handlerError', e => handlerErrors.push(e));
+
+            // no-ops in this server, and the two smallest requests there are
+            for (let i = 0; i < BURST; i++) {
+                X.GrabServer();
+                X.UngrabServer();
+            }
+            X.flush();
+
+            // the reply can only reach this callback if the server got through
+            // every request before it - its sequence number says how many
+            sync(X, err2 => {
+                X.terminate();
+                if (err2) return done(err2);
+                assert.deepStrictEqual(handlerErrors, []);
+                done();
+            });
+        });
+    });
+
+    it('dispatches thousands of events written as one chunk', done => {
+        const server = createServer();
+        const [clientSide, serverSide] = createStreamPair();
+        server.addClientStream(serverSide);
+        x11.createClient({ display: ':9', stream: clientSide }, (err, display) => {
+            if (err) return done(err);
+            const X = display.client;
+            let seen = 0;
+            X.on('event', ev => {
+                assert.strictEqual(ev.name, 'Expose');
+                assert.strictEqual(ev.x, seen % 0x10000);
+                if (++seen === BURST) {
+                    X.terminate();
+                    done();
+                }
+            });
+
+            const events = [];
+            for (let i = 0; i < BURST; i++)
+                events.push(x11.packEvent({
+                    name: 'Expose', wid: 1, x: i % 0x10000, y: 0,
+                    width: 1, height: 1, count: 0
+                }));
+            // the stream pair hands over exactly what is written, so this is
+            // one chunk - the same thing a socket does when it coalesces
+            serverSide.write(Buffer.concat(events));
+        });
+    });
+});


### PR DESCRIPTION
Closes #276.

## The bug

A single inbound chunk carrying a few thousand packets kills the connection with

```
RangeError: Maximum call stack size exceeded
    at FrameBuffer._pumpReads (lib/framebuffer.js:151)
    at FrameBuffer.get (lib/framebuffer.js:148)
    at proceed (lib/xserver/server.js:109)
    …repeating…
```

`_pumpReads()` is written as a drain loop, but the recursion comes in through the callback. Every reader in the library is a continuation: the callback that consumes a packet arms the read for the next one (request header → body → next header in `lib/xserver/server.js`, packet header → body → next header in `lib/xcore.js`). That nested `get()` pushes its read *and calls `_pumpReads()` again*, so the drain that is already running never gets control back — depth grows by a few stack frames per packet available in the buffer, and V8 gives out somewhere around 1900 of them.

Nothing exotic is needed to hit it, only enough packets in one chunk:

- **outbound** — a client with `bufferRequests` on flushing a frame's worth of small requests. A 16 KB batch holds ~4000 four-byte requests; the report was ~3000 Render requests per frame under react-x11's in-process test harness.
- **inbound** — a burst of events or replies that the socket coalesces into one read.

## The fix

A reentrancy guard on the drain (`lib/framebuffer.js`). A `get()` issued from a callback now only enqueues; the loop already in progress serves it on its next turn. Callback order is unchanged — the one visible difference is that a read queued from inside a callback runs after that callback returns rather than in the middle of it, which is what the readers already assume (both arm the next read as their last statement).

The recursion was also the depth limit on the handshake's `readVisuals`/`readDepths` walk; those are iterative now too.

## Testing

Both new suites fail on master with the stack trace above and pass with the fix.

- `test/framebuffer-reads.js` — the inbound path on its own: 5000 chained reads drained from one chunk with the callback nesting asserted flat, reads queued up front served in queue order, the ordering of a read queued from a callback, data written from inside a callback, and a read split across chunks.
- `test/xserver/burst.js` — end to end over an in-process stream pair, in both directions: 10 000 requests written as one chunk (a buffered client, the sequence number of the following reply proving the server got through all of them), and 5000 events written as one chunk to the client.

Full suite: 477 passing under Xvfb, 286 in `test:xserver`, 52 in `test:glx-emu`, lint clean.