### PR TITLE
feat(render): decode the screens section of QueryPictFormats

### DIFF
--- a/docs/ext/render.md
+++ b/docs/ext/render.md
@@ -24,13 +24,17 @@ X.require('render', (err, Render) => {
 });
 ```
 
-While requiring, the module calls `QueryPictFormat` and scans the reply for
-the standard formats, exposing their PICTFORMAT ids as properties:
+While requiring, the module calls `QueryPictFormat`, keeps the whole reply as
+`Render.pictFormats`, and scans it for the standard formats, exposing their
+PICTFORMAT ids as properties:
 
 - `Render.mono1` — 1-bit alpha (a1)
 - `Render.rgb24` — 24-bit TrueColor without alpha (x8r8g8b8)
 - `Render.rgba32` — 32-bit TrueColor with alpha (a8r8g8b8)
 - `Render.a8` — 8-bit alpha-only
+
+Those four cover the visuals a client picks for itself; for a visual chosen by
+someone else, see `findVisualFormat` below.
 
 Colors are given as `[r, g, b, a]` arrays of floats in 0..1 (clamped, scaled
 to 16 bits per channel). Coordinates and matrix/filter values are JS numbers
@@ -52,6 +56,28 @@ Two things about colors are easy to get wrong, and both fail quietly:
   `const rgba = (r, g, b, a) => [r * a, g * a, b * a, a]` and calling that is
   the readable way to keep it straight; the examples do.
 
+## Visual to format lookup
+
+### findVisualFormat(visual)
+Returns the PICTFORMAT id RENDER uses for `visual`, or `undefined` if RENDER
+describes no format for it. Synchronous: it answers out of the screens section
+of the `QueryPictFormat` reply cached while requiring the extension, so no
+round trip and no callback. Visual ids are unique across screens, so the
+screen the visual belongs to does not have to be named.
+
+The case for it is a visual the client did not choose — a compositing manager
+wrapping a redirected window's pixmap gets the window's visual id from
+`GetWindowAttributes`, and the format that describes it is whatever the server
+says, not what its depth suggests (depth 32 alone does not tell RGBA from
+BGRA, and a 565 visual matches none of the standard formats):
+
+```js
+X.GetWindowAttributes(win, (err, attrs) => {
+    const pic = X.AllocID();
+    Render.CreatePicture(pic, pixmap, Render.findVisualFormat(attrs.visual));
+});
+```
+
 ## Requests
 
 ### QueryVersion(clientMajor, clientMinor, cb)
@@ -59,7 +85,13 @@ Two things about colors are easy to get wrong, and both fail quietly:
 carries no version fields unless you call this yourself.
 
 ### QueryPictFormat(cb) / QueryPictFormats(cb)
-`cb(err, {formats})` — `formats` is an array of 12-element arrays:
+`cb(err, {formats, screens, subpixels})`. `QueryPictFormats` is a
+protocol-name alias. Called automatically by `X.require`, which keeps the
+reply as `Render.pictFormats`.
+
+`formats` lists every picture format the server supports. Each entry is a
+12-element array that also carries the same fields under names — `f[2]` and
+`f.depth` are one field, not two, so old positional code keeps working:
 
 ```
 [id, type, depth,
@@ -67,9 +99,27 @@ carries no version fields unless you call this yourself.
  blueShift, blueMask, alphaShift, alphaMask, colormap]
 ```
 
-`QueryPictFormats` is a protocol-name alias. The screen/depth/visual and
-subpixel sections of the reply are not parsed. Called automatically by
-`X.require` to discover the standard formats above.
+`type` is `Render.PictType.Direct` or `.Indexed`; `colormap` is a colormap id
+or 0 (None). Shifts and masks describe the channel layout of a direct format:
+the red channel of `x8r8g8b8` is `redShift: 16, redMask: 255`. Note the masks
+are the mask *value*, not its width.
+
+`screens` has one entry per screen, in the order of `display.screen`:
+
+```js
+{ fallback,                              // PICTFORMAT for drawables with no
+  depths: [                              //   matching visual (e.g. pixmaps)
+    { depth, visuals: [ { visual, format } ] }
+  ] }
+```
+
+This is the mapping from a visual id to the format that describes it — use
+`findVisualFormat` rather than walking it by hand. A visual the server cannot
+composite (a rarely-supported depth) has no entry.
+
+`subpixels` is one `Render.Subpixel` value per screen, the physical subpixel
+order the screen reports for LCD glyph anti-aliasing. Servers older than
+RENDER 0.6 send none, so the array can be shorter than `screens`.
 
 ### QueryPictIndexValues(pictformat, cb)
 `cb(err, values)` — array of `{pixel, red, green, blue, alpha}`. Only valid
@@ -243,6 +293,7 @@ does not name a defined ...").
     blend modes Multiply..HSLLuminosity (0x30..0x3e).
   - `Render.PolyEdge = {Sharp: 0, Smooth: 1}`,
     `Render.PolyMode = {Precise: 0, Imprecise: 1}`
+  - `Render.PictType = {Indexed: 0, Direct: 1}`
   - `Render.Repeat = {None: 0, Normal: 1, Pad: 2, Reflect: 3}`
   - `Render.Subpixel = {Unknown: 0, HorizontalRGB: 1, HorizontalBGR: 2,
     VerticalRGB: 3, VerticalBGR: 4, None: 5}`

--- a/lib/ext/render.js
+++ b/lib/ext/render.js
@@ -1,6 +1,91 @@
 const x11 = require('..');
 const xutil = require('../xutil');
 
+// QueryPictFormats reply body (the buffer starts 8 bytes into the reply, so
+// the first list begins at 24 here and at 32 on the wire):
+//   num_formats, num_screens, num_depths, num_visuals, num_subpixel, pad
+//   PICTFORMINFO[num_formats]   28 bytes each
+//   PICTSCREEN[num_screens]     variable
+//   CARD32[num_subpixel]        one subpixel order per screen (RENDER 0.6+)
+// num_depths/num_visuals are reply-wide totals; the per-screen counts inside
+// the PICTSCREEN list are what the walk below uses.
+function unpackPictFormats(buf) {
+  const num_formats = buf.readUInt32LE(0);
+  const num_screens = buf.readUInt32LE(4);
+  const num_subpixel = buf.readUInt32LE(16);
+  let offset = 24;
+
+  const formats = [];
+  for (let i = 0; i < num_formats; ++i) {
+    // positional for compatibility, named for readability - same fields
+    const format = [
+      buf.readUInt32LE(offset), // 0 id
+      buf.readUInt8(offset + 4), // 1 type
+      buf.readUInt8(offset + 5), // 2 depth
+      buf.readUInt16LE(offset + 8), // 3 red shift
+      buf.readUInt16LE(offset + 10), // 4 red mask
+      buf.readUInt16LE(offset + 12), // 5 green shift
+      buf.readUInt16LE(offset + 14), // 6 green mask
+      buf.readUInt16LE(offset + 16), // 7 blue shift
+      buf.readUInt16LE(offset + 18), // 8 blue mask
+      buf.readUInt16LE(offset + 20), // 9 alpha shift
+      buf.readUInt16LE(offset + 22), // 10 alpha mask
+      buf.readUInt32LE(offset + 24) // 11 colormap or None
+    ];
+    Object.assign(format, {
+      id: format[0],
+      type: format[1],
+      depth: format[2],
+      redShift: format[3],
+      redMask: format[4],
+      greenShift: format[5],
+      greenMask: format[6],
+      blueShift: format[7],
+      blueMask: format[8],
+      alphaShift: format[9],
+      alphaMask: format[10],
+      colormap: format[11]
+    });
+    formats.push(format);
+    offset += 28;
+  }
+
+  const screens = [];
+  for (let s = 0; s < num_screens; ++s) {
+    const numDepths = buf.readUInt32LE(offset);
+    const fallback = buf.readUInt32LE(offset + 4);
+    offset += 8;
+    const depths = [];
+    for (let d = 0; d < numDepths; ++d) {
+      const depth = buf.readUInt8(offset);
+      const numVisuals = buf.readUInt16LE(offset + 2);
+      offset += 8;
+      const visuals = [];
+      for (let v = 0; v < numVisuals; ++v) {
+        visuals.push({
+          visual: buf.readUInt32LE(offset),
+          format: buf.readUInt32LE(offset + 4)
+        });
+        offset += 8;
+      }
+      depths.push({ depth, visuals });
+    }
+    screens.push({ fallback, depths });
+  }
+
+  const subpixels = [];
+  for (let i = 0; i < num_subpixel; ++i) {
+    subpixels.push(buf.readUInt32LE(offset));
+    offset += 4;
+  }
+
+  return { formats, screens, subpixels };
+}
+
+// exported for the unit test: no test server produces a reply with several
+// screens or several depths per screen
+exports.unpackPictFormats = unpackPictFormats;
+
 // adding XRender functions manually from
 //     http://cgit.freedesktop.org/xcb/proto/tree/src/render.xml?id=HEAD
 // and http://www.x.org/releases/X11R7.6/doc/renderproto/renderproto.txt
@@ -11,6 +96,9 @@ exports.requireExt = (display, callback) => {
     if (!ext.present) {
       return callback(new Error('extension not available'));
     }
+
+    // visual id -> PICTFORMAT, filled from the QueryPictFormats reply below
+    const visualFormats = new Map();
 
     ext.QueryVersion = (clientMaj, clientMin, callback) => {
       X.seq_num++;
@@ -37,44 +125,18 @@ exports.requireExt = (display, callback) => {
       b.writeUInt16LE(1, 2);
       X.pack_stream.put(b);
       X.seq_num++;
-      X.replies[X.seq_num] = [
-        (buf, opt) => {
-          const res = {};
-          const num_formats = buf.readUInt32LE(0);
-          const num_screens = buf.readUInt32LE(4);
-          const num_depths = buf.readUInt32LE(8);
-          const num_visuals = buf.readUInt32LE(12);
-          const num_subpixel = buf.readUInt32LE(16);
-          // formats list:
-          let offset = 24;
-          res.formats = [];
-          for (let i = 0; i < num_formats; ++i) {
-            const format = [
-              buf.readUInt32LE(offset),
-              buf.readUInt8(offset + 4),
-              buf.readUInt8(offset + 5),
-              buf.readUInt16LE(offset + 8),
-              buf.readUInt16LE(offset + 10),
-              buf.readUInt16LE(offset + 12),
-              buf.readUInt16LE(offset + 14),
-              buf.readUInt16LE(offset + 16),
-              buf.readUInt16LE(offset + 18),
-              buf.readUInt16LE(offset + 20),
-              buf.readUInt16LE(offset + 22),
-              buf.readUInt32LE(offset + 24)
-            ];
-            res.formats.push(format);
-            offset += 28;
-          }
-          return res;
-        },
-        callback
-      ];
+      X.replies[X.seq_num] = [buf => unpackPictFormats(buf), callback];
       X.pack_stream.submit(true);
     };
 
     // protocol-name alias (spec: QueryPictFormats)
     ext.QueryPictFormats = callback => ext.QueryPictFormat(callback);
+
+    // Which PICTFORMAT describes a given visual, from the screens section of
+    // the reply cached while requiring the extension. Visual ids are unique
+    // across screens, so one flat map answers for all of them; a visual RENDER
+    // has no format for (an unsupported depth, say) answers undefined.
+    ext.findVisualFormat = visual => visualFormats.get(visual >>> 0);
 
     ext.QueryFilters = callback => {
       const b = Buffer.alloc(8);
@@ -1007,40 +1069,32 @@ exports.requireExt = (display, callback) => {
 
     // TODO: implement xutil-like code https://github.com/alexer/python-xlib-render/blob/master/xutil.py
 
-    // TODO: name format fields
-    // 0 - id
-    // 1 - type ( direct / ? /)
-    // 2 - depth
-    //
-    // 3 - red shift
-    // 4 - red mask
-    // 5 - green shift
-    // 6 - green mask
-    // 7 - blue shift
-    // 8 - blue mask
-    // 9 - alpha shift
-    // 10 - alpha mask
-
-    // 11 - colormap or none
-
-    ext.QueryPictFormat((err, formats) => {
+    ext.QueryPictFormat((err, res) => {
       if (err) return callback(err);
-      for (let i = 0; i < formats.formats.length; ++i) {
-        const f = formats.formats[i];
-        if (f[2] == 1 && f[10] == 1) ext.mono1 = f[0];
-        if (f[2] == 24 && f[3] == 16 && f[5] == 8 && f[7] == 0) ext.rgb24 = f[0];
-        // 1, 32, 16, 255, 8, 255, 0, 255, 24, 255, 0
+      ext.pictFormats = res;
+      for (const screen of res.screens)
+        for (const d of screen.depths)
+          for (const v of d.visuals) visualFormats.set(v.visual, v.format);
+      for (const f of res.formats) {
+        if (f.depth == 1 && f.alphaMask == 1) ext.mono1 = f.id;
         if (
-          f[2] == 32 &&
-          f[3] == 16 &&
-          f[4] == 255 &&
-          f[5] == 8 &&
-          f[6] == 255 &&
-          f[7] == 0 &&
-          f[9] == 24
+          f.depth == 24 &&
+          f.redShift == 16 &&
+          f.greenShift == 8 &&
+          f.blueShift == 0
         )
-          ext.rgba32 = f[0];
-        if (f[2] == 8 && f[10] == 255) ext.a8 = f[0];
+          ext.rgb24 = f.id;
+        if (
+          f.depth == 32 &&
+          f.redShift == 16 &&
+          f.redMask == 255 &&
+          f.greenShift == 8 &&
+          f.greenMask == 255 &&
+          f.blueShift == 0 &&
+          f.alphaShift == 24
+        )
+          ext.rgba32 = f.id;
+        if (f.depth == 8 && f.alphaMask == 255) ext.a8 = f.id;
       }
       callback(null, ext);
     });
@@ -1145,6 +1199,11 @@ exports.requireExt = (display, callback) => {
       Normal: 1,
       Pad: 2,
       Reflect: 3
+    };
+
+    ext.PictType = {
+      Indexed: 0,
+      Direct: 1
     };
 
     ext.Subpixel = {

--- a/test/pict-formats.js
+++ b/test/pict-formats.js
@@ -1,0 +1,131 @@
+// Unit test for the QueryPictFormats reply walk: the screens section is a
+// list of variable-length structs (PICTSCREEN -> PICTDEPTH -> PICTVISUAL),
+// and neither Xvfb nor the bundled JS server answers with more than one
+// screen or more than one depth, so the nesting is exercised here against a
+// hand-built reply instead.
+const assert = require('assert');
+const { unpackPictFormats } = require('../lib/ext/render');
+
+// reply body as the client sees it: the first 8 bytes of the reply are
+// stripped, so num_formats is at 0 and the format list starts at 24
+function buildReply(formats, screens, subpixels) {
+    const chunks = [];
+    const header = Buffer.alloc(24);
+    header.writeUInt32LE(formats.length, 0);
+    header.writeUInt32LE(screens.length, 4);
+    header.writeUInt32LE(
+        screens.reduce((n, s) => n + s.depths.length, 0), 8);
+    header.writeUInt32LE(
+        screens.reduce((n, s) =>
+            n + s.depths.reduce((m, d) => m + d.visuals.length, 0), 0), 12);
+    header.writeUInt32LE(subpixels.length, 16);
+    chunks.push(header);
+
+    for (const f of formats) {
+        const b = Buffer.alloc(28);
+        b.writeUInt32LE(f.id, 0);
+        b.writeUInt8(f.type, 4);
+        b.writeUInt8(f.depth, 5);
+        b.writeUInt16LE(f.redShift, 8);
+        b.writeUInt16LE(f.redMask, 10);
+        b.writeUInt16LE(f.greenShift, 12);
+        b.writeUInt16LE(f.greenMask, 14);
+        b.writeUInt16LE(f.blueShift, 16);
+        b.writeUInt16LE(f.blueMask, 18);
+        b.writeUInt16LE(f.alphaShift, 20);
+        b.writeUInt16LE(f.alphaMask, 22);
+        b.writeUInt32LE(f.colormap, 24);
+        chunks.push(b);
+    }
+
+    for (const s of screens) {
+        const head = Buffer.alloc(8);
+        head.writeUInt32LE(s.depths.length, 0);
+        head.writeUInt32LE(s.fallback, 4);
+        chunks.push(head);
+        for (const d of s.depths) {
+            const dh = Buffer.alloc(8);
+            dh.writeUInt8(d.depth, 0);
+            dh.writeUInt16LE(d.visuals.length, 2);
+            chunks.push(dh);
+            for (const v of d.visuals) {
+                const vb = Buffer.alloc(8);
+                vb.writeUInt32LE(v.visual, 0);
+                vb.writeUInt32LE(v.format, 4);
+                chunks.push(vb);
+            }
+        }
+    }
+
+    const sub = Buffer.alloc(subpixels.length * 4);
+    subpixels.forEach((v, i) => sub.writeUInt32LE(v, i * 4));
+    chunks.push(sub);
+
+    return Buffer.concat(chunks);
+}
+
+const RGB24 = { id: 32, type: 1, depth: 24,
+    redShift: 16, redMask: 255, greenShift: 8, greenMask: 255,
+    blueShift: 0, blueMask: 255, alphaShift: 0, alphaMask: 0, colormap: 0 };
+const RGBA32 = { id: 33, type: 1, depth: 32,
+    redShift: 16, redMask: 255, greenShift: 8, greenMask: 255,
+    blueShift: 0, blueMask: 255, alphaShift: 24, alphaMask: 255, colormap: 0 };
+const RGB565 = { id: 34, type: 1, depth: 16,
+    redShift: 11, redMask: 31, greenShift: 5, greenMask: 63,
+    blueShift: 0, blueMask: 31, alphaShift: 0, alphaMask: 0, colormap: 0 };
+
+const SCREENS = [
+    { fallback: 32, depths: [
+        { depth: 16, visuals: [{ visual: 0x20, format: 34 }] },
+        { depth: 24, visuals: [
+            { visual: 0x21, format: 32 },
+            { visual: 0x22, format: 32 }
+        ] },
+        { depth: 32, visuals: [{ visual: 0x23, format: 33 }] }
+    ] },
+    { fallback: 32, depths: [
+        { depth: 24, visuals: [{ visual: 0x140, format: 32 }] }
+    ] }
+];
+
+describe('RENDER QueryPictFormats reply', () => {
+
+    it('should decode formats, screens and subpixels of a multi-screen reply', () => {
+        const res = unpackPictFormats(
+            buildReply([RGB24, RGBA32, RGB565], SCREENS, [0, 1]));
+        assert.deepStrictEqual(res.formats.map(f => f.id), [32, 33, 34]);
+        assert.deepStrictEqual(res.screens, SCREENS);
+        assert.deepStrictEqual(res.subpixels, [0, 1]);
+    });
+
+    it('should give every format entry both positional and named fields', () => {
+        const res = unpackPictFormats(buildReply([RGB565], SCREENS, [0, 0]));
+        const f = res.formats[0];
+        assert.deepStrictEqual(Array.from(f),
+            [34, 1, 16, 11, 31, 5, 63, 0, 31, 0, 0, 0]);
+        assert.strictEqual(f.length, 12);
+        for (const [i, name] of ['id', 'type', 'depth',
+            'redShift', 'redMask', 'greenShift', 'greenMask',
+            'blueShift', 'blueMask', 'alphaShift', 'alphaMask',
+            'colormap'].entries())
+            assert.strictEqual(f[name], f[i], name);
+    });
+
+    it('should read the screens section past a format list of any length', () => {
+        // regression guard: the screens walk starts after num_formats * 28
+        // bytes, so a wrong stride shows up as a garbage first screen
+        const many = [];
+        for (let i = 0; i < 17; ++i)
+            many.push(Object.assign({}, RGB24, { id: 100 + i }));
+        const res = unpackPictFormats(buildReply(many, SCREENS, [5]));
+        assert.strictEqual(res.formats.length, 17);
+        assert.deepStrictEqual(res.screens, SCREENS);
+        assert.deepStrictEqual(res.subpixels, [5]);
+    });
+
+    it('should tolerate a server that sends no subpixel list (pre-0.6)', () => {
+        const res = unpackPictFormats(buildReply([RGB24], SCREENS, []));
+        assert.deepStrictEqual(res.subpixels, []);
+        assert.strictEqual(res.screens.length, 2);
+    });
+});

--- a/test/render.js
+++ b/test/render.js
@@ -90,6 +90,79 @@ describe('RENDER extension', () => {
         });
     });
 
+    it('QueryPictFormats should name the fields of every format entry', done => {
+        render.QueryPictFormats((err, res) => {
+            should.not.exist(err);
+            const rgb24 = res.formats.find(f => f.id === render.rgb24);
+            should.exist(rgb24);
+            // named fields alias the positional ones, they are one entry
+            rgb24.id.should.equal(rgb24[0]);
+            rgb24.type.should.equal(rgb24[1]);
+            rgb24.depth.should.equal(rgb24[2]);
+            rgb24.redShift.should.equal(rgb24[3]);
+            rgb24.redMask.should.equal(rgb24[4]);
+            rgb24.greenShift.should.equal(rgb24[5]);
+            rgb24.greenMask.should.equal(rgb24[6]);
+            rgb24.blueShift.should.equal(rgb24[7]);
+            rgb24.blueMask.should.equal(rgb24[8]);
+            rgb24.alphaShift.should.equal(rgb24[9]);
+            rgb24.alphaMask.should.equal(rgb24[10]);
+            rgb24.colormap.should.equal(rgb24[11]);
+            rgb24.type.should.equal(render.PictType.Direct);
+            rgb24.depth.should.equal(24);
+            done();
+        });
+    });
+
+    it('QueryPictFormats should decode the screens and subpixel sections', done => {
+        render.QueryPictFormats((err, res) => {
+            should.not.exist(err);
+            res.screens.should.be.an.Array();
+            res.screens.length.should.equal(display.screen.length);
+            const ids = res.formats.map(f => f.id);
+            res.screens.forEach(screen => {
+                ids.should.containEql(screen.fallback);
+                screen.depths.should.be.an.Array();
+                screen.depths.length.should.be.above(0);
+                screen.depths.forEach(d => {
+                    d.depth.should.be.a.Number();
+                    d.visuals.forEach(v => {
+                        v.visual.should.be.a.Number();
+                        ids.should.containEql(v.format);
+                    });
+                });
+            });
+            // one subpixel order per screen since RENDER 0.6
+            res.subpixels.should.be.an.Array();
+            res.subpixels.forEach(s => {
+                s.should.be.within(render.Subpixel.Unknown, render.Subpixel.None);
+            });
+            done();
+        });
+    });
+
+    it('findVisualFormat should map the root visual to a format of its depth', () => {
+        const format = render.findVisualFormat(display.screen[0].root_visual);
+        should.exist(format);
+        const info = render.pictFormats.formats.find(f => f.id === format);
+        should.exist(info);
+        info.depth.should.equal(depth);
+        should.not.exist(render.findVisualFormat(0xdeadbeef));
+    });
+
+    it('findVisualFormat should cover every visual of the connection setup', () => {
+        // the setup block lists the server's visuals; RENDER describes the
+        // ones it can composite, and must not invent ids for the others
+        const ids = render.pictFormats.formats.map(f => f.id);
+        Object.keys(display.screen[0].depths).forEach(d => {
+            Object.keys(display.screen[0].depths[d]).forEach(visual => {
+                const format = render.findVisualFormat(Number(visual));
+                if (format !== undefined)
+                    ids.should.containEql(format);
+            });
+        });
+    });
+
     it('QueryPictIndexValues should return Match error for a direct (non-indexed) format', done => {
         // Xvfb only has TrueColor/direct formats, so the server must answer
         // with a Match error - proves the request is correctly formed

--- a/test/xserver/render.js
+++ b/test/xserver/render.js
@@ -84,6 +84,31 @@ describe('xserver: RENDER', () => {
             assert.ok(render.mono1, 'mono1');
         });
 
+        it('QueryPictFormats decodes the screens section', done => {
+            render.QueryPictFormats((err, res) => {
+                if (err) return done(err);
+                assert.strictEqual(res.screens.length, 1);
+                const screen = res.screens[0];
+                assert.strictEqual(screen.fallback, render.rgb24);
+                assert.deepStrictEqual(screen.depths, [{
+                    depth: 24,
+                    visuals: [{
+                        visual: display.screen[0].root_visual,
+                        format: render.rgb24
+                    }]
+                }]);
+                assert.deepStrictEqual(res.subpixels, [render.Subpixel.Unknown]);
+                done();
+            });
+        });
+
+        it('findVisualFormat answers for the root visual', () => {
+            assert.strictEqual(
+                render.findVisualFormat(display.screen[0].root_visual),
+                render.rgb24);
+            assert.strictEqual(render.findVisualFormat(0x12345), undefined);
+        });
+
         it('QueryFilters lists nearest/bilinear/convolution', done => {
             render.QueryFilters((err, res) => {
                 if (err) return done(err);


### PR DESCRIPTION
Closes #280.

## Context

`Render.QueryPictFormats` read `num_formats`, `num_screens`, `num_depths`,
`num_visuals` and `num_subpixel` out of the reply header and then returned
only `{formats}` — the `PICTSCREEN` list those counts lead into, and the
subpixel list after it, were skipped.

That list is the reply's answer to the question RENDER exists to answer:
**which picture format describes a given visual**. Without it a client can only
guess a format from a depth, which is what `Render.rgb24` / `rgba32` / `a8` do.
That guess is right for the visuals a client picks for itself and silently
wrong otherwise: a 16-bit 565 visual matches none of the standard layouts, and
depth 32 alone does not distinguish RGBA from BGRA. The case that surfaced it
is a compositing manager (sidorares/ntk#289), where every redirected window
arrives with whatever visual that client chose and `CreatePicture` on its
pixmap needs that visual's format.

## New API

`QueryPictFormat` / `QueryPictFormats` now call back with
`{formats, screens, subpixels}`:

```js
res.screens;    // one per screen, in display.screen order:
                //   { fallback, depths: [ { depth, visuals: [ {visual, format} ] } ] }
res.subpixels;  // one Render.Subpixel value per screen (RENDER 0.6+)
```

The reply is parsed once while requiring the extension and kept as
`Render.pictFormats`, so the lookup itself needs no round trip and no callback:

```js
X.GetWindowAttributes(win, (err, attrs) => {
    Render.CreatePicture(pic, pixmap, Render.findVisualFormat(attrs.visual));
});
```

`findVisualFormat` returns the PICTFORMAT id, or `undefined` for a visual
RENDER describes no format for. Visual ids are unique across screens, so the
screen does not have to be named.

`Render.PictType = {Indexed: 0, Direct: 1}` is added for the `type` field.

## Named format fields, without an API break

The issue floated naming the fields of `res.formats` entries as a possible
API break. That turned out to be unnecessary: each entry is still the same
12-element array **and** carries the same fields under names, so `f[2]` and
`f.depth` are one field rather than two, and code indexing positionally keeps
working. The format scan inside `require()` now reads

```js
if (f.depth == 24 && f.redShift == 16 && f.greenShift == 8 && f.blueShift == 0)
    ext.rgb24 = f.id;
```

instead of `f[2] == 24 && f[3] == 16 && …`, which retires the "TODO: name
format fields" comment above it. The one wrinkle worth knowing: extra
properties on an array are invisible to `JSON.stringify`, so a serialized
format entry is still just the positional list.

## Testing

`npm run test:local` (Xvfb) 503 passing, `npm run test:xserver` 289 passing,
`npm run lint` clean.

- `test/render.js` — against Xvfb: named fields alias the positional ones,
  the screens/subpixel sections decode into ids that exist in the formats
  list, and `findVisualFormat(root_visual)` returns a format of the root
  depth. Every visual in the connection setup block either maps to a real
  format id or to `undefined` — no invented ids.
- `test/xserver/render.js` — against the bundled JS server, whose
  `QueryPictFormats` already emitted the sections nobody parsed: the exact
  screen structure, and the root visual resolving to `rgb24`.
- `test/pict-formats.js` (new) — the walk over the variable-length
  `PICTSCREEN` → `PICTDEPTH` → `PICTVISUAL` nesting, against a hand-built
  reply. Neither Xvfb nor the JS server answers with more than one screen or
  more than one depth per screen, so multi-screen replies, a format list long
  enough to catch a wrong stride, and a pre-0.6 server sending no subpixel
  list are only covered here.

`docs/ext/render.md` documents the new reply shape, `findVisualFormat` and
`PictType`.