### PR TITLE
feat(bun): pass file descriptors with bun:ffi, and receive them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,20 @@ jobs:
       - run: npm run test:xserver
       - run: npm run test:glx-emu
 
+  # The Bun descriptor transport (lib/fdpass-bun.js): sendmsg/recvmsg through
+  # bun:ffi, which Node's suite cannot exercise.
+  test-bun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install Xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Run the Bun suite under Xvfb
+        run: xvfb-run -a -s "-screen 0 1280x1024x24 -nolisten tcp" bun test test/bun
+
   test:
     runs-on: ubuntu-latest
     # Tests run inside debian bookworm containers rather than on the runner:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ No build step, no transpilation: `lib/` is what ships.
 ```sh
 npm run test:local   # = ./scripts/test-local.sh
 npm run lint         # eslint: no-var / prefer-const / no-redeclare
+npm run test:bun     # = bun test test/bun (only if bun is installed)
 ```
 
 Full suite takes ~2 s. It starts (or reuses) a private Xvfb on display `:99`
@@ -72,6 +73,10 @@ Details the script handles for you:
 - `test-runner.js` (not plain mocha) is the entry point: it probes the server
   and skips `dpms.js` / `xtest.js` / `randr.js` when the extension is missing.
   To run a single file directly: `DISPLAY=… npx mocha test/<file>.js`.
+- `test/bun/` is the one suite Node cannot run: the descriptor transport built
+  on `bun:ffi` (`lib/fdpass-bun.js`). It needs `bun` on PATH; its X-server
+  tests skip themselves when `DISPLAY` is unset. Subdirectories of `test/` are
+  invisible to `test-runner.js`, so `npm test` is unaffected either way.
 
 ## Repo map
 
@@ -85,6 +90,7 @@ Details the script handles for you:
 | `lib/generated/` | Auto-generated parsers from `autogen/proto/` (`npm run gen:protocol`) |
 | `lib/auth.js` | `~/.Xauthority` parsing / auth negotiation |
 | `lib/ext/*.js` | Protocol extensions (render, randr, glx, xtest, dpms, …) |
+| `lib/fdpass.js`, `lib/fdpass-bun.js` | File-descriptor passing (`SCM_RIGHTS`) for MIT-SHM/DRI3: Node bindings and the Bun `bun:ffi` transport |
 | `lib/keysyms.js` | Generated keysym table (see `lib/keysyms.update.sh`) |
 | `lib/xserver.js` | Experimental X server implementation |
 | `autogen/` | Scripts that generate request stubs from XML protocol specs (xcb-proto) |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ protocol prefix (`x11.registerDisplayProtocol(name, connect)` +
 `myproto/host:0`), and `createClient({ stream })` accepts any duplex stream.
 See the [custom transports guide](https://sidorares.github.io/node-x11/docs/guides/custom-transports).
 
+It runs under [Bun](https://bun.sh) too, including the parts that pass file
+descriptors over the connection (MIT-SHM segments, DRI3 buffers) — and there,
+uniquely, descriptors can also be *received*: see
+[Running under Bun](docs/README.md#running-under-bun).
+
 ## Install
 
     npm install x11

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ x11.createClient((err, display) => {
 | `bufferRequests` | batch outgoing requests into fewer socket writes: `true`, or `{ maxSize, maxDelay, flushOnReply, shouldFlush }` — see [Buffering the output](#buffering-the-output) |
 | `tcpNoDelay` | turn Nagle's algorithm off on a TCP connection (default: on when `bufferRequests` is set) |
 | `shm` | MIT-SHM segment provider: unset for the built-in one on local connections, `false`/`'off'` to disable, or a provider object — see [ext/shm.md](ext/shm.md) |
+| `receiveFds` | ask for a connection that can also *receive* file descriptors from the server (Bun only) — see [Running under Bun](#running-under-bun) |
 
 The client connects over a unix socket when the display refers to the local
 host (on macOS the display must be a literal socket path, XQuartz launchd
@@ -52,6 +53,33 @@ which looks the same as having no cookie file at all.
 
 `createClient` returns the client object immediately; subscribe to `'error'`
 on it to catch connection-phase failures.
+
+### Running under Bun
+
+The library runs unchanged under [Bun](https://bun.sh). The one part of X11
+that is not plain bytes on a socket is **file-descriptor passing** — MIT-SHM's
+`ShmAttachFd` and DRI3's `PixmapFromBuffer` hand the server a descriptor as
+`SCM_RIGHTS` ancillary data — and that needs a different implementation per
+runtime: Node reaches it through internal bindings
+([`lib/fdpass.js`](../lib/fdpass.js)), Bun through `sendmsg(2)` called with
+`bun:ffi` ([`lib/fdpass-bun.js`](../lib/fdpass-bun.js)). Both are picked
+automatically on a local unix-socket display, so shared memory and DRI3 buffer
+imports work the same on either runtime.
+
+Receiving descriptors is where the two differ. Under Node there is no way to
+do it at all: a descriptor arriving on the connection aborts the process before
+any JavaScript runs. Under Bun it works, on request:
+
+```js
+x11.createClient({ receiveFds: true }, (err, display) => { /* ... */ });
+```
+
+That connection is read with `recvmsg(2)` instead of by Bun's own socket
+reader — which would drop the ancillary data — so it costs a thread blocked in
+`poll(2)`, and is therefore opt-in. It is what makes DRI3 `Open`,
+`BufferFromPixmap`, `BuffersFromPixmap` and `FDFromFence` usable (see
+[ext/dri3.md](ext/dri3.md)); everything else behaves identically. Under Node
+the option is ignored, and those four requests keep reporting an error.
 
 ### The display object
 

--- a/docs/ext/dri3.md
+++ b/docs/ext/dri3.md
@@ -27,7 +27,9 @@ say on the wire).
   the client)
 - Source: [`lib/ext/dri3.js`](../../lib/ext/dri3.js) ·
   Tests: [`test/dri3.js`](../../test/dri3.js) (encoding, no server needed),
-  [`test/dri3-live.js`](../../test/dri3-live.js) (against a DRI3 server)
+  [`test/dri3-live.js`](../../test/dri3-live.js) (against a DRI3 server),
+  [`test/bun/fdpass.test.js`](../../test/bun/fdpass.test.js) (the Bun
+  descriptor transport)
 - Spec: [dri3proto.txt](https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/dri3proto.txt)
 - Working samples: [`examples/dri3/`](../../examples/dri3/) — a
   self-contained folder (own `package.json`, `npm install && npm start`)
@@ -56,7 +58,7 @@ native companion package [`x11-dri`](https://github.com/sidorares/node-x11-dri)
 (`npm install x11-dri`) provides two such producers (an OpenGL ES 2 renderer
 and udmabuf) plus `dup()`; the `x11` package itself stays pure JS.
 
-## Descriptors only flow client → server
+## Which direction descriptors can flow
 
 Requests that *send* descriptors (`PixmapFromBuffer`, `PixmapFromBuffers`,
 `FenceFromFD`, `ImportSyncobj`) work on any fd-capable connection — the
@@ -66,10 +68,16 @@ matching how they are produced (`gbm_bo_get_fd` returns a fresh fd whose only
 purpose is this send). Keep a copy with `dup()` first if you need one.
 
 The four requests whose **replies carry descriptors** — `Open`,
-`BufferFromPixmap`, `FDFromFence`, `BuffersFromPixmap` — are not wired: a
-descriptor arriving on the connection aborts the Node process before any JS
-runs (the libuv abort described in `lib/fdpass.js`), so they report an error
-instead of touching the wire. In practice none of them is needed:
+`BufferFromPixmap`, `FDFromFence`, `BuffersFromPixmap` — need a connection
+that can *receive* one, which depends on the runtime:
+
+| runtime | sending | receiving |
+|---|---|---|
+| Node | yes, on a local unix socket | no: an arriving descriptor aborts the process (the libuv abort described in `lib/fdpass.js`) |
+| Bun | yes, on a local unix socket | with `createClient({ receiveFds: true })` — see [Running under Bun](../README.md#running-under-bun) |
+
+Where they are unavailable they report an explanatory error instead of
+touching the wire, and in practice none of them is needed:
 
 - instead of `Open` (get a DRM device fd from the server), open a **render
   node** directly — `fs.openSync('/dev/dri/renderD128', 'r+')` — which
@@ -80,7 +88,9 @@ instead of touching the wire. In practice none of them is needed:
   create the buffers client-side and import them.
 
 `DRI3.fdCapable` tells whether this connection can send descriptors at all
-(false on TCP or on a transport without the fd-capable socket).
+(false on TCP or on a transport without the fd-capable socket);
+`DRI3.fdReceiveCapable` whether the four requests above will work.
+Descriptors that arrive are **owned by the caller** — close them when done.
 
 ## Requests
 
@@ -123,9 +133,31 @@ major/minor (`fs.fstatSync(fd).rdev` decoded). Void.
 Imports (and frees) a DRM timeline syncobj for explicit synchronization with
 Present 1.4 servers. The fd is consumed.
 
-### Open / BufferFromPixmap / FDFromFence / BuffersFromPixmap
-Refused with an explanatory error — their replies carry descriptors (see
-above).
+### Open(drawable, provider, cb) — needs a receiving connection
+`cb(err, fd)` with the DRM device descriptor for `drawable`'s screen, already
+authenticated for direct rendering; `provider` picks the GPU on a multi-GPU
+screen (`0` for the default one). The descriptor is yours to close.
+
+### BufferFromPixmap(pixmap, cb) — needs a receiving connection
+The inverse of `PixmapFromBuffer`: exports the pixmap's storage as a dma-buf.
+`cb(err, { fd, size, width, height, stride, depth, bpp })`. The pixels behind
+the descriptor are the server's, live; the descriptor is yours to close.
+
+### BuffersFromPixmap(pixmap, cb) — DRI3 ≥ 1.2, needs a receiving connection
+The multi-planar, modifier-aware inverse of `PixmapFromBuffers`.
+`cb(err, { width, height, modifier, depth, bpp, planes })` with `planes` an
+array of `{fd, stride, offset}` — shaped like the `opts` `PixmapFromBuffers`
+takes, so a buffer can be handed straight to another screen. `modifier` is a
+**BigInt**. Every plane descriptor is yours to close.
+
+### FDFromFence(drawable, fence, cb) — needs a receiving connection
+The inverse of `FenceFromFD`: `cb(err, fd)` with the poll-able fence
+descriptor behind a SYNC fence. The descriptor is yours to close.
+
+Each of the four needs a callback (there would be nothing to hand the
+descriptors to) and reports an error, rather than touching the wire, when the
+connection cannot receive descriptors — see
+[Which direction descriptors can flow](#which-direction-descriptors-can-flow).
 
 ## Constants
 

--- a/docs/ext/shm.md
+++ b/docs/ext/shm.md
@@ -97,7 +97,15 @@ Passing a descriptor uses Node's internal `pipe_wrap` binding (there is no
 public API for `SCM_RIGHTS`). It is isolated in [`lib/fdpass.js`](../../lib/fdpass.js)
 and fully guarded: under `--permission`, in a browser bundle, or if the binding
 ever disappears, the connection silently falls back to a plain socket and
-`usable()` reports false.
+`usable()` reports false. Under Bun, where those bindings do not exist, the
+same descriptor is passed with `sendmsg(2)` through `bun:ffi`
+([`lib/fdpass-bun.js`](../../lib/fdpass-bun.js)) — picked automatically, so
+`AttachFd` behaves the same on either runtime.
+
+`CreateSegment` (minor opcode 7, where the *server* allocates the segment and
+returns its descriptor) is not implemented: receiving a descriptor aborts the
+Node process, and the built-in provider has no use for it — it allocates the
+segment itself.
 
 ### Writing a provider
 

--- a/lib/ext/dri3.js
+++ b/lib/ext/dri3.js
@@ -20,14 +20,19 @@
 //   own reference).
 //
 //   server -> client — Open, BufferFromPixmap, FDFromFence, BuffersFromPixmap
-//   — is NOT wired: a descriptor arriving on the connection aborts the Node
-//   process before any JS runs (see lib/fdpass.js). These four requests are
-//   never put on the wire; they report an error instead. The standard
-//   substitute for Open is opening a render node directly —
-//   fs.openSync('/dev/dri/renderD128', 'r+') — which needs no X-side
-//   authentication at all. On multi-GPU machines, probe each
-//   /dev/dri/renderD* by importing a small test buffer with PixmapFromBuffer
-//   until one succeeds.
+//   — needs a connection that can RECEIVE descriptors, which is a runtime
+//   question. Under Node there is none: a descriptor arriving on a libuv-read
+//   socket aborts the process before any JS runs (see lib/fdpass.js), so these
+//   four requests are never put on the wire and report an error instead. Under
+//   Bun they work on a unix-socket display opened with
+//   `createClient({ receiveFds: true })` (lib/fdpass-bun.js). Check
+//   `ext.fdReceiveCapable` before using them, or just read the error.
+//
+//   The descriptors they return are OWNED BY THE CALLER: close them when done.
+//   Where Open is unavailable the standard substitute is opening a render node
+//   directly — fs.openSync('/dev/dri/renderD128', 'r+') — which needs no X-side
+//   authentication at all. On multi-GPU machines, probe each /dev/dri/renderD*
+//   by importing a small test buffer with PixmapFromBuffer until one succeeds.
 
 const fs = require('fs');
 
@@ -52,14 +57,53 @@ exports.requireExt = (display, callback) => {
         const closeAll = fds =>
             fds.forEach(fd => { try { fs.closeSync(fd); } catch { /* ignore */ } });
 
-        // Requests that make the server send a descriptor back are refused
-        // here (fds are unreceivable — see the header). Errors, not throws,
-        // when a callback is given, so probing code can fall back cleanly.
+        // Whether the server can hand this connection a descriptor at all.
+        // Only the Bun transport can receive one, and only when the client was
+        // created with `receiveFds: true` (see the header and lib/fdpass.js).
+        const canReceive = () => !!(X.stream && X.stream._fdReceiving &&
+            typeof X.stream.takeFds === 'function');
+
+        // What the four descriptor-returning requests report when the
+        // connection cannot receive. An error, not a throw, when a callback is
+        // given, so probing code can fall back cleanly.
         const unreceivable = (what, hint, cb) => {
             const err = new Error(`DRI3: ${what} makes the server return a file descriptor, ` +
-                'and receiving one would abort the Node process (see lib/fdpass.js). ' + hint);
+                'which this connection cannot receive — under Node one arriving would abort ' +
+                'the process, and under Bun it needs createClient({ receiveFds: true }) on a ' +
+                'unix-socket display (see lib/fdpass.js). ' + hint);
             if (cb) return process.nextTick(() => cb(err));
             throw err;
+        };
+
+        // Shared tail of every request whose REPLY carries descriptors. They
+        // travel with the reply's own bytes, so the transport has them queued
+        // by the time the reply is parsed: take exactly as many as the reply
+        // declares in its `nfd` byte and hand them to `cb`, which owns them
+        // from then on. Without a callback there would be nothing to hand them
+        // to and the transport's queue would drift, so one is required.
+        const replyWithFds = (b, what, hint, parse, cb) => {
+            if (typeof cb !== 'function')
+                throw new TypeError(`DRI3: ${what} returns file descriptors and needs a callback`);
+            if (!canReceive())
+                return unreceivable(what, hint, cb);
+            X.seq_num++;
+            X.replies[X.seq_num] = [
+                function(buf, nfd) { return { buf, nfd, fds: this.stream.takeFds(nfd) }; },
+                (err, reply) => {
+                    if (err)
+                        return cb(err);
+                    if (reply.fds.length !== reply.nfd) {
+                        closeAll(reply.fds);
+                        return cb(new Error(`DRI3: ${what} reply declared ${reply.nfd} ` +
+                            `descriptors but ${reply.fds.length} arrived`));
+                    }
+                    if (reply.nfd === 0)
+                        return cb(new Error(`DRI3: ${what} reply carried no descriptor`));
+                    cb(null, parse(reply.buf, reply.fds));
+                }
+            ];
+            X.pack_stream.put(b);
+            X.pack_stream.submit(true);
         };
 
         // Shared tail of every descriptor-carrying request. The descriptors
@@ -103,10 +147,22 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.submit(true);
         }
 
-        // The reply carries the DRM device fd — unreceivable (see header).
-        ext.Open = (drawable, provider, cb) =>
-            unreceivable('Open', 'Open a render node directly instead: ' +
-                "fs.openSync('/dev/dri/renderD128', 'r+').", cb);
+        // The DRM device fd for `drawable`'s screen, authenticated for direct
+        // rendering: what a client would otherwise get by opening a render
+        // node and authenticating with DRI2. `provider` selects the GPU on a
+        // multi-GPU screen (0 for the default one). cb(err, fd); the fd is the
+        // caller's to close.
+        ext.Open = (drawable, provider, cb) => {
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(1, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeUInt32LE(provider >>> 0, 8);
+            replyWithFds(b, 'Open', 'Open a render node directly instead: ' +
+                "fs.openSync('/dev/dri/renderD128', 'r+').",
+                (buf, fds) => fds[0], cb);
+        }
 
         // Turn a dma-buf into `pixmap` (a fresh XID) on `drawable`'s screen.
         // opts: { fd, width, height, stride, depth, bpp, size? } — size
@@ -131,11 +187,29 @@ exports.requireExt = (display, callback) => {
             sendWithFds(b, [opts.fd], 'PixmapFromBuffer', cb);
         }
 
-        // The reply carries the buffer's dma-buf fd — unreceivable.
-        ext.BufferFromPixmap = (pixmap, cb) =>
-            unreceivable('BufferFromPixmap',
+        // Export a pixmap's storage as a dma-buf: the inverse of
+        // PixmapFromBuffer. cb(err, { fd, size, width, height, stride, depth,
+        // bpp }) — the fd is the caller's to close, and the pixels behind it
+        // are the server's, live.
+        ext.BufferFromPixmap = (pixmap, cb) => {
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(3, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(pixmap >>> 0, 4);
+            replyWithFds(b, 'BufferFromPixmap',
                 'Keep the buffer on the client side instead: create it yourself and ' +
-                'import it with PixmapFromBuffer.', cb);
+                'import it with PixmapFromBuffer.',
+                (buf, fds) => ({
+                    fd: fds[0],
+                    size: buf.readUInt32LE(0),
+                    width: buf.readUInt16LE(4),
+                    height: buf.readUInt16LE(6),
+                    stride: buf.readUInt16LE(8),
+                    depth: buf.readUInt8(10),
+                    bpp: buf.readUInt8(11)
+                }), cb);
+        }
 
         // Create SYNC fence `fence` (a fresh XID) on `drawable`'s screen from
         // a poll-able fence fd (SyncFD). The fd is consumed.
@@ -151,9 +225,19 @@ exports.requireExt = (display, callback) => {
             sendWithFds(b, [fd], 'FenceFromFD', cb);
         }
 
-        ext.FDFromFence = (drawable, fence, cb) =>
-            unreceivable('FDFromFence',
-                'Create the fence from a client-side fd with FenceFromFD instead.', cb);
+        // The poll-able fence fd behind a SYNC fence: the inverse of
+        // FenceFromFD. cb(err, fd); the fd is the caller's to close.
+        ext.FDFromFence = (drawable, fence, cb) => {
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(5, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeUInt32LE(fence >>> 0, 8);
+            replyWithFds(b, 'FDFromFence',
+                'Create the fence from a client-side fd with FenceFromFD instead.',
+                (buf, fds) => fds[0], cb);
+        }
 
         // DRI3 1.2: which format modifiers the server can import for this
         // window (and for its screen as a whole) at depth/bpp.
@@ -221,10 +305,40 @@ exports.requireExt = (display, callback) => {
             sendWithFds(b, planes.map(p => p.fd), 'PixmapFromBuffers', cb);
         }
 
-        ext.BuffersFromPixmap = (pixmap, cb) =>
-            unreceivable('BuffersFromPixmap',
+        // DRI3 1.2: the multi-planar, modifier-aware inverse of
+        // PixmapFromBuffers. cb(err, { width, height, modifier, depth, bpp,
+        // planes: [{ fd, stride, offset }] }) — shaped like the opts that
+        // PixmapFromBuffers takes, so a buffer can be handed straight to
+        // another screen. Every plane fd is the caller's to close.
+        ext.BuffersFromPixmap = (pixmap, cb) => {
+            const b = Buffer.alloc(8);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(8, 1);
+            b.writeUInt16LE(2, 2);
+            b.writeUInt32LE(pixmap >>> 0, 4);
+            replyWithFds(b, 'BuffersFromPixmap',
                 'Keep the buffers on the client side instead: create them yourself and ' +
-                'import them with PixmapFromBuffers.', cb);
+                'import them with PixmapFromBuffers.',
+                (buf, fds) => {
+                    const planes = [];
+                    // strides and offsets follow the fixed part, one CARD32
+                    // each per descriptor (reply byte 32 = body byte 24)
+                    for (let i = 0; i < fds.length; i++)
+                        planes.push({
+                            fd: fds[i],
+                            stride: buf.readUInt32LE(24 + i * 4),
+                            offset: buf.readUInt32LE(24 + (fds.length + i) * 4)
+                        });
+                    return {
+                        width: buf.readUInt16LE(0),
+                        height: buf.readUInt16LE(2),
+                        modifier: buf.readBigUInt64LE(8),
+                        depth: buf.readUInt8(16),
+                        bpp: buf.readUInt8(17),
+                        planes
+                    };
+                }, cb);
+        }
 
         // DRI3 1.3: tell the server which DRM device (by dev_t major/minor)
         // this window's buffers will come from, so multi-GPU servers pick the
@@ -276,9 +390,11 @@ exports.requireExt = (display, callback) => {
         }
 
         // Whether this connection can put descriptor-carrying requests on the
-        // wire at all (local unix socket with the fd-capable transport).
+        // wire at all (local unix socket with the fd-capable transport), and
+        // whether it can also take descriptors back from the server.
         ext.fdCapable = !!(X.stream && X.stream._fdCapable &&
             typeof X.stream.sendFds === 'function');
+        ext.fdReceiveCapable = canReceive();
 
         // the spec requires clients to negotiate the version before use
         ext.QueryVersion(1, 4, (e, vers) => {

--- a/lib/ext/shm.js
+++ b/lib/ext/shm.js
@@ -10,13 +10,15 @@
 //
 // The built-in provider is an unlinked /dev/shm file handed to the server with
 // AttachFd (SHM 1.2), which needs an fd-capable local connection — see
-// lib/fdpass.js. Node has no SysV shmget/shmat, so the classic Attach path
-// still needs a caller-supplied provider (`createClient({ shm: provider })`);
-// that same seam takes an mmap/koffi provider for zero-copy.
+// lib/fdpass.js (and lib/fdpass-bun.js under Bun). Node has no SysV
+// shmget/shmat, so the classic Attach path still needs a caller-supplied
+// provider (`createClient({ shm: provider })`); that same seam takes an
+// mmap/koffi provider for zero-copy.
 //
 // CreateSegment (minor opcode 7, the server-allocates-and-returns-an-fd
 // variant) is deliberately NOT implemented: receiving a regular-file fd over a
-// libuv-read socket aborts the Node process (SIGABRT). AttachFd sends only.
+// libuv-read socket aborts the Node process (SIGABRT), and the provider that
+// would use it allocates its own segment anyway. AttachFd sends only.
 
 const { EventEmitter } = require('events');
 const { createBuiltinProvider } = require('../shm-provider');

--- a/lib/fdpass-bun.js
+++ b/lib/fdpass-bun.js
@@ -1,0 +1,884 @@
+'use strict';
+
+// File-descriptor passing under Bun.
+//
+// lib/fdpass.js reaches uv_write2 through process.binding('pipe_wrap') and
+// ('stream_wrap'). Neither binding exists under Bun (oven-sh/bun#4957), so the
+// probe there degrades to "no fd passing" and the whole descriptor-passing
+// half of the library — MIT-SHM AttachFd, DRI3 PixmapFromBuffer(s) — is off.
+// Bun has a different way in: `bun:ffi` can call sendmsg(2)/recvmsg(2)
+// directly, and unlike Node it can do so in BOTH directions.
+//
+// dlopen, not cc(). bun:ffi's cc() would make the CMSG_* macros free, but it
+// compiles against the system libc and headers at runtime, which a slim
+// container need not have ("tcc: error: library 'c' not found"). Plain dlopen
+// of sendmsg/recvmsg needs neither compiler nor headers — only hand-built
+// msghdr/cmsghdr bytes, whose layouts differ between Linux and macOS but are
+// small, fixed and documented (see "wire structs" below).
+//
+// Two transports, because receiving costs more than sending:
+//
+//   SEND ONLY — connect(path). An ordinary Bun net.Socket carries the
+//   connection and sendFds() puts the request bytes on the wire with sendmsg()
+//   on that socket's own descriptor. No extra threads, no change to how the
+//   connection reads: this is the Node transport's behaviour, restored.
+//
+//   SEND AND RECEIVE — connect(path, { receiveFds: true }), reached from
+//   createClient({ receiveFds: true }). Bun's socket reader does a plain
+//   read(2), which silently DROPS ancillary data (no SIGABRT like Node — the
+//   descriptor is simply lost), so a connection that must receive descriptors
+//   cannot let Bun read it. This transport therefore owns the descriptor end
+//   to end: recvmsg(2) from here, with read readiness coming from a worker
+//   thread blocked in poll(2). That is what makes DRI3 Open, BufferFromPixmap,
+//   BuffersFromPixmap and FDFromFence implementable under Bun at all.
+//
+// Ownership, both directions:
+//   - descriptors handed to sendFds() are CONSUMED (closed once the message
+//     is on the wire, or when it fails) — same contract as lib/fdpass.js;
+//   - descriptors that arrive are OWNED BY THE CALLER once takeFds() hands
+//     them over. Anything still queued when the connection is destroyed is
+//     closed here rather than leaked.
+
+const { EventEmitter } = require('events');
+const fs = require('fs');
+
+// require() behind an indirection. The specifiers loaded through it exist only
+// on the runtime that uses them, and a bundler targeting the browser must
+// neither resolve nor inline them — a computed specifier is not enough, since
+// esbuild folds `'bun' + ':ffi'` straight back into a literal. Nothing here
+// runs unless `Bun` is defined.
+const nodeRequire = require;
+const loadModule = name => nodeRequire(name);
+
+const isDarwin = process.platform === 'darwin';
+const supportedPlatform = isDarwin || process.platform === 'linux';
+
+// ---------------------------------------------------------------------------
+// libc through bun:ffi
+// ---------------------------------------------------------------------------
+
+const LIBC_CANDIDATES = isDarwin
+    ? ['/usr/lib/libSystem.B.dylib']
+    : ['libc.so.6', 'libc.so', 'libc.musl-x86_64.so.1', 'libc.musl-aarch64.so.1'];
+
+// Only non-variadic entry points: fcntl(2) and ioctl(2) are variadic, and a
+// variadic call made through a fixed FFI signature passes its arguments in the
+// wrong place on arm64. Nothing here needs them — MSG_DONTWAIT makes every
+// send and receive non-blocking per call, so the descriptor never has to be
+// switched to O_NONBLOCK (which would also be visible to Bun's own socket).
+const SYMBOLS = {
+    socket:   { args: ['int', 'int', 'int'], returns: 'int' },
+    connect:  { args: ['int', 'ptr', 'int'], returns: 'int' },
+    sendmsg:  { args: ['int', 'ptr', 'int'], returns: 'i64' },
+    recvmsg:  { args: ['int', 'ptr', 'int'], returns: 'i64' },
+    send:     { args: ['int', 'ptr', 'u64', 'int'], returns: 'i64' },
+    write:    { args: ['int', 'ptr', 'u64'], returns: 'i64' },
+    shutdown: { args: ['int', 'int'], returns: 'int' },
+    dup:      { args: ['int'], returns: 'int' },
+    pipe:     { args: ['ptr'], returns: 'int' },
+    close:    { args: ['int'], returns: 'int' }
+};
+
+const ERRNO_SYMBOL = isDarwin
+    ? { __error: { args: [], returns: 'ptr' } }
+    : { __errno_location: { args: [], returns: 'ptr' } };
+
+let libc = null;
+let libcProbed = false;
+
+function loadLibc() {
+    if (libcProbed)
+        return libc;
+    libcProbed = true;
+    if (typeof Bun === 'undefined' || !supportedPlatform)
+        return null;
+    let ffi;
+    try {
+        ffi = loadModule('bun:ffi');
+    } catch {
+        return null;
+    }
+    for (const name of LIBC_CANDIDATES) {
+        let lib;
+        try {
+            lib = ffi.dlopen(name, Object.assign({}, SYMBOLS, ERRNO_SYMBOL));
+        } catch {
+            continue; // not this libc — try the next candidate
+        }
+        const sym = lib.symbols;
+        const errnoLocation = isDarwin ? sym.__error : sym.__errno_location;
+        libc = {
+            name,
+            sym,
+            ptr: ffi.ptr,
+            errno: () => ffi.read.i32(errnoLocation(), 0)
+        };
+        break;
+    }
+    return libc;
+}
+
+// ---------------------------------------------------------------------------
+// wire structs
+//
+// Both platforms are LP64 (8-byte pointers), and struct msghdr is 56 bytes on
+// both, but two fields differ:
+//
+//   struct msghdr  msg_iovlen / msg_controllen are `int` + padding on macOS
+//                  and `size_t` on Linux
+//   struct cmsghdr { len; int level; int type; } — len is socklen_t (4 bytes)
+//                  on macOS and size_t (8) on Linux, so the header is 12 vs 16
+//                  bytes and the payload after it aligns to 4 vs 8
+//   struct iovec   { void *base; size_t len; } — 16 bytes on both
+// ---------------------------------------------------------------------------
+
+const MSGHDR_SIZE = 56;
+const OFF_IOV = 16;
+const OFF_IOVLEN = 24;
+const OFF_CONTROL = 32;
+const OFF_CONTROLLEN = 40;
+const OFF_FLAGS = 48;
+
+const CMSG_HDR = isDarwin ? 12 : 16;
+const cmsgAlign = n => (isDarwin ? (n + 3) & ~3 : (n + 7) & ~7);
+const OFF_CMSG_LEVEL = isDarwin ? 4 : 8;
+const OFF_CMSG_TYPE = isDarwin ? 8 : 12;
+
+const AF_UNIX = 1;
+const SOCK_STREAM = 1;
+const SHUT_WR = 1;
+const SOL_SOCKET = isDarwin ? 0xffff : 1;
+const SCM_RIGHTS = 1;
+const MSG_DONTWAIT = isDarwin ? 0x80 : 0x40;
+const MSG_CTRUNC = isDarwin ? 0x20 : 0x08;
+const EINTR = 4;
+const EAGAIN = isDarwin ? 35 : 11; // == EWOULDBLOCK on both
+const EMSGSIZE = isDarwin ? 40 : 90;
+const ENOENT = 2;
+const SUN_PATH_MAX = isDarwin ? 104 : 108;
+
+// Descriptors per message. The X protocol never sends more than a handful
+// (DRI3 BuffersFromPixmap: up to 4 planes); 16 is room to spare in a control
+// buffer small enough to keep as a scratch allocation.
+const MAX_FDS = 16;
+const READ_SIZE = 65536;
+
+// Scratch, reused for every call: these are pointed at by pointers handed to
+// libc, so they must not move or be collected mid-call. Every use is
+// synchronous and single-threaded, so one set is enough.
+const msgScratch = Buffer.alloc(MSGHDR_SIZE);
+const iovScratch = Buffer.alloc(16);
+const ctlScratch = Buffer.alloc(cmsgAlign(CMSG_HDR) + cmsgAlign(4 * MAX_FDS));
+
+function setMsghdr(iovPtr, ctlPtr, ctlLen) {
+    msgScratch.fill(0);
+    msgScratch.writeBigUInt64LE(BigInt(iovPtr), OFF_IOV);
+    if (isDarwin)
+        msgScratch.writeInt32LE(1, OFF_IOVLEN);
+    else
+        msgScratch.writeBigUInt64LE(1n, OFF_IOVLEN);
+    if (ctlLen > 0) {
+        msgScratch.writeBigUInt64LE(BigInt(ctlPtr), OFF_CONTROL);
+        if (isDarwin)
+            msgScratch.writeUInt32LE(ctlLen, OFF_CONTROLLEN);
+        else
+            msgScratch.writeBigUInt64LE(BigInt(ctlLen), OFF_CONTROLLEN);
+    }
+}
+
+function setIovec(buf) {
+    iovScratch.writeBigUInt64LE(BigInt(libc.ptr(buf)), 0);
+    iovScratch.writeBigUInt64LE(BigInt(buf.length), 8);
+}
+
+// Send `buf` with `fds` attached as SCM_RIGHTS ancillary data. Returns the
+// number of bytes accepted (a stream socket may take fewer than offered — the
+// descriptors go with the bytes that were taken), or -1 with errno set.
+function sendmsgWithFds(fd, buf, fds) {
+    setIovec(buf);
+    const payload = 4 * fds.length;
+    const ctlLen = cmsgAlign(CMSG_HDR) + cmsgAlign(payload);
+    ctlScratch.fill(0, 0, ctlLen);
+    if (isDarwin)
+        ctlScratch.writeUInt32LE(CMSG_HDR + payload, 0);
+    else
+        ctlScratch.writeBigUInt64LE(BigInt(CMSG_HDR + payload), 0);
+    ctlScratch.writeInt32LE(SOL_SOCKET, OFF_CMSG_LEVEL);
+    ctlScratch.writeInt32LE(SCM_RIGHTS, OFF_CMSG_TYPE);
+    for (let i = 0; i < fds.length; i++)
+        ctlScratch.writeInt32LE(fds[i], CMSG_HDR + 4 * i);
+    setMsghdr(libc.ptr(iovScratch), libc.ptr(ctlScratch), ctlLen);
+    return Number(libc.sym.sendmsg(fd, libc.ptr(msgScratch), MSG_DONTWAIT));
+}
+
+function sendPlain(fd, buf) {
+    return Number(libc.sym.send(fd, libc.ptr(buf), BigInt(buf.length), MSG_DONTWAIT));
+}
+
+// One recvmsg into `buf`. Returns { n, fds }: n is the byte count (0 at end of
+// stream, -1 with errno set on failure) and fds the descriptors that arrived
+// with those bytes.
+//
+// Descriptors can arrive EARLY but never late. Linux glues queued messages
+// into one read and hands over the descriptors of the first one that carries
+// any (it stops there, so never two batches at once); macOS stops at the
+// message boundary instead. Either way a descriptor is delivered no later than
+// the bytes it belongs to — which is what makes the arrival-ordered queue in
+// FdSocket, popped by the reply that declares them, the right model.
+function recvmsgInto(fd, buf) {
+    setIovec(buf);
+    ctlScratch.fill(0);
+    setMsghdr(libc.ptr(iovScratch), libc.ptr(ctlScratch), ctlScratch.length);
+    const n = Number(libc.sym.recvmsg(fd, libc.ptr(msgScratch), MSG_DONTWAIT));
+    if (n <= 0)
+        return { n, fds: null, truncated: false };
+    const controlLen = isDarwin
+        ? msgScratch.readUInt32LE(OFF_CONTROLLEN)
+        : Number(msgScratch.readBigUInt64LE(OFF_CONTROLLEN));
+    const truncated = (msgScratch.readInt32LE(OFF_FLAGS) & MSG_CTRUNC) !== 0;
+    let fds = null;
+    let off = 0;
+    while (off + CMSG_HDR <= controlLen) {
+        const len = isDarwin
+            ? ctlScratch.readUInt32LE(off)
+            : Number(ctlScratch.readBigUInt64LE(off));
+        if (len < CMSG_HDR)
+            break;
+        if (ctlScratch.readInt32LE(off + OFF_CMSG_LEVEL) === SOL_SOCKET &&
+            ctlScratch.readInt32LE(off + OFF_CMSG_TYPE) === SCM_RIGHTS) {
+            fds = fds || [];
+            for (let p = off + CMSG_HDR; p + 4 <= off + len; p += 4)
+                fds.push(ctlScratch.readInt32LE(p));
+        }
+        off += cmsgAlign(len);
+    }
+    return { n, fds, truncated };
+}
+
+function closeFds(fds) {
+    for (const fd of fds) {
+        try { fs.closeSync(fd); } catch { /* already gone */ }
+    }
+}
+
+// sockaddr_un: { u8 len; u8 family; char path[104] } on macOS,
+//              { u16 family; char path[108] } on Linux.
+function sockaddrUn(socketPath) {
+    const bytes = Buffer.byteLength(socketPath);
+    if (bytes >= SUN_PATH_MAX)
+        return null;
+    const sa = Buffer.alloc(2 + SUN_PATH_MAX);
+    if (isDarwin) {
+        sa.writeUInt8(sa.length, 0);
+        sa.writeUInt8(AF_UNIX, 1);
+    } else {
+        sa.writeUInt16LE(AF_UNIX, 0);
+    }
+    sa.write(socketPath, 2);
+    return sa;
+}
+
+// ---------------------------------------------------------------------------
+// send-only transport: an ordinary Bun net.Socket, plus sendFds()
+// ---------------------------------------------------------------------------
+
+const EMPTY = Buffer.alloc(0);
+// How long to wait before retrying a descriptor-carrying write the kernel
+// would not take, and for how long. Only reachable with the socket send buffer
+// full — for the ~64 byte requests that carry descriptors, a server that has
+// stopped reading — and giving up then poisons the connection the way a failed
+// socket write does.
+const SEND_RETRY_MS = 1;
+const SEND_RETRY_LIMIT = 5000;
+
+// Attach sendFds() to a connected Bun socket whose descriptor is `fd`.
+//
+// The bytes of an fd-carrying request must land where the output queue put
+// them, and ancillary data attaches to the byte it is sent with — so a
+// sendmsg() straight to the descriptor is only correct while Bun has nothing
+// of its own buffered. When it has (writableLength > 0: the kernel would not
+// take everything earlier writes offered), the request and everything written
+// after it are held here until Bun's buffer has drained, and then replayed in
+// order. socket.write is wrapped for exactly that window.
+function attachSender(socket, fd) {
+    socket._fdCapable = true;
+
+    const rawWrite = socket.write;
+    const queue = [];      // { chunk, cb } | { chunk, fds, cb, attempts }
+    let holding = false;   // draining the queue: everything written goes on it
+    let deferred = false;  // a write was held back, so a 'drain' is owed
+
+    const finish = (item, err) => {
+        if (item.fds)
+            closeFds(item.fds); // consumed: sent, or given up on
+        if (item.cb)
+            item.cb(err || null);
+    };
+
+    // sendmsg the head of the queue, with everything before it already gone to
+    // the kernel. Returns false when the kernel took nothing and the whole
+    // thing should be retried.
+    const sendHead = item => {
+        if (socket.destroyed) {
+            queue.shift();
+            finish(item, new Error('connection is not fd-capable or already closed'));
+            return true;
+        }
+        const sent = sendmsgWithFds(fd, item.chunk, item.fds);
+        if (sent < 0) {
+            const errno = libc.errno();
+            // EMSGSIZE is how macOS reports "no room for this message right
+            // now" when it carries control data; elsewhere it is EAGAIN.
+            const wouldBlock = errno === EAGAIN || errno === EINTR || errno === EMSGSIZE;
+            if (wouldBlock && item.attempts++ < SEND_RETRY_LIMIT)
+                return false;
+            queue.shift();
+            finish(item, new Error(`fd write failed (errno ${errno})`));
+            return true;
+        }
+        queue.shift();
+        if (sent < item.chunk.length) {
+            // Partial write: the descriptors went with the bytes the kernel
+            // took, and the rest is plain bytes that must follow immediately.
+            // Bun's buffer is empty here, so writing them keeps the order.
+            closeFds(item.fds);
+            item.fds = null;
+            rawWrite.call(socket, item.chunk.subarray(sent), item.cb || undefined);
+            return true;
+        }
+        finish(item, null);
+        return true;
+    };
+
+    // Work through the queue in order. Nothing may overtake an fd request that
+    // is still waiting, so the pump stops on anything that has to wait and is
+    // resumed by the event that unblocks it.
+    const pump = () => {
+        while (queue.length > 0) {
+            const item = queue[0];
+            if (!item.fds) {
+                queue.shift();
+                rawWrite.call(socket, item.chunk, item.cb || undefined);
+                continue;
+            }
+            if (socket.writableLength !== 0) {
+                // Bun buffered more while we were held: wait for it again
+                rawWrite.call(socket, EMPTY, pump);
+                return;
+            }
+            if (!sendHead(item)) {
+                // socket send buffer full: nothing of ours is queued in Bun,
+                // so there is no 'drain' to wait for
+                setTimeout(pump, SEND_RETRY_MS);
+                return;
+            }
+        }
+        holding = false;
+        if (deferred) {
+            // Those writes returned false, so the output queue is waiting for
+            // a 'drain' Bun may never emit (it never backed up on its own).
+            deferred = false;
+            socket.emit('drain');
+        }
+    };
+
+    socket.write = function(chunk, cb) {
+        if (!holding)
+            return rawWrite.call(socket, chunk, cb);
+        queue.push({ chunk, cb: typeof cb === 'function' ? cb : null });
+        deferred = true;
+        return false;
+    };
+
+    socket.sendFds = function sendFds(reqBuffer, fds, cb) {
+        const done = cb || null;
+        if (fds.length === 0) {
+            if (done) process.nextTick(() => done(new Error('sendFds: no descriptors given')));
+            return;
+        }
+        if (fds.length > MAX_FDS) {
+            closeFds(fds);
+            if (done) process.nextTick(() => done(new Error(`sendFds: at most ${MAX_FDS} descriptors per request`)));
+            return;
+        }
+        queue.push({ chunk: reqBuffer, fds, cb: done, attempts: 0 });
+        if (!holding) {
+            holding = true;
+            pump();
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// send-and-receive transport: the connection descriptor, owned here
+// ---------------------------------------------------------------------------
+
+// The reader thread. It blocks in poll(2) — which is exactly what Bun's event
+// loop cannot be asked to do for a descriptor it does not own — and posts a
+// message when the connection becomes readable or writable. It never touches
+// the byte stream: recvmsg stays on the main thread, so data and descriptors
+// need no thread hop and arrive in one piece.
+//
+// Main -> worker is a byte on a pipe (the poll wakes on it immediately):
+//   'r' watch for readable again (sent once the main thread has drained)
+//   'o' watch for writable / 'p' stop watching for writable
+//   's' stop: close the descriptors this thread owns and exit
+//
+// The thread holds its own dup() of the connection, so a descriptor number
+// reused after close() can never be polled by mistake.
+const POLLER_SOURCE = `
+'use strict';
+const { parentPort, workerData } = require('worker_threads');
+const ffi = require('bun' + ':ffi');
+const lib = ffi.dlopen(workerData.libc, {
+    poll:  { args: ['ptr', 'int', 'int'], returns: 'int' },
+    read:  { args: ['int', 'ptr', 'u64'], returns: 'i64' },
+    close: { args: ['int'], returns: 'int' }
+});
+const POLLIN = 1, POLLOUT = 4;
+const sock = workerData.sock, wake = workerData.wake;
+const pollfds = Buffer.alloc(16); // two struct pollfd { int fd; short ev; short rev; }
+const commands = Buffer.alloc(64);
+let watchRead = true, watchWrite = false, running = true, failures = 0;
+while (running) {
+    pollfds.writeInt32LE(sock, 0);
+    pollfds.writeInt16LE((watchRead ? POLLIN : 0) | (watchWrite ? POLLOUT : 0), 4);
+    pollfds.writeInt16LE(0, 6);
+    pollfds.writeInt32LE(wake, 8);
+    pollfds.writeInt16LE(POLLIN, 12);
+    pollfds.writeInt16LE(0, 14);
+    const rc = lib.symbols.poll(ffi.ptr(pollfds), 2, -1);
+    if (rc < 0) {
+        // EINTR: retry. A descriptor that has really gone bad shows up as
+        // POLLNVAL below instead, so a poll that keeps failing is something
+        // this thread cannot fix — say so rather than spin.
+        if (++failures < 64) continue;
+        parentPort.postMessage(-1);
+        break;
+    }
+    failures = 0;
+    const woken = pollfds.readInt16LE(14);
+    if (woken) {
+        const n = Number(lib.symbols.read(wake, ffi.ptr(commands), 64));
+        for (let i = 0; i < n; i++) {
+            const c = commands[i];
+            if (c === 115) running = false;         // 's'
+            else if (c === 114) watchRead = true;   // 'r'
+            else if (c === 111) watchWrite = true;  // 'o'
+            else if (c === 112) watchWrite = false; // 'p'
+        }
+        if (!running)
+            break;
+    }
+    const revents = pollfds.readInt16LE(6);
+    if (revents) {
+        // Level-triggered: stop watching what fired until the main thread
+        // says it has drained, or this loop would spin.
+        if (revents & POLLIN) watchRead = false;
+        if (revents & POLLOUT) watchWrite = false;
+        parentPort.postMessage(revents);
+    }
+}
+lib.symbols.close(sock);
+lib.symbols.close(wake);
+`;
+
+const POLLIN = 1;
+const POLLOUT = 4;
+const POLLERR = 8;
+const POLLHUP = 16;
+const POLLNVAL = 32;
+
+// A net.Socket stand-in over a raw connection descriptor: the subset the
+// client and the output queue use (write/end/destroy, 'connect'/'data'/'end'/
+// 'error'/'close'/'drain', writableLength for backpressure) plus sendFds() and
+// takeFds().
+class FdSocket extends EventEmitter {
+    constructor(fd) {
+        super();
+        this._fd = fd;
+        this._wake = -1;
+        this._worker = null;
+        this._backlog = [];        // { buf, off, fds, cb } — in wire order
+        this._backlogBytes = 0;
+        this._watchingWrite = false;
+        this._readFds = [];        // received, waiting to be taken
+        this._drainPending = false;
+        this._shutdown = false;
+        this.destroyed = false;
+        this.writableEnded = false;
+        this.readableEnded = false;
+        this.readBuffer = null;
+        // what lib/ext/{shm,dri3}.js and lib/fdpass.js users check
+        this._fdCapable = true;
+        this._fdReceiving = true;
+    }
+
+    get writableLength() {
+        return this._backlogBytes;
+    }
+
+    // ---- reading ----------------------------------------------------------
+
+    _startReader() {
+        const { Worker } = loadModule('worker_threads');
+        const pipefds = new Int32Array(2);
+        if (libc.sym.pipe(libc.ptr(pipefds)) !== 0)
+            throw new Error(`could not create the reader wake pipe (errno ${libc.errno()})`);
+        const dup = libc.sym.dup(this._fd);
+        if (dup < 0) {
+            libc.sym.close(pipefds[0]);
+            libc.sym.close(pipefds[1]);
+            throw new Error(`could not duplicate the connection descriptor (errno ${libc.errno()})`);
+        }
+        this._wake = pipefds[1];
+        try {
+            // The worker source is inlined rather than kept in a sibling file
+            // so that a bundled application (`bun build`) still has it.
+            this._worker = new Worker(POLLER_SOURCE, {
+                eval: true,
+                workerData: { libc: libc.name, sock: dup, wake: pipefds[0] }
+            });
+        } catch (err) {
+            // nothing owns these yet
+            libc.sym.close(dup);
+            libc.sym.close(pipefds[0]);
+            libc.sym.close(pipefds[1]);
+            this._wake = -1;
+            throw err;
+        }
+        this._worker.on('message', revents => this._onReady(revents));
+        this._worker.on('error', err => this._fail(err));
+        this._worker.on('exit', () => {
+            // it exits on 's', after destroy(); any other time it took the
+            // read side with it
+            if (!this.destroyed)
+                this._fail(new Error('the connection reader thread stopped'));
+        });
+        // A blocked poll() keeps the thread alive, and with it the process —
+        // which is what an open connection should do (a net.Socket does the
+        // same). destroy() stops it.
+    }
+
+    _tell(command) {
+        if (this._wake < 0)
+            return;
+        const byte = Buffer.from(command);
+        libc.sym.write(this._wake, libc.ptr(byte), 1n);
+    }
+
+    _onReady(revents) {
+        if (this.destroyed)
+            return;
+        if (revents < 0) {
+            this._fail(new Error('waiting on the connection failed'));
+            return;
+        }
+        if (revents & POLLNVAL) {
+            this._fail(new Error('connection descriptor became invalid'));
+            return;
+        }
+        if (revents & POLLOUT) {
+            this._watchingWrite = false;
+            this._flushBacklog();
+        }
+        if (!this.destroyed && (revents & (POLLIN | POLLHUP | POLLERR)))
+            this._drainReads((revents & (POLLHUP | POLLERR)) !== 0);
+    }
+
+    // `hangup`: poll reported the peer gone. Then a read that comes up empty
+    // is the end of the stream, not "nothing yet" — re-arming on it would put
+    // this thread and the reader in a loop.
+    _drainReads(hangup) {
+        if (!this.readBuffer)
+            this.readBuffer = Buffer.allocUnsafeSlow(READ_SIZE);
+        for (;;) {
+            const { n, fds, truncated } = recvmsgInto(this._fd, this.readBuffer);
+            if (fds)
+                this._readFds.push(...fds);
+            if (truncated) {
+                this._fail(new Error('descriptors were dropped: control message truncated'));
+                return;
+            }
+            if (n > 0) {
+                // A private copy: the read buffer is reused, and the frame
+                // buffer keeps chunks until it has parsed them.
+                this.emit('data', Buffer.from(this.readBuffer.subarray(0, n)));
+                if (this.destroyed)
+                    return;
+                continue;
+            }
+            if (n === 0) {
+                this._endOfStream();
+                return;
+            }
+            const errno = libc.errno();
+            if (errno === EAGAIN || errno === EINTR) {
+                if (hangup)
+                    this._endOfStream();
+                else
+                    this._tell('r'); // drained: watch for the next bytes
+                return;
+            }
+            this._fail(errnoError('read from the connection failed', errno));
+            return;
+        }
+    }
+
+    _endOfStream() {
+        this.readableEnded = true;
+        this.emit('end');
+        if (!this.destroyed)
+            this.destroy();
+    }
+
+    // Descriptors arrive with the reply that declares them, so they are in the
+    // queue by the time that reply is parsed. `n` of them, oldest first; the
+    // caller owns them from here (and must close them).
+    takeFds(n) {
+        return this._readFds.splice(0, n);
+    }
+
+    // ---- writing ----------------------------------------------------------
+
+    write(chunk, cb) {
+        const done = typeof cb === 'function' ? cb : null;
+        if (this.destroyed || this.writableEnded) {
+            if (done)
+                process.nextTick(() => done(new Error('write after end')));
+            return false;
+        }
+        if (chunk.length === 0) {
+            // the output queue's "tell me when everything so far is out" probe
+            if (this._backlog.length > 0)
+                this._queue({ buf: chunk, off: 0, fds: null, cb: done });
+            else if (done)
+                process.nextTick(done);
+            return this._backlog.length === 0;
+        }
+        this._queue({ buf: chunk, off: 0, fds: null, cb: done });
+        return this._flushBacklog();
+    }
+
+    sendFds(reqBuffer, fds, cb) {
+        const done = cb || null;
+        if (fds.length === 0) {
+            if (done) process.nextTick(() => done(new Error('sendFds: no descriptors given')));
+            return;
+        }
+        if (fds.length > MAX_FDS) {
+            closeFds(fds);
+            if (done) process.nextTick(() => done(new Error(`sendFds: at most ${MAX_FDS} descriptors per request`)));
+            return;
+        }
+        if (this.destroyed || this.writableEnded) {
+            closeFds(fds);
+            if (done) process.nextTick(() => done(new Error('connection is not fd-capable or already closed')));
+            return;
+        }
+        this._queue({ buf: reqBuffer, off: 0, fds, cb: done });
+        this._flushBacklog();
+    }
+
+    _queue(item) {
+        this._backlog.push(item);
+        this._backlogBytes += item.buf.length - item.off;
+    }
+
+    // Write as much of the backlog as the kernel takes, in order. Returns
+    // false when it stopped short, so callers can apply backpressure.
+    _flushBacklog() {
+        while (this._backlog.length > 0) {
+            const item = this._backlog[0];
+            const rest = item.buf.subarray(item.off);
+            let sent = 0;
+            if (rest.length > 0) {
+                sent = item.fds ? sendmsgWithFds(this._fd, rest, item.fds)
+                    : sendPlain(this._fd, rest);
+                if (sent < 0) {
+                    const errno = libc.errno();
+                    // EMSGSIZE: macOS for "no room for this message right now"
+                    // when it carries control data (EAGAIN everywhere else)
+                    if (errno === EAGAIN || errno === EINTR || errno === EMSGSIZE) {
+                        this._watchWritable();
+                        return false;
+                    }
+                    this._fail(errnoError('write to the connection failed', errno));
+                    return false;
+                }
+                if (item.fds) {
+                    // on the wire with the first byte taken, consumed either way
+                    closeFds(item.fds);
+                    item.fds = null;
+                }
+            }
+            item.off += sent;
+            this._backlogBytes -= sent;
+            if (item.off < item.buf.length) {
+                this._watchWritable();
+                return false;
+            }
+            this._backlog.shift();
+            if (item.cb)
+                process.nextTick(item.cb, null);
+        }
+        if (this._watchingWrite) {
+            this._watchingWrite = false;
+            this._tell('p');
+        }
+        if (this._drainPending) {
+            this._drainPending = false;
+            this.emit('drain');
+        }
+        if (this.writableEnded && !this._shutdown)
+            this._shutdownWrite();
+        return true;
+    }
+
+    _watchWritable() {
+        this._drainPending = true;
+        if (this._watchingWrite)
+            return;
+        this._watchingWrite = true;
+        this._tell('o');
+    }
+
+    // ---- teardown ---------------------------------------------------------
+
+    _shutdownWrite() {
+        this._shutdown = true;
+        libc.sym.shutdown(this._fd, SHUT_WR);
+    }
+
+    end() {
+        if (this.writableEnded || this.destroyed)
+            return this;
+        this.writableEnded = true;
+        if (this._flushBacklog() && !this._shutdown)
+            this._shutdownWrite();
+        return this;
+    }
+
+    destroy() {
+        if (this.destroyed)
+            return this;
+        this.destroyed = true;
+        this.writableEnded = true;
+        this._tell('s'); // the thread closes its dup and the read end, then exits
+        if (this._wake >= 0)
+            libc.sym.close(this._wake);
+        this._wake = -1;
+        // Anything still queued is dropped, but its descriptors are consumed
+        // (the contract) and received ones nobody took must not leak.
+        for (const item of this._backlog) {
+            if (item.fds)
+                closeFds(item.fds);
+        }
+        this._backlog = [];
+        this._backlogBytes = 0;
+        closeFds(this._readFds);
+        this._readFds = [];
+        libc.sym.close(this._fd);
+        this._fd = -1;
+        process.nextTick(() => this.emit('close'));
+        return this;
+    }
+
+    _fail(err) {
+        if (this.destroyed)
+            return;
+        this.emit('error', err);
+        this.destroy();
+    }
+}
+
+function errnoError(message, errno) {
+    const err = new Error(`${message} (errno ${errno})`);
+    err.errno = errno;
+    return err;
+}
+
+// ---------------------------------------------------------------------------
+// entry points
+// ---------------------------------------------------------------------------
+
+// Whether this runtime can pass descriptors at all. Cheap and memoised.
+function available() {
+    return loadLibc() !== null;
+}
+
+// Connect to `socketPath`, fd-capable. Returns the connection synchronously,
+// "connecting" (it emits 'connect' on success and 'error' on failure, like
+// net.createConnection), or null when fd passing is unavailable so the caller
+// falls back to a plain socket.
+//
+// With `options.receiveFds` the connection can also receive descriptors, at
+// the cost of a reader thread; without it, it sends only, exactly like the
+// Node transport in lib/fdpass.js.
+function connect(socketPath, options) {
+    const c = loadLibc();
+    if (!c)
+        return null;
+    if (!(options && options.receiveFds))
+        return connectSending(socketPath);
+    return connectReceiving(socketPath);
+}
+
+function connectSending(socketPath) {
+    let socket;
+    try {
+        const net = require('net');
+        socket = net.createConnection(socketPath);
+    } catch {
+        return null; // any surprise -> caller uses a plain socket
+    }
+    socket.once('connect', () => {
+        // Bun exposes the raw descriptor of a client socket here; without it
+        // the connection still works, it just cannot pass descriptors.
+        const fd = socket._handle && socket._handle.fd;
+        if (typeof fd === 'number' && fd >= 0)
+            attachSender(socket, fd);
+    });
+    return socket;
+}
+
+function connectReceiving(socketPath) {
+    const sa = sockaddrUn(socketPath);
+    if (!sa)
+        return null; // path too long for sockaddr_un -> plain socket
+    const fd = libc.sym.socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0)
+        return null;
+    const socket = new FdSocket(fd);
+    // Blocking connect: a unix socket either has a listener or does not, and
+    // this is the same descriptor Bun would have connected synchronously.
+    if (libc.sym.connect(fd, libc.ptr(sa), sa.length) !== 0) {
+        const errno = libc.errno();
+        libc.sym.close(fd);
+        socket._fd = -1;
+        socket.destroyed = true;
+        process.nextTick(() => {
+            const err = errnoError(`connect to ${socketPath} failed`, errno);
+            // surface ENOENT so the caller keeps its unix->TCP fallback
+            err.code = errno === ENOENT ? 'ENOENT' : `E${errno}`;
+            socket.emit('error', err);
+        });
+        return socket;
+    }
+    try {
+        socket._startReader();
+    } catch (err) {
+        libc.sym.close(fd);
+        socket._fd = -1;
+        socket.destroyed = true;
+        process.nextTick(() => socket.emit('error', err));
+        return socket;
+    }
+    process.nextTick(() => {
+        if (!socket.destroyed)
+            socket.emit('connect');
+    });
+    return socket;
+}
+
+module.exports = { available, connect };

--- a/lib/fdpass.js
+++ b/lib/fdpass.js
@@ -15,10 +15,12 @@
 // degrades to "no shared memory" (the caller falls back to a plain socket and
 // core PutImage) rather than throwing out of connection setup.
 //
-// SEND ONLY. Never wire the reverse direction (receiving an fd, i.e. MIT-SHM
-// ShmCreateSegment or DRI3 Open/BufferFromPixmap): a regular-file fd arriving
-// on a libuv-read socket aborts the process with SIGABRT. See
+// SEND ONLY, under Node. Never wire the reverse direction (receiving an fd,
+// i.e. MIT-SHM ShmCreateSegment or DRI3 Open/BufferFromPixmap): a regular-file
+// fd arriving on a libuv-read socket aborts the process with SIGABRT. See
 // ~/NODE_BUG_ANDREY_TO_FIX.md and the notes in lib/ext/shm.js, lib/ext/dri3.js.
+// Bun has no such hazard and a transport that can receive — see
+// lib/fdpass-bun.js and `receiveFds` in docs/README.md.
 //
 // One send primitive: sendFds(req, fds, cb). The descriptors are CONSUMED —
 // handed to libuv and closed once written, success or not. That is the only
@@ -35,6 +37,29 @@
 
 let bindings = null;      // { Pipe, PipeConnectWrap, WriteWrap, PipeConstants }
 let bindingsProbed = false;
+
+// Bun has neither binding, but it can reach sendmsg(2)/recvmsg(2) through
+// bun:ffi: a sibling implementation with the same two entry points (plus the
+// receive direction Node cannot have). Probed once, at first use.
+let bunImpl;
+
+function bunTransport() {
+    if (bunImpl !== undefined)
+        return bunImpl;
+    bunImpl = null;
+    if (typeof Bun !== 'undefined') {
+        try {
+            // Loaded through an alias so a bundler targeting the browser does
+            // not follow it into a module full of Bun builtins (a computed
+            // specifier is not enough: esbuild folds it back into a literal).
+            const nodeRequire = require;
+            bunImpl = nodeRequire('./fdpass-bun');
+        } catch {
+            bunImpl = null; // sibling missing or unusable: no fd passing
+        }
+    }
+    return bunImpl;
+}
 
 function loadBindings() {
     if (bindingsProbed)
@@ -62,6 +87,9 @@ function loadBindings() {
 
 // Whether this runtime can pass file descriptors. Cheap and memoised.
 function available() {
+    const bun = bunTransport();
+    if (bun)
+        return bun.available();
     return loadBindings() !== null;
 }
 
@@ -144,7 +172,14 @@ function attachSender(socket, b) {
 // success and 'error' on failure, matching net.createConnection so the caller
 // can treat it identically. Returns null if fd passing is unavailable, so the
 // caller falls back to net.createConnection.
-function connect(socketPath) {
+//
+// `options.receiveFds` asks for a connection that can also receive
+// descriptors. Only the Bun transport can honour it; under Node it is ignored
+// (receiving is what aborts the process — see the header).
+function connect(socketPath, options) {
+    const bun = bunTransport();
+    if (bun)
+        return bun.connect(socketPath, options);
     const b = loadBindings();
     if (!b)
         return null;

--- a/lib/xcore.js
+++ b/lib/xcore.js
@@ -879,10 +879,16 @@ module.exports.createClient = (options, initCb) => {
         const providerNeedsFd = !options.shm ||
             (typeof options.shm !== 'object') || options.shm.flavor !== 'shmid';
         const disableShm = options.shm === false || options.shm === 'off';
+        // `receiveFds` additionally asks for a connection that can receive
+        // descriptors from the server (DRI3 Open/BufferFromPixmap/...). Only
+        // the Bun transport can do it, and it costs a reader thread, so it is
+        // opt-in; under Node it is ignored (see lib/fdpass.js).
+        const fdOptions = { receiveFds: !!options.receiveFds };
         const connectStream = () => {
-            const wantFdPassing = !!socketPath && !disableShm && providerNeedsFd;
+            const wantFdPassing = !!socketPath &&
+                (options.receiveFds || (!disableShm && providerNeedsFd));
             if (socketPath) {
-                stream = wantFdPassing ? fdpass.connect(socketPath) : null;
+                stream = wantFdPassing ? fdpass.connect(socketPath, fdOptions) : null;
                 if (!stream)
                     stream = net.createConnection(socketPath);
             } else {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:local": "./scripts/test-local.sh",
     "test:glx-emu": "mocha test/glx-emu/ --timeout 10000",
     "test:xserver": "mocha test/xserver/ --timeout 10000",
+    "test:bun": "bun test test/bun",
     "lint": "eslint .",
     "gen:events": "node autogen/generate-events.js",
     "gen:replies": "node autogen/generate-replies.js",

--- a/test/bun/fdpass.test.js
+++ b/test/bun/fdpass.test.js
@@ -1,0 +1,383 @@
+// The Bun transport (lib/fdpass-bun.js), end to end over a real unix socket.
+//
+// Run with `npm run test:bun` (= `bun test test/bun`). Nothing here runs under
+// Node — mocha and test-runner.js never look into test subdirectories — and
+// that is the point: this is the half of the library Node cannot reach.
+//
+// The peer side is built here with its own hand-rolled sendmsg/recvmsg through
+// bun:ffi rather than by importing the module under test, so a mistake in the
+// msghdr/cmsghdr layouts cannot cancel itself out.
+
+const { test, expect, beforeAll, afterAll } = require('bun:test');
+const { dlopen, ptr, read } = require('bun:ffi');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const fdpass = require('../../lib/fdpass');
+const x11 = require('../../lib');
+
+// --- the peer side: unix listener + descriptor-passing, built from scratch ---
+
+const isDarwin = process.platform === 'darwin';
+const libc = dlopen(isDarwin ? '/usr/lib/libSystem.B.dylib' : 'libc.so.6', {
+    socket:  { args: ['int', 'int', 'int'], returns: 'int' },
+    bind:    { args: ['int', 'ptr', 'int'], returns: 'int' },
+    listen:  { args: ['int', 'int'], returns: 'int' },
+    accept:  { args: ['int', 'ptr', 'ptr'], returns: 'int' },
+    sendmsg: { args: ['int', 'ptr', 'int'], returns: 'i64' },
+    recvmsg: { args: ['int', 'ptr', 'int'], returns: 'i64' },
+    close:   { args: ['int'], returns: 'int' },
+    ...(isDarwin
+        ? { __error: { args: [], returns: 'ptr' } }
+        : { __errno_location: { args: [], returns: 'ptr' } })
+}).symbols;
+
+const errno = () => read.i32(isDarwin ? libc.__error() : libc.__errno_location(), 0);
+
+const CMSG_HDR = isDarwin ? 12 : 16;
+const align = n => (isDarwin ? (n + 3) & ~3 : (n + 7) & ~7);
+const SOL_SOCKET = isDarwin ? 0xffff : 1;
+const SCM_RIGHTS = 1;
+const MSG_DONTWAIT = isDarwin ? 0x80 : 0x40;
+const EAGAIN = isDarwin ? 35 : 11;
+
+function msghdr(iov, ctl, ctlLen) {
+    const m = Buffer.alloc(56);
+    m.writeBigUInt64LE(BigInt(ptr(iov)), 16);
+    if (isDarwin) m.writeInt32LE(1, 24);
+    else m.writeBigUInt64LE(1n, 24);
+    if (ctlLen > 0) {
+        m.writeBigUInt64LE(BigInt(ptr(ctl)), 32);
+        if (isDarwin) m.writeUInt32LE(ctlLen, 40);
+        else m.writeBigUInt64LE(BigInt(ctlLen), 40);
+    }
+    return m;
+}
+
+function iovec(buf) {
+    const iov = Buffer.alloc(16);
+    iov.writeBigUInt64LE(BigInt(ptr(buf)), 0);
+    iov.writeBigUInt64LE(BigInt(buf.length), 8);
+    return iov;
+}
+
+// send `data` on `fd`, with `fds` as SCM_RIGHTS ancillary data
+function peerSend(fd, data, fds) {
+    const payload = 4 * fds.length;
+    const ctl = Buffer.alloc(fds.length ? align(CMSG_HDR) + align(payload) : 0);
+    if (fds.length) {
+        if (isDarwin) ctl.writeUInt32LE(CMSG_HDR + payload, 0);
+        else ctl.writeBigUInt64LE(BigInt(CMSG_HDR + payload), 0);
+        ctl.writeInt32LE(SOL_SOCKET, isDarwin ? 4 : 8);
+        ctl.writeInt32LE(SCM_RIGHTS, isDarwin ? 8 : 12);
+        fds.forEach((v, i) => ctl.writeInt32LE(v, CMSG_HDR + 4 * i));
+    }
+    const m = msghdr(iovec(data), ctl, ctl.length);
+    const n = Number(libc.sendmsg(fd, ptr(m), 0));
+    expect(n).toBe(data.length);
+}
+
+// one non-blocking recvmsg: { n, data, fds } (n < 0 means "nothing yet")
+function peerRecv(fd, max) {
+    const data = Buffer.alloc(max);
+    const ctl = Buffer.alloc(align(CMSG_HDR) + align(4 * 16));
+    const m = msghdr(iovec(data), ctl, ctl.length);
+    const n = Number(libc.recvmsg(fd, ptr(m), MSG_DONTWAIT));
+    const fds = [];
+    if (n > 0) {
+        const ctlLen = isDarwin ? m.readUInt32LE(40) : Number(m.readBigUInt64LE(40));
+        let off = 0;
+        while (off + CMSG_HDR <= ctlLen) {
+            const len = isDarwin ? ctl.readUInt32LE(off) : Number(ctl.readBigUInt64LE(off));
+            if (len < CMSG_HDR) break;
+            if (ctl.readInt32LE(off + (isDarwin ? 4 : 8)) === SOL_SOCKET &&
+                ctl.readInt32LE(off + (isDarwin ? 8 : 12)) === SCM_RIGHTS)
+                for (let p = off + CMSG_HDR; p + 4 <= off + len; p += 4)
+                    fds.push(ctl.readInt32LE(p));
+            off += align(len);
+        }
+    }
+    return { n, data: data.subarray(0, Math.max(n, 0)), fds };
+}
+
+// keep recvmsg'ing until `want` bytes have arrived, recording where each
+// descriptor turned up in the stream
+async function peerRecvAll(fd, want) {
+    const chunks = [];
+    const marks = []; // { offset, fds }
+    let total = 0;
+    const deadline = Date.now() + 5000;
+    while (total < want && Date.now() < deadline) {
+        const got = peerRecv(fd, 1 << 16);
+        if (got.n < 0) {
+            expect(errno()).toBe(EAGAIN);
+            await Bun.sleep(1);
+            continue;
+        }
+        if (got.n === 0) break;
+        if (got.fds.length)
+            marks.push({ offset: total, fds: got.fds });
+        chunks.push(got.data);
+        total += got.n;
+    }
+    return { bytes: Buffer.concat(chunks), marks };
+}
+
+const AF_UNIX = 1;
+const SOCK_STREAM = 1;
+
+function listenUnix(socketPath) {
+    const sa = Buffer.alloc(2 + (isDarwin ? 104 : 108));
+    if (isDarwin) {
+        sa.writeUInt8(sa.length, 0);
+        sa.writeUInt8(AF_UNIX, 1);
+    } else {
+        sa.writeUInt16LE(AF_UNIX, 0);
+    }
+    sa.write(socketPath, 2);
+    const fd = libc.socket(AF_UNIX, SOCK_STREAM, 0);
+    expect(fd).toBeGreaterThanOrEqual(0);
+    expect(libc.bind(fd, ptr(sa), sa.length)).toBe(0);
+    expect(libc.listen(fd, 4)).toBe(0);
+    return fd;
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+let dir;
+let payloadPath;
+const PAYLOAD = 'descriptors really do cross\n';
+const open = () => fs.openSync(payloadPath, 'r');
+const readThrough = fd => {
+    const buf = Buffer.alloc(PAYLOAD.length);
+    fs.readSync(fd, buf, 0, buf.length, 0);
+    return buf.toString();
+};
+const once = (emitter, event) => new Promise((resolve, reject) => {
+    emitter.once(event, resolve);
+    emitter.once('error', reject);
+});
+
+let sockCounter = 0;
+// a connected pair: our transport on one side, a raw descriptor on the other
+async function connectPair(options) {
+    const socketPath = path.join(dir, `s${sockCounter++}`);
+    const listener = listenUnix(socketPath);
+    const client = fdpass.connect(socketPath, options);
+    expect(client).not.toBe(null);
+    await once(client, 'connect');
+    const peer = libc.accept(listener, null, null);
+    expect(peer).toBeGreaterThanOrEqual(0);
+    libc.close(listener);
+    fs.unlinkSync(socketPath);
+    return { client, peer };
+}
+
+beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'x11-fdpass-'));
+    payloadPath = path.join(dir, 'payload');
+    fs.writeFileSync(payloadPath, PAYLOAD);
+});
+
+afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// --- tests ------------------------------------------------------------------
+
+test('fd passing is available under Bun', () => {
+    expect(fdpass.available()).toBe(true);
+});
+
+test('sendFds puts the request bytes and the descriptor on the wire', async () => {
+    const { client, peer } = await connectPair();
+    expect(client._fdCapable).toBe(true);
+
+    const fd = open();
+    const sent = new Promise(resolve => client.sendFds(Buffer.from('REQ0'), [fd], resolve));
+    expect(await sent).toBe(null);
+    // consumed: the descriptor handed to sendFds is closed once it is sent
+    // (before the peer receives it, or its number could be handed straight
+    // back to us as the received one)
+    expect(() => fs.fstatSync(fd)).toThrow();
+
+    const { bytes, marks } = await peerRecvAll(peer, 4);
+    expect(bytes.toString()).toBe('REQ0');
+    expect(marks.length).toBe(1);
+    expect(readThrough(marks[0].fds[0])).toBe(PAYLOAD);
+
+    marks[0].fds.forEach(f => fs.closeSync(f));
+    libc.close(peer);
+    client.destroy();
+});
+
+test('several descriptors ride one request', async () => {
+    const { client, peer } = await connectPair();
+    const fds = [open(), open(), open()];
+    const sent = new Promise(resolve => client.sendFds(Buffer.from('MULTI'), fds, resolve));
+    expect(await sent).toBe(null);
+
+    const { bytes, marks } = await peerRecvAll(peer, 5);
+    expect(bytes.toString()).toBe('MULTI');
+    expect(marks.length).toBe(1);
+    expect(marks[0].fds.length).toBe(3);
+    marks[0].fds.forEach(f => {
+        expect(readThrough(f)).toBe(PAYLOAD);
+        fs.closeSync(f);
+    });
+    libc.close(peer);
+    client.destroy();
+});
+
+// The ancillary data lands on the byte it was sent with, so a descriptor
+// request queued behind bytes Bun has not managed to write yet must wait for
+// them — and everything written after it must wait for it in turn.
+test('an fd request keeps its place behind buffered output', async () => {
+    const { client, peer } = await connectPair();
+    const filler = Buffer.alloc(1 << 22, 0x41); // 4 MB: more than any send buffer
+    client.write(filler);
+    expect(client.writableLength).toBeGreaterThan(0);
+
+    const fd = open();
+    const sent = new Promise(resolve => client.sendFds(Buffer.from('FDREQ'), [fd], resolve));
+    client.write(Buffer.from('AFTER'));
+
+    const total = filler.length + 5 + 5;
+    const { bytes, marks } = await peerRecvAll(peer, total);
+    expect(await sent).toBe(null);
+    expect(bytes.length).toBe(total);
+    expect(bytes.subarray(filler.length).toString()).toBe('FDREQAFTER');
+    expect(marks.length).toBe(1);
+    // The descriptor cannot turn up after the bytes it belongs to. It may turn
+    // up before them: Linux glues queued messages into one read and hands over
+    // the descriptors of the first one carrying any, so it arrives with
+    // whatever preceded it (macOS stops at the message boundary and reports
+    // exactly `filler.length`).
+    expect(marks[0].offset).toBeLessThanOrEqual(filler.length);
+    expect(readThrough(marks[0].fds[0])).toBe(PAYLOAD);
+
+    fs.closeSync(marks[0].fds[0]);
+    libc.close(peer);
+    client.destroy();
+}, 20000);
+
+test('a receiving connection takes descriptors off the wire', async () => {
+    const { client, peer } = await connectPair({ receiveFds: true });
+    expect(client._fdCapable).toBe(true);
+    expect(client._fdReceiving).toBe(true);
+
+    const chunks = [];
+    let takenWith = null; // what takeFds() gives while the marked bytes arrive
+    client.on('data', chunk => {
+        chunks.push(chunk.toString());
+        if (chunk.toString().includes('WITHFD'))
+            takenWith = client.takeFds(1);
+    });
+
+    const fd = open();
+    peerSend(peer, Buffer.from('PLAIN'), []);
+    peerSend(peer, Buffer.from('WITHFD'), [fd]);
+    peerSend(peer, Buffer.from('TAIL'), []);
+    fs.closeSync(fd);
+
+    const deadline = Date.now() + 5000;
+    while (chunks.join('').length < 15 && Date.now() < deadline)
+        await Bun.sleep(1);
+
+    expect(chunks.join('')).toBe('PLAINWITHFDTAIL');
+    // the descriptor is queued before the bytes it belongs to are handed over,
+    // which is what lets a reply parser take it while parsing that reply
+    expect(takenWith).not.toBe(null);
+    expect(takenWith.length).toBe(1);
+    expect(readThrough(takenWith[0])).toBe(PAYLOAD);
+    expect(client.takeFds(1)).toEqual([]);
+
+    fs.closeSync(takenWith[0]);
+    libc.close(peer);
+    client.destroy();
+});
+
+test('a receiving connection writes, reports end of stream and closes', async () => {
+    const { client, peer } = await connectPair({ receiveFds: true });
+
+    client.write(Buffer.from('PING'));
+    const { bytes } = await peerRecvAll(peer, 4);
+    expect(bytes.toString()).toBe('PING');
+
+    const ended = once(client, 'end');
+    const closed = once(client, 'close');
+    peerSend(peer, Buffer.from('BYE'), []);
+    libc.close(peer);
+    await ended;
+    await closed;
+    expect(client.destroyed).toBe(true);
+});
+
+test('a receiving connection shuts its write side down on end()', async () => {
+    const { client, peer } = await connectPair({ receiveFds: true });
+    client.write(Buffer.from('LAST'));
+    client.end();
+
+    const { bytes } = await peerRecvAll(peer, 4);
+    expect(bytes.toString()).toBe('LAST');
+    // the peer now sees end of stream
+    const deadline = Date.now() + 5000;
+    let n = -1;
+    while (n !== 0 && Date.now() < deadline) {
+        n = peerRecv(peer, 16).n;
+        if (n < 0) await Bun.sleep(1);
+    }
+    expect(n).toBe(0);
+    libc.close(peer);
+    client.destroy();
+});
+
+test('connect reports a missing socket as ENOENT so the caller can fall back', async () => {
+    const client = fdpass.connect(path.join(dir, 'not-there'), { receiveFds: true });
+    const err = await new Promise(resolve => client.once('error', resolve));
+    expect(err.code).toBe('ENOENT');
+});
+
+// --- against a real X server -------------------------------------------------
+
+const haveDisplay = !!process.env.DISPLAY;
+const liveTest = haveDisplay ? test : test.skip;
+
+liveTest('a local connection is fd-capable', async () => {
+    const display = await new Promise((resolve, reject) => {
+        x11.createClient((err, dpy) => (err ? reject(err) : resolve(dpy)));
+    });
+    const X = display.client;
+    expect(X.stream._fdCapable).toBe(true);
+    await new Promise(resolve => X.close(resolve));
+});
+
+liveTest('the receiving transport carries the protocol', async () => {
+    const display = await new Promise((resolve, reject) => {
+        x11.createClient({ receiveFds: true }, (err, dpy) => (err ? reject(err) : resolve(dpy)));
+    });
+    const X = display.client;
+    expect(X.stream._fdReceiving).toBe(true);
+
+    const root = display.screen[0].root;
+    const wid = X.AllocID();
+    X.CreateWindow(wid, root, 0, 0, 64, 32);
+    const geometry = await new Promise((resolve, reject) => {
+        X.GetGeometry(wid, (err, g) => (err ? reject(err) : resolve(g)));
+    });
+    expect(geometry.width).toBe(64);
+    expect(geometry.height).toBe(32);
+
+    // a reply larger than one read, to exercise the recvmsg loop
+    const name = Buffer.alloc(60000, 0x78);
+    X.ChangeProperty(0, root, X.atoms.WM_NAME, X.atoms.STRING, 8, name);
+    const prop = await new Promise((resolve, reject) => {
+        X.GetProperty(0, root, X.atoms.WM_NAME, X.atoms.STRING, 0, 60000,
+            (err, p) => (err ? reject(err) : resolve(p)));
+    });
+    expect(prop.data.length).toBe(name.length);
+
+    X.DestroyWindow(wid);
+    await new Promise(resolve => X.close(resolve));
+});

--- a/test/dri3.js
+++ b/test/dri3.js
@@ -259,6 +259,10 @@ describe('DRI3 extension (encoding)', () => {
         }));
     });
 
+    it('reports that the connection cannot receive descriptors', () => {
+        DRI3.fdReceiveCapable.should.equal(false);
+    });
+
     it('fails cleanly and consumes the descriptor when the connection cannot pass fds', done => {
         const plain = fakeClient({}); // stream without sendFds
         requireDri3(plain, ext => {
@@ -271,6 +275,164 @@ describe('DRI3 extension (encoding)', () => {
                 done();
             });
         });
+    });
+});
+
+// The reverse direction: replies that carry descriptors. Only a transport
+// that can receive them puts these four requests on the wire (Bun with
+// createClient({ receiveFds: true }) — see lib/fdpass-bun.js), so the fake
+// stream here grows the takeFds() queue such a transport exposes.
+describe('DRI3 extension (replies carrying descriptors)', () => {
+
+    let h;
+    let DRI3;
+    let arrived; // descriptors the "transport" has queued, in arrival order
+
+    const receivingStream = () => {
+        arrived = [];
+        return {
+            _fdCapable: true,
+            _fdReceiving: true,
+            sendFds: () => {},
+            takeFds: n => arrived.splice(0, n)
+        };
+    };
+
+    // answer the pending reply with `body` (the reply from byte 8 on) and
+    // `nfd` in the header's data byte, after handing `fds` to the transport
+    const respondWithFds = (body, fds) => {
+        arrived.push(...fds);
+        h.respond(h.X.seq_num, body, fds.length);
+    };
+
+    const openNull = () => fs.openSync('/dev/null', 'r');
+
+    beforeEach(done => {
+        h = fakeClient(receivingStream());
+        requireDri3(h, ext => {
+            DRI3 = ext;
+            h.sent.length = 0;
+            done();
+        });
+    });
+
+    it('reports that the connection can receive descriptors', () => {
+        DRI3.fdReceiveCapable.should.equal(true);
+    });
+
+    it('encodes Open and hands back the device descriptor', done => {
+        const fd = openNull();
+        DRI3.Open(0x321, 0, (err, deviceFd) => {
+            should.not.exist(err);
+            deviceFd.should.equal(fd);
+            fs.closeSync(deviceFd);
+            done();
+        });
+        const { buf } = h.sent[0];
+        buf.length.should.equal(12);           // sz_xDRI3OpenReq
+        buf.readUInt8(0).should.equal(OPCODE);
+        buf.readUInt8(1).should.equal(1);      // minor opcode
+        buf.readUInt16LE(2).should.equal(3);
+        buf.readUInt32LE(4).should.equal(0x321);
+        buf.readUInt32LE(8).should.equal(0);   // provider
+        respondWithFds(Buffer.alloc(24), [fd]);
+    });
+
+    it('encodes BufferFromPixmap and parses the buffer description', done => {
+        const fd = openNull();
+        DRI3.BufferFromPixmap(0x600001, (err, buffer) => {
+            should.not.exist(err);
+            buffer.should.eql({
+                fd, size: 65536, width: 64, height: 32, stride: 256, depth: 24, bpp: 32
+            });
+            fs.closeSync(buffer.fd);
+            done();
+        });
+        const { buf } = h.sent[0];
+        buf.length.should.equal(8);            // sz_xDRI3BufferFromPixmapReq
+        buf.readUInt8(1).should.equal(3);
+        buf.readUInt16LE(2).should.equal(2);
+        buf.readUInt32LE(4).should.equal(0x600001);
+        const body = Buffer.alloc(24);
+        body.writeUInt32LE(65536, 0);          // size
+        body.writeUInt16LE(64, 4);             // width
+        body.writeUInt16LE(32, 6);             // height
+        body.writeUInt16LE(256, 8);            // stride
+        body.writeUInt8(24, 10);               // depth
+        body.writeUInt8(32, 11);               // bpp
+        respondWithFds(body, [fd]);
+    });
+
+    it('encodes FDFromFence and hands back the fence descriptor', done => {
+        const fd = openNull();
+        DRI3.FDFromFence(0x42, 0x99, (err, fenceFd) => {
+            should.not.exist(err);
+            fenceFd.should.equal(fd);
+            fs.closeSync(fenceFd);
+            done();
+        });
+        const { buf } = h.sent[0];
+        buf.length.should.equal(12);           // sz_xDRI3FDFromFenceReq
+        buf.readUInt8(1).should.equal(5);
+        buf.readUInt32LE(4).should.equal(0x42);
+        buf.readUInt32LE(8).should.equal(0x99);
+        respondWithFds(Buffer.alloc(24), [fd]);
+    });
+
+    it('encodes BuffersFromPixmap and parses planes, strides and offsets', done => {
+        const fd0 = openNull();
+        const fd1 = openNull();
+        DRI3.BuffersFromPixmap(0xAB, (err, buffers) => {
+            should.not.exist(err);
+            buffers.width.should.equal(128);
+            buffers.height.should.equal(64);
+            buffers.depth.should.equal(24);
+            buffers.bpp.should.equal(32);
+            buffers.modifier.should.equal(0x0100000000000001n); // > 2^53: BigInt
+            buffers.planes.should.eql([
+                { fd: fd0, stride: 512, offset: 0 },
+                { fd: fd1, stride: 256, offset: 32768 }
+            ]);
+            buffers.planes.forEach(p => fs.closeSync(p.fd));
+            done();
+        });
+        const { buf } = h.sent[0];
+        buf.length.should.equal(8);            // sz_xDRI3BuffersFromPixmapReq
+        buf.readUInt8(1).should.equal(8);
+        buf.readUInt16LE(2).should.equal(2);
+        buf.readUInt32LE(4).should.equal(0xAB);
+        const body = Buffer.alloc(24 + 4 * 4);
+        body.writeUInt16LE(128, 0);            // width
+        body.writeUInt16LE(64, 2);             // height
+        body.writeBigUInt64LE(0x0100000000000001n, 8); // modifier
+        body.writeUInt8(24, 16);               // depth
+        body.writeUInt8(32, 17);               // bpp
+        body.writeUInt32LE(512, 24);           // strides
+        body.writeUInt32LE(256, 28);
+        body.writeUInt32LE(0, 32);             // offsets
+        body.writeUInt32LE(32768, 36);
+        respondWithFds(body, [fd0, fd1]);
+    });
+
+    it('reports a reply whose descriptors did not all arrive, and closes what did', done => {
+        const fd = openNull();
+        DRI3.BuffersFromPixmap(1, err => {
+            should.exist(err);
+            err.message.should.match(/declared 2 descriptors but 1 arrived/);
+            should.throws(() => fs.fstatSync(fd)); // closed, not leaked
+            done();
+        });
+        const body = Buffer.alloc(24 + 4 * 4);
+        arrived.push(fd);
+        h.respond(h.X.seq_num, body, 2); // the reply claims two
+    });
+
+    it('requires a callback: there would be nothing to hand the descriptors to', () => {
+        should.throws(() => DRI3.Open(1, 0), /needs a callback/);
+        should.throws(() => DRI3.BufferFromPixmap(1), /needs a callback/);
+        should.throws(() => DRI3.FDFromFence(1, 2), /needs a callback/);
+        should.throws(() => DRI3.BuffersFromPixmap(1), /needs a callback/);
+        h.sent.length.should.equal(0);
     });
 });
 


### PR DESCRIPTION
Closes #289.

## The gap

`lib/fdpass.js` reaches `uv_write2` through `process.binding('pipe_wrap')` and
`('stream_wrap')`. Neither binding exists under Bun, so the probe degraded to
"no fd passing" exactly as designed — and with it went the whole
descriptor-passing half of the library: no MIT-SHM `ShmAttachFd`, no DRI3
`PixmapFromBuffer`, silently falling back to core `PutImage`.

```
$ node -e 'console.log(require("x11/lib/fdpass.js").available())'   # true
$ bun  -e 'console.log(require("x11/lib/fdpass.js").available())'   # false  -> now true
```

Bun has a different way in: `bun:ffi` can call `sendmsg(2)`/`recvmsg(2)`
directly, and unlike Node it can do so in *both* directions — a descriptor
arriving on a Bun-read socket is silently dropped rather than aborting the
process, so nothing stands in the way of reading it properly.

`lib/fdpass-bun.js` is that implementation, selected by a runtime probe in
`lib/fdpass.js`. `dlopen`, not `bun:ffi`'s `cc()`: `cc()` would make the
`CMSG_*` macros free but compiles against system libc and headers at runtime,
which a slim container need not have (`tcc: error: library 'c' not found`).
Plain `dlopen` needs only hand-built `msghdr`/`cmsghdr` bytes — small, fixed,
and different enough between Linux and macOS to be worth stating in one place,
which the file does.

## Sending: parity, by default

A local unix-socket connection under Bun is fd-capable again, with no extra
threads and no change to how it reads: an ordinary Bun `net.Socket` carries the
connection, and `sendFds()` puts the request bytes on the wire with `sendmsg()`
on the socket's own descriptor. `Shm.usable()` is true again, and DRI3 buffer
imports work.

One thing the Node transport gets for free had to be built here. Ancillary data
attaches to the byte it is sent with, and Bun buffers what the kernel would not
take, so a `sendmsg()` straight to the descriptor is only correct while Bun has
nothing of its own pending. When it does, the fd request — and everything
written after it — is held until that output has drained, then replayed in
order. A descriptor request can therefore never overtake the bytes queued
before it, which is the one way this could have corrupted a connection.

Descriptors handed to `sendFds()` are consumed (closed once sent, or when the
send fails), unchanged from Node.

## Receiving: opt-in, and it unlocks four requests

Bun's socket reader does a plain `read(2)`, which drops the ancillary data — so
a connection that must receive descriptors cannot let Bun read it. That
transport owns the connection descriptor end to end: `recvmsg(2)` from the
module, with read readiness coming from a worker thread blocked in `poll(2)`
(woken through a pipe; it never touches the byte stream, so data and
descriptors need no thread hop). It costs a thread, so it is opt-in:

```js
x11.createClient({ receiveFds: true }, (err, display) => { /* ... */ });
```

Under Node the option is ignored — receiving is what aborts the process there.

With it, the four DRI3 requests whose replies carry descriptors are implemented
rather than refused:

| request | callback |
|---|---|
| `Open(drawable, provider, cb)` | `cb(err, fd)` — the screen's DRM device, authenticated |
| `BufferFromPixmap(pixmap, cb)` | `cb(err, { fd, size, width, height, stride, depth, bpp })` |
| `BuffersFromPixmap(pixmap, cb)` | `cb(err, { width, height, modifier, depth, bpp, planes: [{fd, stride, offset}] })` |
| `FDFromFence(drawable, fence, cb)` | `cb(err, fd)` |

`BuffersFromPixmap` hands back exactly the shape `PixmapFromBuffers` takes, so
a server-side buffer can be re-imported elsewhere without reshaping. Received
descriptors are **owned by the caller** — close them when done. Each request
requires a callback (there would be nothing to hand the descriptors to), and
`DRI3.fdReceiveCapable` says whether they will work. Where the connection
cannot receive, they report the same kind of explanatory error as before,
without touching the wire — so existing Node code sees no behaviour change.

This is what makes `Open` usable at all: until now both `lib/ext/dri3.js` and
`x11-dri`'s `listRenderNodes()` had to recommend opening `/dev/dri/renderD*`
directly as a substitute.

## Scope limits

- Sending stays impossible under Node's model for the reverse direction, and
  MIT-SHM `CreateSegment` (where the *server* allocates and returns the
  descriptor) is still not implemented: the built-in provider allocates its own
  segment and has no use for it.
- The four new DRI3 requests are verified at the encoding/parsing level and on
  the transport that carries them; no CI machine has a DRI3 server (Xvfb never
  advertises it), so they have not been round-tripped against real GPU
  hardware.
- `receiveFds` is Bun-only by nature, not by policy — there is no Node
  transport that could honour it.

## Testing

- `test/bun/fdpass.test.js` — new, run by `npm run test:bun` (`bun test
  test/bun`) and by a new CI job on Linux. It drives the transport over a real
  unix socket against a peer built from its own hand-rolled
  `sendmsg`/`recvmsg`, so a mistake in the struct layouts cannot cancel itself
  out: both directions, multiple descriptors per request, the consumed-fd
  contract, write ordering behind 4 MB of buffered output, end-of-stream and
  teardown, `ENOENT` fallback, plus a live X server round trip (skipped when
  `$DISPLAY` is unset).
- `test/dri3.js` — eight new cases for the descriptor-carrying replies:
  encodings against `dri3proto.h`, parsed fields, 64-bit modifiers, a reply
  that declares more descriptors than arrived (reported, and what did arrive is
  closed), and the "needs a callback" contract.
- Node suites unchanged in behaviour: 515 passing (was 507), plus 289
  `test:xserver` and 52 `test:glx-emu`.
- Verified on macOS arm64 (Bun 1.4.0, Node 26, XQuartz Xvfb) and in a Linux
  container (Bun 1.x, Xvfb), where MIT-SHM `AttachFd` round-trips pixels
  through a real `/dev/shm` segment under Bun — the parity claim, end to end.

One behaviour worth recording, found while testing on Linux and now documented
in the code: descriptors can be delivered **early** but never late. Linux glues
queued messages into a single `recvmsg` and hands over the descriptors of the
first one that carries any, so they can arrive with bytes that precede them
(macOS stops at the message boundary instead). Either way a descriptor is never
delivered *after* the bytes it belongs to, which is what makes the
arrival-ordered queue — popped by the reply that declares them — correct on
both.
