### PR TITLE
fix: GrabKeyboard wrote the grab modes inside the time field

### DIFF
--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -884,8 +884,8 @@ const templates = {
            b.writeUInt16LE(4, 2);
            b.writeUInt32LE(wid >>> 0, 4);
            b.writeUInt32LE(time >>> 0, 8);
-           b[10] = pointerMode;
-           b[11] = keybMode;
+           b[12] = pointerMode;
+           b[13] = keybMode;
            return b;
        },
        (buf, status) => status

--- a/lib/xserver/input.js
+++ b/lib/xserver/input.js
@@ -323,7 +323,11 @@ function install(server) {
             status = 1;
         else
             server.grabs.keyboard = {
-                client, wid: win.id, ownerEvents: !!ownerEvents, implicit: false
+                client, wid: win.id, ownerEvents: !!ownerEvents,
+                time: body.readUInt32LE(4),
+                pointerMode: body.readUInt8(8),
+                keybMode: body.readUInt8(9),
+                implicit: false
             };
         client.send(client.startReply(0, status));
     };

--- a/test/xserver/grabs.js
+++ b/test/xserver/grabs.js
@@ -164,6 +164,21 @@ describe('xserver: grabs', () => {
         });
     });
 
+    it('GrabKeyboard marshals time and the modes at their protocol offsets', done => {
+        // Regression: the modes used to be written at bytes 10/11 — inside the
+        // time field — so a real server saw a garbage timestamp and both modes
+        // as Synchronous. Distinct values on every field catch any reshuffle.
+        A.GrabKeyboard(winA, 0, 0x12345678, 1, 0, (err, status) => {
+            if (err) return done(err);
+            assert.strictEqual(status, 0);
+            assert.strictEqual(server.grabs.keyboard.time, 0x12345678);
+            assert.strictEqual(server.grabs.keyboard.pointerMode, 1);
+            assert.strictEqual(server.grabs.keyboard.keybMode, 0);
+            A.UngrabKeyboard(0);
+            sync(A, () => done());
+        });
+    });
+
     it('GrabKey activates a keyboard grab for the matching key only', done => {
         // A passively grabs key 38 on the root (ancestor of every window)
         A.GrabKey(root, 0, 0x8000, 38, 1, 1);


### PR DESCRIPTION
## The bug

`GrabKeyboard` in `lib/corereqs.js` marshalled pointer-mode/keyboard-mode at request bytes **10/11** — the two high bytes of the 4-byte `time` field — instead of the protocol's **12/13**:

```
1  31        opcode
1  BOOL      owner-events
2  4         request length
4  WINDOW    grab-window
4  TIMESTAMP time          ← bytes 8–11; modes were written into 10/11
1  pointer-mode             ← byte 12, was left 0 (Synchronous)
1  keyboard-mode            ← byte 13, was left 0 (Synchronous)
2  unused
```

It reads as a copy-paste from `GrabPointer`, where 10/11 *is* correct — that request has a 2-byte event-mask at offset 8 rather than a timestamp.

## What a real server saw

- `time` corrupted: CurrentTime (0) became `pointerMode << 16 | keybMode << 24` — nonzero whenever either mode was Asynchronous, which Xorg typically answers with **InvalidTime**.
- Both modes read from the zeroed bytes 12/13 as **Synchronous** — so the rare grab that did succeed froze the keyboard until AllowEvents.

The in-process JS test server never read those bytes ([lib/xserver/input.js](lib/xserver/input.js) opcode 31 handler only parsed the window), which is how the suite stayed green headlessly. The ancient #90 — "grab keyboard doesn't take effect", 2015, where passing `time = 0` instead of `new Date()` "fixed" it — fits this bug's symptoms exactly.

Found downstream in react-x11 (sidorares/react-x11#377) while verifying its eyedropper against a live Xorg session: `X.GrabKeyboard` with CurrentTime kept coming back InvalidTime, and the wire dump showed the modes riding inside the timestamp.

## The fix

- `corereqs.js`: write the modes at bytes 12/13, after the intact timestamp.
- `lib/xserver/input.js`: the JS server's `GrabKeyboard` handler now parses `time`, `pointerMode`, and `keybMode` into the grab it records (matching how `GrabButton` stores its modes), so the wire offsets are visible to tests.
- `test/xserver/grabs.js`: a round-trip regression test sends distinct values in every field (`time = 0x12345678`, asymmetric modes) and asserts the server saw exactly them — any reshuffle of the offsets now fails.

## Verified

- `npm run test:xserver`: 287 passing (includes the new regression test).
- Full `npm test` against a live X server (XQuartz): 447 passing / 17 failing — byte-identical counts to a clean-tree baseline run; the failures are this machine's known display-environment flakes (XInput, xkb, DBE, Present, event-routing races) and none touch grabs.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)