### PR TITLE
fix(ext)!: report the wire event type on every extension event

### DIFF
--- a/docs/ext/apple-wm.md
+++ b/docs/ext/apple-wm.md
@@ -18,7 +18,7 @@ X.require('apple-wm', (err, AppleWM) => {
     AppleWM.SetWindowLevel(win, AppleWM.WindowLevel.Floating);
     X.on('event', ev => {
         if (ev.name === 'AppleWMControllerNotify' &&
-            ev.type === AppleWM.EventKind.Controller.CloseWindow) {
+            ev.kind === AppleWM.EventKind.Controller.CloseWindow) {
             // user picked Close from the native menu
         }
     });
@@ -101,14 +101,15 @@ Minor opcode 13. Marks window `child` as a transient attached to `parent`
 ## Events
 
 Enable delivery with `SelectInput`. All three events share one parsed
-shape: `{name, type, time, arg}` where `name` is the event name below,
-`type` is the kind code (see `EventKind`), `time` is the server timestamp
-and `arg` is a kind-specific 32-bit argument (e.g. the window id for
-per-window controller actions).
+shape: `{name, type, seq, kind, time, arg}` where `name` is the event name
+below, `type` is the wire event type (`firstEvent + events.*`), `seq` is
+the sequence number, `kind` is the kind code (see `EventKind`), `time` is
+the server timestamp and `arg` is a kind-specific 32-bit argument (e.g.
+the window id for per-window controller actions).
 
 ### AppleWMControllerNotify
 First event + 0, selected by `NotifyMask.Controller`. Sent when the user
-drives X11 windows from the native side. `type` is one of
+drives X11 windows from the native side. `kind` is one of
 `EventKind.Controller`: `MinimizeWindow` 0, `ZoomWindow` 1, `CloseWindow`
 2, `BringAllToFront` 3, `WideWindow` 4, `HideAll` 5, `ShowAll` 6,
 `WindowMenuItem` 9, `WindowMenuNotify` 10, `NextWindow` 11,
@@ -116,11 +117,11 @@ drives X11 windows from the native side. `type` is one of
 
 ### AppleWMActivationNotify
 First event + 1, selected by `NotifyMask.Activation`. X11.app gained or
-lost the native foreground. `type` is one of `EventKind.Activation`:
+lost the native foreground. `kind` is one of `EventKind.Activation`:
 `IsActive` 0, `IsInactive` 1, `ReloadPreferences` 2.
 
 ### AppleWMPasteboardNotify
-First event + 2, selected by `NotifyMask.Pasteboard`. `type` is
+First event + 2, selected by `NotifyMask.Pasteboard`. `kind` is
 `EventKind.Pasteboard.CopyToPasteboard` (0) — the server wants the current
 selection copied to the macOS pasteboard.
 

--- a/docs/ext/damage.md
+++ b/docs/ext/damage.md
@@ -72,6 +72,7 @@ Delivered when a monitored drawable changes, subject to the report level.
 Not selected via an event mask — creating a damage object selects delivery.
 Parsed fields:
 
+- `type` — wire event type (`firstEvent + Damage.events.DamageNotify`)
 - `level` — report level of the damage object (`Damage.ReportLevel`); the
   server may set bit `0x80` when more events for the same drawable follow
 - `seq` — sequence number

--- a/docs/ext/screen-saver.md
+++ b/docs/ext/screen-saver.md
@@ -79,6 +79,7 @@ are dropped when it disconnects. No reply.
 ### ScreenSaverNotify
 Delivered after `SelectInput`. Parsed fields:
 
+- `type` — wire event type (`firstEvent + Saver.events.ScreenSaverNotify`)
 - `state` — new saver state (`Saver.State`; `Cycle: 2` for cycle events)
 - `seq` — sequence number
 - `time` — server timestamp

--- a/lib/ext/apple-wm.js
+++ b/lib/ext/apple-wm.js
@@ -369,7 +369,11 @@ exports.requireExt = (display, callback) => {
                 case ext.firstEvent + ext.events.AppleWMActivationNotify: event.name = 'AppleWMActivationNotify'; break;
                 case ext.firstEvent + ext.events.AppleWMPasteboardNotify: event.name = 'AppleWMPasteboardNotify'; break;
             }
-            event.type = code;
+            event.type = type;
+            event.seq = seq;
+            // the detail byte is the notify kind (EventKind.*); `type` stays
+            // the wire event type, as in every other extension parser
+            event.kind = code;
             event.time = extra;
             event.arg = raw.readUInt32LE(2);
             return event;

--- a/lib/ext/damage.js
+++ b/lib/ext/damage.js
@@ -98,6 +98,7 @@ exports.requireExt = (display, callback) => {
 
         X.eventParsers[ext.firstEvent + ext.events.DamageNotify] = (type, seq, extra, code, raw) => {
             const event = {};
+            event.type = type;
             event.level = code;
             event.seq = seq;
             event.drawable = extra;

--- a/lib/ext/screen-saver.js
+++ b/lib/ext/screen-saver.js
@@ -177,6 +177,7 @@ exports.requireExt = (display, callback) => {
 
         X.eventParsers[ext.firstEvent + ext.events.ScreenSaverNotify] = (type, seq, extra, code, raw) => {
             const event = {};
+            event.type = type;
             event.state = code;
             event.seq = seq;
             event.time = extra;

--- a/test/apple-wm.js
+++ b/test/apple-wm.js
@@ -80,6 +80,22 @@ describe('Apple-WM', () => {
     }
   });
 
+  it('parses a notify into name/type/kind/time/arg', () => {
+    const { X } = makeExt();
+    // xAppleWMNotifyEvent: type, kind, sequenceNumber, time, pad1, arg
+    // -> the parser gets bytes 8+, so arg sits at raw offset 2
+    const raw = Buffer.alloc(24);
+    raw.writeUInt32LE(0x12345678, 2);
+    const type = FIRST_EVENT + 0;
+    const ev = X.eventParsers[type](type, 9, 0xaabbccdd, 2 /* CloseWindow */, raw);
+    assert.strictEqual(ev.name, 'AppleWMControllerNotify');
+    assert.strictEqual(ev.type, type, 'type is the wire event type');
+    assert.strictEqual(ev.kind, 2, 'kind is the detail byte (EventKind.*)');
+    assert.strictEqual(ev.seq, 9);
+    assert.strictEqual(ev.time, 0xaabbccdd);
+    assert.strictEqual(ev.arg, 0x12345678);
+  });
+
   it('encodes FrameHitTest with px/py after the pad word', () => {
     const { ext, last } = makeExt();
     ext.FrameHitTest(

--- a/test/damage.js
+++ b/test/damage.js
@@ -35,6 +35,8 @@ describe('DAMAGE extension', () => {
                 return;
             X.removeListener('event', listener);
             ev.drawable.should.equal(wid);
+            // routing by type must work as it does for every other event
+            ev.type.should.equal(this.damage.firstEvent + this.damage.events.DamageNotify);
             this.damage.Destroy(damage);
             X.FreeGC(gc);
             X.DestroyWindow(wid);

--- a/test/ext-event-type.js
+++ b/test/ext-event-type.js
@@ -4,11 +4,7 @@
 // that reports only `name` is invisible to a type-keyed dispatcher.
 //
 // Hermetic: the client is stubbed, so this needs no X server.
-//
-// Apple-WM is the documented exception: its three notifies publish the kind
-// code (EventKind.*) as `event.type`, which is what docs/ext/apple-wm.md
-// tells consumers to switch on. Correcting that is a breaking change, so it
-// is left alone here rather than fixed in passing.
+
 
 const assert = require('assert');
 const fs = require('fs');
@@ -50,11 +46,7 @@ describe('extension event parsers', () => {
     const files = fs.readdirSync(path.join(__dirname, '..', 'lib', 'ext'))
         .filter(f => f.endsWith('.js'));
 
-    const skip = new Set(['apple-wm.js']);
-
     for (const file of files) {
-        if (skip.has(file))
-            continue;
         const parsers = loadParsers(file);
         const types = Object.keys(parsers).map(Number);
         if (types.length === 0)

--- a/test/ext-event-type.js
+++ b/test/ext-event-type.js
@@ -1,0 +1,72 @@
+// Every extension event parser must stamp `event.type` with the wire event
+// type it was registered under. Consumers route by type (that is the only
+// field that identifies the event once firstEvent is known), so a parser
+// that reports only `name` is invisible to a type-keyed dispatcher.
+//
+// Hermetic: the client is stubbed, so this needs no X server.
+//
+// Apple-WM is the documented exception: its three notifies publish the kind
+// code (EventKind.*) as `event.type`, which is what docs/ext/apple-wm.md
+// tells consumers to switch on. Correcting that is a breaking change, so it
+// is left alone here rather than fixed in passing.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const FIRST_EVENT = 64;
+const MAJOR = 130;
+
+// Extensions whose events are GenericEvents (no classic 32-byte event, so no
+// eventParsers entry) or which need a live reply before registering are not
+// exercised here; the loop below simply finds no parsers for them.
+function loadParsers(file) {
+    const mod = require(path.join('..', 'lib', 'ext', file));
+    const eventParsers = {};
+    const X = {
+        seq_num: 0,
+        replies: {},
+        eventParsers,
+        geEventParsers: {},
+        pack_stream: { put: () => {}, submit: () => {} },
+        QueryExtension: (name, cb) => cb(null, {
+            present: true,
+            majorOpcode: MAJOR,
+            firstEvent: FIRST_EVENT,
+            firstError: 128
+        })
+    };
+    const display = { client: X, screen: [{ root: 1, depths: {} }] };
+    try {
+        mod.requireExt(display, () => {});
+    } catch (e) {
+        // an extension that insists on a real reply before it can finish;
+        // whatever it managed to register is still checked below
+    }
+    return eventParsers;
+}
+
+describe('extension event parsers', () => {
+    const files = fs.readdirSync(path.join(__dirname, '..', 'lib', 'ext'))
+        .filter(f => f.endsWith('.js'));
+
+    const skip = new Set(['apple-wm.js']);
+
+    for (const file of files) {
+        if (skip.has(file))
+            continue;
+        const parsers = loadParsers(file);
+        const types = Object.keys(parsers).map(Number);
+        if (types.length === 0)
+            continue;
+
+        for (const type of types) {
+            it(`${file}: parser for event ${type} sets event.type`, () => {
+                const raw = Buffer.alloc(64);
+                const ev = parsers[type](type, 7, 0, 0, raw);
+                assert.strictEqual(ev.type, type,
+                    `${file} event ${type} reported type ${ev.type}`);
+            });
+        }
+    }
+});


### PR DESCRIPTION
Upstream fix for the wrinkle called out in [ntk#305](https://github.com/sidorares/ntk/pull/305): node-x11's DamageNotify parser is the one extension parser that sets `event.name` but not `event.type`, so ntk's routing map has to be keyed by both the computed type code and the wire name.

`type` is the only field that identifies an event once `firstEvent` is known — a dispatcher keyed by type simply never saw DamageNotify. `lib/ext/damage.js` now stamps it, as every other extension parser already does.

Auditing the rest turned up two more offenders:

- **MIT-SCREEN-SAVER** `ScreenSaverNotify` — same omission, same one-line fix.
- **Apple-WM** — its three notifies put the detail byte (the notify *kind*) in `event.type`, shadowing the field. `type` is now the wire event type, the kind moves to `event.kind`, and the sequence number is reported as `seq` like everywhere else.

BREAKING CHANGE: Apple-WM notify events report the `EventKind` code as `event.kind`; `event.type` is now the wire event type. XQuartz-only, and no known users.

## Testing

- `test/ext-event-type.js` — hermetic: stubs the client, loads every module under `lib/ext/`, and asserts each registered event parser reports the type it was registered under. Covers apple-wm ×3, damage, fixes ×2, randr, screen-saver, shape, shm, sync ×2, xkb, xv ×2.
- `test/apple-wm.js` — new case pinning the parsed shape (`name`/`type`/`kind`/`seq`/`time`/`arg`, `arg` after the pad word).
- `test/damage.js` — the live DamageNotify test now also asserts `ev.type`.
- Full suite against Xvfb: 495 passing, 4 pending, 0 failures.

Docs updated: event field lists in `docs/ext/damage.md`, `docs/ext/screen-saver.md`, and `docs/ext/apple-wm.md` (including the `ev.kind` switch in its example).

The issue's other upstream idea — parsers also setting `wid` — is not done here; per ntk#305 it would not remove the need for the name table and coalescing on that side.