### PR TITLE
perf: cache QueryExtension replies for the life of a connection

### DIFF
--- a/docs/core-requests.md
+++ b/docs/core-requests.md
@@ -655,6 +655,12 @@ Opcode 98. `cb(err, ext)` — `{present, majorOpcode, firstEvent,
 firstError}`. Normally not called directly: `X.require(module, cb)` performs
 it (and the extension setup) for you, see [README.md](README.md#extensions).
 
+A server's extension set is fixed for the life of a connection, so replies are
+cached and a repeat query answers without a round trip — including a
+`present: 0` answer, which is what keeps code that re-probes for a missing
+extension off the wire. Each call gets its own reply object, so it is safe to
+add properties to one.
+
 ### ListExtensions(cb)
 Opcode 99. `cb(err, names)` — array of extension name strings.
 

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -201,6 +201,10 @@ XClient.prototype.init = function(stream)
     this.geEventParsers = {};
     this.errorParsers = {};
     this._extensions = {};
+    // QueryExtension replies, keyed by extension name. The set of
+    // extensions a server supports is fixed for the life of a connection,
+    // so the answer never changes once we have it.
+    this._extension_info = {};
 
     this.importRequestsFromTemplates(this, coreRequests);
 
@@ -384,6 +388,35 @@ XClient.prototype.importRequestsFromTemplates = function(target, reqs)
                      } else {
                          client.pending_atoms[client.seq_num] = atom;
                      }
+                 }
+
+                 // Cached like the atoms above: a server's extension set is
+                 // fixed for the connection, so asking twice always gets the
+                 // same answer. require() remembers only the extensions it
+                 // resolved, so without this a client that keeps probing for
+                 // one the server lacks - a popup asking for Present every
+                 // time it opens - pays a round trip on every attempt.
+                 if (reqName === 'QueryExtension' && callback) {
+                     const extName = args[0];
+                     const known = client._extension_info[extName];
+                     const cb = callback;
+                     if (known) {
+                         -- client.seq_num;
+                         // A fresh copy each time: requireExt decorates the
+                         // reply it is handed with the extension's own
+                         // methods and constants.
+                         setImmediate(() => {
+                             cb(undefined, Object.assign({}, known));
+                         });
+                         return true;
+                     }
+                     callback = (err, ext) => {
+                         if (!err && ext)
+                             client._extension_info[extName] = Object.assign({}, ext);
+                         // The return value says whether an error was handled;
+                         // swallowing it would emit a spurious 'error'.
+                         return cb(err, ext);
+                     };
                  }
 
                  // pack template returns a Buffer (Buffer.write* style)

--- a/test/cache-extensions.js
+++ b/test/cache-extensions.js
@@ -1,5 +1,9 @@
 const x11 = require('../lib');
 const should = require('should');
+const sinon = require('sinon');
+
+// No server has this, so QueryExtension always answers present = 0.
+const ABSENT = 'NoSuchExtension-node-x11';
 
 describe('requiring an X11 extension on same connection', () => {
     before(function(done) {
@@ -22,6 +26,70 @@ describe('requiring an X11 extension on same connection', () => {
             self.X.require('xtest', (err, randr1) => {
                 should.not.exist(err);
                 randr.should.equal(randr1);
+                done();
+            });
+        });
+    });
+
+    it('should not re-ask the server for an extension it already queried', function(done) {
+        const self = this;
+        this.X.QueryExtension('XTEST', (err, first) => {
+            should.not.exist(err);
+            const spy = sinon.spy(self.X.pack_stream, 'put');
+            self.X.QueryExtension('XTEST', (err, second) => {
+                should.not.exist(err);
+                second.majorOpcode.should.equal(first.majorOpcode);
+                sinon.assert.notCalled(spy);
+                spy.restore();
+                done();
+            });
+        });
+    });
+
+    // The reason this cache exists: require() remembers only the extensions it
+    // resolved, so a client that keeps probing for a missing one used to put a
+    // QueryExtension on the wire every single time.
+    it('should not re-ask for an extension the server does not have', function(done) {
+        const self = this;
+        this.X.QueryExtension(ABSENT, (err, first) => {
+            should.not.exist(err);
+            first.present.should.equal(0);
+            const spy = sinon.spy(self.X.pack_stream, 'put');
+            self.X.QueryExtension(ABSENT, (err, second) => {
+                should.not.exist(err);
+                second.present.should.equal(0);
+                sinon.assert.notCalled(spy);
+                spy.restore();
+                done();
+            });
+        });
+    });
+
+    it('should keep a failing require() off the wire after the first try', function(done) {
+        const self = this;
+        this.X.require('dri3', () => {
+            // Whether this server has DRI3 or not, asking again is free.
+            const spy = sinon.spy(self.X.pack_stream, 'put');
+            self.X.require('dri3', () => {
+                sinon.assert.notCalled(spy);
+                spy.restore();
+                done();
+            });
+        });
+    });
+
+    // requireExt() hangs the extension's own methods off the reply object it
+    // is handed, so handing out the cached one would let it be decorated once
+    // and then reused in that state.
+    it('should hand out a fresh reply object each time', function(done) {
+        const self = this;
+        this.X.QueryExtension('XTEST', (err, first) => {
+            should.not.exist(err);
+            first.scribble = 'mutated';
+            self.X.QueryExtension('XTEST', (err, second) => {
+                should.not.exist(err);
+                second.should.not.equal(first);
+                should.not.exist(second.scribble);
                 done();
             });
         });


### PR DESCRIPTION
## The problem

`X.require()` caches only the extensions it successfully resolved. When the
server does not have an extension, nothing is remembered, so every probe puts
another `QueryExtension` on the wire.

That is easy to hit from a higher layer. ntk's `Window#enablePresent()` is
memoized *per window*, which is correct — but a `<popup>` builds a new window
on each open, so a menu re-queried `Present` and `XFIXES` every single time it
was shown. It bites servers that lack the extensions (Xvfb) and is invisible on
Xorg/XQuartz, where the first query succeeds and `require()`'s existing cache
takes over.

## The fix

Cache the `QueryExtension` reply, keyed by name, in the request proxy — right
next to the `InternAtom` / `GetAtomName` caches that are already there and work
the same way. A server's extension set is fixed once the connection is up, so
the reply is a pure function of the name and re-asking cannot produce a
different answer.

Caching the *reply* rather than the *failure* is what keeps this correct:

- Only the server's answer is remembered. An extension that is present but
  whose setup fails afterwards (say a `QueryVersion` that errors) is not
  written off, and can still be retried.
- No error has to be classified as permanent or transient — a judgement the
  library is in no position to make, and one that string-matching
  `'extension not available'` would get wrong.

Each caller gets its own copy of the reply, because `requireExt()` decorates
the object it is handed with the extension's methods and constants; handing out
the shared one would let it be decorated once and reused in that state.

## Measured

An `Xvfb` started with `-extension XFIXES`, driven by the `enablePresent()`
pattern (`require('present')` + `require('fixes')` per popup open):

| | QueryExtension requests for 20 popup opens |
|---|---|
| before | 21 |
| after | 2 |

## Tests

Four cases added to `test/cache-extensions.js`, all of which fail without the
change (except the last, which guards the defensive copy and was checked
against a mutant that returns the cached object directly):

- a repeat query for a **present** extension makes no request
- a repeat query for an **absent** extension makes no request — the actual bug
- a repeated failing `require()` stays off the wire
- each call gets a fresh reply object

Full suite against Xvfb: 507 passing, 0 failing. `eslint` clean.