### PR TITLE
fix(auth): warn about an unmatched Xauthority only when the server refuses

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -119,15 +119,18 @@ const MAX_LISTED_ENTRIES = 8;
 const warnedMatchFailures = new Set();
 
 /**
- * Say why a cookie file that exists did not produce a cookie.
+ * Explain why a cookie file that exists did not produce a cookie.
  *
  * Falling back to an unauthenticated connection is right — plenty of servers
- * accept one — but doing it silently means the only symptom is the server's
- * generic "Authorization required", which looks identical to having no
- * Xauthority file at all. Naming the file, what was wanted and what was in it
- * turns that into a one-line diagnosis.
+ * accept one, and when one does, the mismatch cost nothing and deserves no
+ * words (nor a copy of the file's contents in the app's logs). So nothing is
+ * printed here: the caller gets a print-once function to invoke only if the
+ * server actually refuses the connection. At that point, naming the file,
+ * what was wanted and what was in it turns the server's generic
+ * "Authorization required" — which looks identical to having no Xauthority
+ * file at all — into a one-line diagnosis.
  */
-function warnNoMatch(filename, auth, family, host, display) {
+function warnNoMatchOnRefusal(filename, auth, family, host, display) {
   let found;
   if (auth.length === 0) {
     found = '    (no entries)';
@@ -141,16 +144,25 @@ function warnNoMatch(filename, auth, family, host, display) {
     found = shown.join('\n');
   }
   const message =
-    `x11: no entry in ${filename} matches this connection, so it is being made without\n` +
-    `  authentication - the server will refuse it unless it accepts unauthenticated clients.\n` +
+    `x11: the server refused the connection, which was made without authentication\n` +
+    `  because no entry in ${filename} matches it.\n` +
     `  wanted: ${familyLabel(family)} address ${JSON.stringify(host)} display ${JSON.stringify(display)}\n` +
     `  file has:\n${found}`;
-  if (warnedMatchFailures.has(message))
-    return;
-  warnedMatchFailures.add(message);
-  console.warn(message);
+  return () => {
+    if (warnedMatchFailures.has(message))
+      return;
+    warnedMatchFailures.add(message);
+    console.warn(message);
+  };
 }
 
+/**
+ * Pick the cookie for (display, host, socketFamily).
+ *
+ * cb(err, cookie, warnIfRefused) — `warnIfRefused` is set only when a file
+ * was read and nothing in it matched: a function for the connection code to
+ * call if the server turns the unauthenticated attempt down.
+ */
 module.exports = (display, host, socketFamily, cb) => {
   let family;
   if (socketFamily === 'IPv4') {
@@ -179,11 +191,12 @@ module.exports = (display, host, socketFamily, cb) => {
           (cookie.display.length === 0 || cookie.display === display))
         return cb( null, cookie );
     }
-    // No cookie matched. Proceed without authentication, but say so.
-    warnNoMatch(filename, auth, family, host, display);
+    // No cookie matched. Proceed without authentication; whether that was
+    // worth mentioning is only known once the server answers, so hand the
+    // caller the warning to fire if it refuses.
     cb(null, {
       authName: '',
       authData: ''
-    });
+    }, warnNoMatchOnRefusal(filename, auth, family, host, display));
   });
 };

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -218,11 +218,16 @@ function getByteOrder() {
     }
 }
 
-function writeClientHello(stream, displayNum, authHost, authFamily, authOverride)
+function writeClientHello(stream, displayNum, authHost, authFamily, authOverride, onNoCookieMatch)
 {
-    const withCookie = (err, cookie) => {
+    const withCookie = (err, cookie, warnIfRefused) => {
         if (err) {
             throw err;
+        }
+        // an Xauthority file was read and nothing in it matched: worth a
+        // warning only if the server refuses, which the caller will know
+        if (warnIfRefused && onNoCookieMatch) {
+            onNoCookieMatch(warnIfRefused);
         }
         const byte_order = getByteOrder();
         const protocol_major = 11; // TODO: config? env?

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -661,9 +661,16 @@ XClient.prototype.expectReplyHeader = function()
 XClient.prototype.startHandshake = function() {
     const client = this;
 
-    handshake.writeClientHello(this.pack_stream, this.displayNum, this.authHost, this.authFamily, this.options.auth);
+    // Set when an Xauthority file was read and no entry matched: a function
+    // that prints the diagnosis. The connection went out unauthenticated,
+    // which is only worth a word if the server turns it down.
+    let warnNoCookieMatched = null;
+    handshake.writeClientHello(this.pack_stream, this.displayNum, this.authHost, this.authFamily, this.options.auth,
+        warn => { warnNoCookieMatched = warn; });
     handshake.readServerHello(this.pack_stream, (err, display) => {
         if (err) {
+            if (warnNoCookieMatched)
+                warnNoCookieMatched();
             client.emit('error', err);
             return;
         }

--- a/test/auth.js
+++ b/test/auth.js
@@ -63,6 +63,12 @@ describe('Xauthority', () => {
             getAuthString(display, host, family, (err, cookie) =>
                 err ? reject(err) : resolve(cookie)));
 
+    /** Like lookup, but also resolves the deferred no-match warning (if any). */
+    const lookupWithReport = (display = '0', host = 'myhost', family = 'pipe') =>
+        new Promise((resolve, reject) =>
+            getAuthString(display, host, family, (err, cookie, warnIfRefused) =>
+                err ? reject(err) : resolve({ cookie, warnIfRefused })));
+
     it('selects a FamilyWild cookie for any address', async () => {
         // the bug: matching tested cookie.family, which parseXauth never sets,
         // so this entry could never be chosen and the connection went out with
@@ -114,20 +120,38 @@ describe('Xauthority', () => {
         assert.strictEqual(cookie.authName, '', 'wildcard is over the address, not the display');
     });
 
-    it('says which file it read and what was in it when nothing matches', async () => {
-        // the silent half of the bug: without this the only symptom is the
-        // server's generic "Authorization required", identical to having no
-        // Xauthority file at all
+    it('stays quiet when nothing matches, until the server actually refuses', async () => {
+        // the server may well accept the unauthenticated connection, and then
+        // the mismatch cost nothing — warning up front was both noise and a
+        // copy of the file's contents in whatever log captured stderr
         const file = useAuthFile(entry(FAMILY_LOCAL, 'otherhost', '0', 'MIT-MAGIC-COOKIE-1', KEY));
 
-        const cookie = await lookup('0', 'myhost');
+        const { cookie, warnIfRefused } = await lookupWithReport('0', 'myhost');
         assert.strictEqual(cookie.authName, '');
+        assert.deepStrictEqual(warnings, [], 'the outcome is not known yet, so nothing to say');
+
+        // the server refused: now the mismatch is the diagnosis
+        warnIfRefused();
         assert.strictEqual(warnings.length, 1);
         const said = warnings[0];
+        assert.ok(said.includes('the server refused the connection'),
+            'describes what happened, not a prediction');
         assert.ok(said.includes(file), 'names the file it read');
         assert.ok(said.includes('"myhost"'), 'names what it was looking for');
         assert.ok(said.includes('"otherhost"'), 'names what it found instead');
         assert.ok(!said.includes(KEY.toString('latin1')), 'never prints the key itself');
+
+        warnIfRefused();
+        assert.strictEqual(warnings.length, 1, 'the same diagnosis is printed once');
+    });
+
+    it('hands back no refusal report when a cookie matched', async () => {
+        useAuthFile(entry(FAMILY_LOCAL, 'myhost', '0', 'MIT-MAGIC-COOKIE-1', KEY));
+
+        const { cookie, warnIfRefused } = await lookupWithReport('0', 'myhost');
+        assert.strictEqual(cookie.authName, 'MIT-MAGIC-COOKIE-1');
+        assert.strictEqual(warnIfRefused, undefined,
+            'a refusal with a matching cookie is not the no-entry story');
     });
 
     it('stays quiet when there is no Xauthority file at all', async () => {

--- a/test/connect.js
+++ b/test/connect.js
@@ -111,4 +111,69 @@ describe('Client', () => {
         done('should not reach here before first done()');
     });
   });
+
+  it('prints the Xauthority no-match diagnosis only when the server refuses', done => {
+    // the warning used to fire on every connection, before the server had
+    // answered, and was usually wrong about the outcome (react-x11#371). Here
+    // the server does refuse, so the diagnosis must still arrive.
+    const fs = require('fs');
+    const os = require('os');
+    const path = require('path');
+    const net = require('net');
+
+    // an Xauthority whose single entry cannot match this connection:
+    // family Local (256), an address no machine has, display "0"
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'x11-noauth-'));
+    const authFile = path.join(home, 'authfile');
+    const fields = [Buffer.from('no-such-host-entry'), Buffer.from('0'),
+        Buffer.from('MIT-MAGIC-COOKIE-1'), Buffer.alloc(16, 0xcd)];
+    fs.writeFileSync(authFile, Buffer.concat([Buffer.from([1, 0])].concat(
+        fields.flatMap(f => [Buffer.from([f.length >> 8, f.length & 0xff]), f]))));
+    const savedXauthority = process.env.XAUTHORITY;
+    process.env.XAUTHORITY = authFile;
+
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+
+    let finished = false;
+    const finish = err => {
+        if (finished) return;
+        finished = true;
+        console.warn = originalWarn;
+        if (savedXauthority === undefined) delete process.env.XAUTHORITY;
+        else process.env.XAUTHORITY = savedXauthority;
+        fs.rmSync(home, { recursive: true, force: true });
+        server.close(() => done(err));
+    };
+
+    const reason = 'Authorization required, but no authorization protocol specified';
+    const server = net.createServer(sock => {
+        sock.once('data', () => {
+            // X11 setup Failed reply; the client reads the status byte and
+            // the reason length, skips the rest of the header, then the text
+            sock.end(Buffer.concat([
+                Buffer.from([0, reason.length]), Buffer.alloc(6), Buffer.from(reason)
+            ]));
+        });
+    });
+    server.listen(0, '127.0.0.1', () => {
+        // createClient dials TCP port 6000 + displayNum
+        const displayNum = server.address().port - 6000;
+        const client = x11.createClient({ display: `127.0.0.1:${displayNum}` }, () => {});
+        client.on('error', err => {
+            try {
+                assert.match(err.message, /Authorization required/);
+                assert.strictEqual(warnings.length, 1,
+                    `expected exactly the diagnosis, got: ${JSON.stringify(warnings)}`);
+                assert.ok(warnings[0].includes('the server refused the connection'),
+                    'describes what happened, not a prediction');
+                assert.ok(warnings[0].includes(authFile), 'names the file it read');
+                finish();
+            } catch (e) {
+                finish(e);
+            }
+        });
+    });
+  });
 });


### PR DESCRIPTION
Fixes sidorares/react-x11#371.

## Problem

Every connection made without a matching `.Xauthority` entry printed a 14-line warning up front — "the server will refuse it unless it accepts unauthenticated clients" — even when the server then accepted it, which is the normal case on XQuartz and any server allowing unauthenticated local clients. Besides being noise on every successful connection (react-x11 tools that open one connection per inspected client multiply it), the warning dumped an inventory of the user's `.Xauthority` entries — host names, addresses, display numbers — into whatever captured stderr.

## Fix

The warning was a prediction; now it waits for the answer.

- `lib/auth.js` no longer prints on a failed cookie match. It builds the same diagnosis (file name, what was wanted, what the file has — never the keys themselves) and hands it to the caller as a print-once function in a new third callback argument.
- `lib/handshake.js` threads that function through `writeClientHello` to the connection code.
- `lib/xcore.js` fires it in `startHandshake` only when the server answers the setup with Failed, right before the error is emitted — so the refusal arrives together with its explanation, and a successful connection stays silent.
- The message is reworded to describe what happened ("the server refused the connection, which was made without authentication because no entry in ... matches it") instead of predicting it.

Nothing changes for connections where a cookie matches, where there is no Xauthority file at all, or for caller-supplied `options.auth`.

## Tests

- `test/auth.js`: the no-match lookup stays quiet, hands back the deferred report, prints it once (and only once) when invoked, still names the file / wanted / found and never the key; a matched cookie hands back no report.
- `test/connect.js`: end-to-end against a mock TCP server that answers the setup with Failed — the diagnosis is printed exactly once, worded as fact, alongside the connection error.
- Mutation-checked: both new tests fail against the previous implementation.
- Verified on macOS/XQuartz with a non-matching `.Xauthority` (the scenario from the issue): the connection succeeds with no output at all.