### PR TITLE
feat(xv): implement the image path and the notify selectors

### DIFF
--- a/docs/ext/xv.md
+++ b/docs/ext/xv.md
@@ -1,14 +1,18 @@
 # XVideo (Xv) extension
 
 Access to hardware video adaptors: scaled/color-converted image output
-(and video input) through per-adaptor "ports". This module implements the
-query/port-management half of the protocol; the actual video-path requests
-are not implemented (see Notes).
+(and video input) through per-adaptor "ports". This module implements
+adaptor/port management and the image path — handing an adaptor a YUV (or
+RGB) frame and letting it convert and scale in hardware. The capture side
+(PutVideo/GetVideo and friends) is not implemented, apart from the
+`StopVideo` teardown every client needs (see Notes).
 
 - Module: `X.require('xv', cb)` (X name `XVideo`, version reported by the
   server, 2.2 on current Xorg/Xvfb)
 - Source: [`lib/ext/xv.js`](../../lib/ext/xv.js) ·
-  Tests: [`test/xv.js`](../../test/xv.js)
+  Tests: [`test/xv.js`](../../test/xv.js),
+  [`test/xserver/xv.js`](../../test/xserver/xv.js) ·
+  Example: [`examples/xv/testpattern.js`](../../examples/xv/testpattern.js)
 - Spec: [xv-protocol-v2.txt](https://xorg.freedesktop.org/releases/X11R7.7/doc/videoproto/xv-protocol-v2.txt)
 
 ```js
@@ -80,10 +84,103 @@ scanlineOrder}`. `id` is the FOURCC as a number, `guid` a 16-byte Buffer,
 `type` an `Xv.ImageFormatInfoType`, `format` an `Xv.ImageFormatInfoFormat`,
 `scanlineOrder` an `Xv.ScanlineOrder`, `compOrder` a string.
 
+### QueryImageAttributes(port, id, width, height, cb)
+`cb(err, {numPlanes, dataSize, width, height, pitches, offsets})` — how a
+frame of image format `id` (from `ListImageFormats`) at `width x height` has
+to be laid out in memory for this port. The server may round the size up
+(planar formats need even dimensions, every plane's pitch is padded), so use
+the `width`/`height` it answers, allocate `dataSize` bytes, and write plane
+`i` at `offsets[i]` with `pitches[i]` bytes per row. Call this before
+`PutImage`, not after.
+
+### PutImage(port, drawable, gc, id, img, [cb])
+Hands the adaptor one frame. `img` is
+`{srcX, srcY, srcWidth, srcHeight, drwX, drwY, drwWidth, drwHeight, width,
+height, data}`: `width`/`height` describe the image in `data` (laid out per
+`QueryImageAttributes`), `src*` selects the part of it to show, `drw*` is the
+destination rectangle in `drawable`. The adaptor scales and colour-converts
+between the two.
+
+```js
+Xv.QueryImageAttributes(port, format.id, 640, 480, (err, plane) => {
+    const frame = Buffer.alloc(plane.dataSize);
+    // ... fill plane 0 at plane.offsets[0], plane.pitches[0] bytes per row
+    Xv.PutImage(port, win, gc, format.id, {
+        srcX: 0, srcY: 0, srcWidth: plane.width, srcHeight: plane.height,
+        drwX: 0, drwY: 0, drwWidth: 1280, drwHeight: 960,
+        width: plane.width, height: plane.height, data: frame
+    });
+});
+```
+
+Two things to know about `data`:
+
+- **It is queued by reference, not copied** (core `PutImage` copies; this one
+  does not, because a frame is large and the point of Xv is to move fewer
+  bytes). Do not overwrite it until the server has read it: alternate two
+  buffers, or wait for `cb`. `ShmPutImage` with `sendEvent` is the proper
+  recycling discipline.
+- **A frame past 256 KiB needs BIG-REQUESTS**, which is enabled by default;
+  the request switches to the extended length encoding on its own. A frame
+  past `display.max_request_length * 4` bytes (that limit is 256 KiB when the
+  connection was made with `disableBigRequests`) is refused before anything
+  is sent — through `cb` if you passed one, otherwise as a thrown `Error` —
+  because a server that reads a length it cannot accept drops the whole
+  connection, not just the request. There is no way to split one XvPutImage:
+  send a smaller frame and let the adaptor scale it up, or use
+  `ShmPutImage`, whose size is bounded by the segment rather than the
+  request.
+
+`cb` is optional and makes this a *checked* void request: it fires with
+`null` once the server has processed the frame, or with the error
+(`XvBadPort`, `BadMatch` for a format the port does not take, `BadAlloc`).
+It forces a round trip, so use it while bringing a pipeline up, not on every
+frame of a playback loop.
+
+### ShmPutImage(port, drawable, gc, shmseg, id, img, [cb])
+`PutImage` with the pixels already in a shared memory segment instead of on
+the wire. `img` takes the same fields except `data`, plus `offset` (where the
+frame starts in the segment) and `sendEvent`. `shmseg` is a segment XID from
+[MIT-SHM](shm.md) — `Shm.createSegment(size, cb)` gives you one with a
+`buffer` to render into.
+
+With `sendEvent: true` the server sends a `ShmCompletion` event once it has
+finished reading the segment, which is what lets you reuse that buffer
+safely; `lib/ext/shm.js` routes it to the segment, so
+`segment.on('complete', ...)` fires:
+
+```js
+Shm.createSegment(plane.dataSize, (err, segment) => {
+    segment.on('complete', () => { /* safe to render the next frame */ });
+    segment.buffer.fill(0x80);
+    segment.commit(0);
+    Xv.ShmPutImage(port, win, gc, segment.shmseg, format.id, {
+        srcX: 0, srcY: 0, srcWidth: w, srcHeight: h,
+        drwX: 0, drwY: 0, drwWidth: w, drwHeight: h,
+        width: w, height: h, offset: 0, sendEvent: true
+    });
+});
+```
+
+### StopVideo(port, drawable, [cb])
+Stops whatever `port` is putting into `drawable` and drops the association
+between the two — the teardown half of `PutImage`, and what makes a server
+send `XvVideoNotify` with reason `Stopped`. Call it when the window a port
+was feeding goes away. Void; `cb` is checked as for `PutImage`.
+
+### SelectVideoNotify(drawable, onoff, [cb])
+Subscribes to (`onoff` true) or unsubscribes from `XvVideoNotify` events for
+`drawable`. Takes a drawable rather than a port, so it works even on a server
+with no adaptors. Void; `cb` is checked as for `PutImage`.
+
+### SelectPortNotify(port, onoff, [cb])
+Subscribes to (`onoff` true) or unsubscribes from `XvPortNotify` events for
+`port` — sent whenever one of its attributes changes, including changes made
+by other clients.
+
 ## Events
 
-Selecting these requires SelectVideoNotify/SelectPortNotify, which are not
-implemented (see Notes); the parsers are registered for completeness.
+Both need the matching Select request above before a server sends them.
 
 ### XvVideoNotify
 Video started/stopped on a drawable. Fields: `type`, `seq`, `reason`
@@ -111,12 +208,23 @@ A port attribute changed. Fields: `type`, `seq`, `time`, `port`,
   InvalidTime: 3, BadReply: 4, BadAlloc: 5}`,
   `Xv.VideoNotifyReason = {Started: 0, Stopped: 1, Busy: 2, Preempted: 3,
   HardError: 4}`.
-- Not implemented: the video-path requests PutVideo (5), PutStill (6),
-  GetVideo (7), GetStill (8), StopVideo (9), SelectVideoNotify (10),
-  SelectPortNotify (11), QueryImageAttributes (17), PutImage (18),
-  ShmPutImage (19). These need a working port to do anything, and Xvfb
-  (the CI server) exposes the extension with zero adaptors, so they cannot
-  be exercised; they are omitted rather than shipped untested.
-- test/xv.js validates the port-based requests against a bogus port: a
-  controlled `XvBadPort` error proves correct request framing. With a real
-  adaptor present the same tests take the success path.
+- Not implemented: the capture-side requests PutVideo (5), PutStill (6),
+  GetVideo (7) and GetStill (8). They drive a video *input* port — a capture
+  card scanning into a drawable — which no current driver ships, and none of
+  them can be exercised anywhere in CI. `StopVideo` (9) *is* implemented
+  despite belonging to the same group: it is how an image client releases a
+  drawable.
+- **There may well be no adaptor.** `QueryAdaptors` returning `[]` is the
+  normal case on anything but a machine with a GPU driver that offers
+  textured video: Xvfb (the CI server) and XQuartz both advertise
+  `X-Video Extension version 2.2` and answer "no adaptors present". A client
+  that wants Xv has to check the list and fall back to core `PutImage`.
+- Testing, given the above: test/xv.js runs against the real server and
+  checks that each port-based request reaches it well formed — a controlled
+  `XvBadPort` rather than a `BadLength`, with the connection still in step
+  afterwards — and takes the success path instead when a real adaptor is
+  present. test/xserver/xv.js registers a test adaptor
+  (test/xserver/xv-adaptor.js) on the pure-JS X server and drives the image
+  path to completion: YUY2 and I420 frames decoded and compared pixel by
+  pixel, plane pitches and offsets, scaling, the BIG-REQUESTS encoding, and
+  the notify events including the Started/Stopped pair around StopVideo.

--- a/examples/xv/README.md
+++ b/examples/xv/README.md
@@ -1,0 +1,49 @@
+# XVideo: handing an adaptor a frame
+
+`testpattern.js` puts 75% colour bars into a window through the X-Video
+extension: the client sends planar YUV, and the adaptor does the colour
+conversion and the scaling.
+
+```sh
+node testpattern.js                       # colour bars at 640x480
+node testpattern.js --width 1920 --height 1080
+node testpattern.js --shm                 # through a MIT-SHM segment
+```
+
+It prints what it found before it draws anything:
+
+```
+X-Video Extension version 2.2
+adaptor "Intel(R) Textured Video": ports 88..119, type 0x11
+  format YUY2 (0x32595559): 16 bpp, 1 plane(s), packed YUYV
+  format I420 (0x30323449): 12 bpp, 3 plane(s), planar YUV
+using port 88, format I420
+frame 640x480: 460800 bytes, pitches 640,320,320, offsets 0,307200,384000
+(core PutImage would be 1228800 bytes for the same frame)
+```
+
+## You will probably see "no adaptors present"
+
+An Xv adaptor comes from a driver with a video path — Intel/AMD textured
+video, NVIDIA, a capture card. **Xvfb and XQuartz both advertise the
+extension and offer zero adaptors**, so this exits after printing the
+adaptor list on any headless CI machine and on macOS. `xvinfo` reports the
+same thing from the command line. A client that wants Xv has to check
+`QueryAdaptors` and fall back to core `PutImage` — which is what the exit
+here stands in for.
+
+## What to look at
+
+- **`QueryImageAttributes` before every allocation.** The server decides the
+  plane layout: dimensions round up, each plane's pitch is padded. Writing
+  rows at `width` bytes instead of `pitches[0]` skews the picture.
+- **The buffer discipline.** Over the wire the frame is queued by reference,
+  so this alternates two buffers. With `--shm` there is one segment and the
+  `ShmCompletion` event says when the server has finished reading it —
+  `segment.on('complete')` paces the loop.
+- **Bytes moved.** The line above compares the frame with what core
+  `PutImage` would send for the same picture: I420 is a third of depth-24
+  RGB, and the conversion and the scale happen in the adaptor rather than in
+  JavaScript.
+
+See [`docs/ext/xv.md`](../../docs/ext/xv.md) for the request reference.

--- a/examples/xv/testpattern.js
+++ b/examples/xv/testpattern.js
@@ -1,0 +1,229 @@
+// XVideo test pattern: hands an adaptor colour bars, one frame at a time.
+//
+//   node examples/xv/testpattern.js [--shm] [--width N] [--height N]
+//
+// Needs an adaptor, which means a real driver: Xvfb and XQuartz advertise the
+// extension and report zero adaptors, and this prints what it found and exits
+// in that case (which is what a client should do - fall back to core
+// PutImage). `xvinfo` lists the same adaptors from the command line.
+//
+// --shm renders into a MIT-SHM segment and uses XvShmPutImage, recycling the
+// segment on the ShmCompletion event.
+
+const x11 = require('../../lib');
+
+const args = process.argv.slice(2);
+const flag = name => args.includes(name);
+const value = (name, dflt) => {
+    const i = args.indexOf(name);
+    return i === -1 ? dflt : parseInt(args[i + 1], 10);
+};
+
+const USE_SHM = flag('--shm');
+const WIDTH = value('--width', 640);
+const HEIGHT = value('--height', 480);
+
+const fourcc = id => String.fromCharCode(id & 0xff, (id >> 8) & 0xff, (id >> 16) & 0xff, (id >> 24) & 0xff);
+
+// 75% colour bars, BT.601 (the values a broadcast generator puts out)
+const BARS = [
+    [180, 128, 128], // white
+    [162, 44, 142],  // yellow
+    [131, 156, 44],  // cyan
+    [112, 72, 58],   // green
+    [84, 184, 198],  // magenta
+    [65, 100, 212],  // red
+    [35, 212, 114],  // blue
+    [16, 128, 128]   // black
+];
+
+// Write one frame of bars into `buf`, with a white sweep line at `phase`
+// (0..1). Handles the two layouts every adaptor offers: packed YUY2-style
+// (one plane, Y per pixel and U/V per pair) and planar I420/YV12-style
+// (three planes, U/V at half resolution both ways).
+function drawFrame(buf, base, plane, planar, uvSwapped, phase) {
+    const { width, height, pitches, offsets } = plane;
+    const sweep = Math.floor(phase * width);
+    const sample = x => {
+        if (x >= sweep && x < sweep + 8)
+            return [235, 128, 128];
+        return BARS[Math.min(BARS.length - 1, Math.floor(x * BARS.length / width))];
+    };
+    if (!planar) {
+        for (let y = 0; y < height; y++) {
+            const row = base + offsets[0] + y * pitches[0];
+            for (let x = 0; x < width; x += 2) {
+                const a = sample(x), b = sample(x + 1);
+                buf[row + x * 2] = a[0];
+                buf[row + x * 2 + 1] = (a[1] + b[1]) >> 1;
+                buf[row + x * 2 + 2] = b[0];
+                buf[row + x * 2 + 3] = (a[2] + b[2]) >> 1;
+            }
+        }
+        return;
+    }
+    const uPlane = uvSwapped ? 2 : 1;
+    const vPlane = uvSwapped ? 1 : 2;
+    for (let y = 0; y < height; y++) {
+        const row = base + offsets[0] + y * pitches[0];
+        for (let x = 0; x < width; x++)
+            buf[row + x] = sample(x)[0];
+    }
+    for (let y = 0; y < height >> 1; y++) {
+        const uRow = base + offsets[uPlane] + y * pitches[uPlane];
+        const vRow = base + offsets[vPlane] + y * pitches[vPlane];
+        for (let x = 0; x < width >> 1; x++) {
+            const s = sample(x * 2);
+            buf[uRow + x] = s[1];
+            buf[vRow + x] = s[2];
+        }
+    }
+}
+
+x11.createClient((err, display) => {
+    if (err)
+        throw err;
+    const X = display.client;
+    const screen = display.screen[0];
+    X.on('error', e => console.error('X error:', e));
+
+    X.require('xv', (err, Xv) => {
+        if (err) {
+            console.error('no XVideo extension on this server:', err.message);
+            return X.terminate();
+        }
+        console.log(`X-Video Extension version ${Xv.major}.${Xv.minor}`);
+
+        Xv.QueryAdaptors(screen.root, (err, adaptors) => {
+            if (err)
+                throw err;
+            if (adaptors.length === 0) {
+                console.log('no adaptors present - nothing can take a frame here.');
+                console.log('(a client should fall back to core PutImage)');
+                return X.terminate();
+            }
+
+            let chosen = null;
+            for (const a of adaptors) {
+                console.log(`adaptor "${a.name}": ports ${a.baseId}..${a.baseId + a.numPorts - 1}, type 0x${a.type.toString(16)}`);
+                if (!chosen && (a.type & Xv.Type.ImageMask))
+                    chosen = a;
+            }
+            if (!chosen) {
+                console.log('no adaptor takes images from client memory (Type.ImageMask)');
+                return X.terminate();
+            }
+
+            const port = chosen.baseId;
+            Xv.ListImageFormats(port, (err, formats) => {
+                if (err)
+                    throw err;
+                for (const f of formats)
+                    console.log(`  format ${fourcc(f.id)} (0x${f.id.toString(16)}): ${f.bpp} bpp, ${f.numPlanes} plane(s), ${f.format === Xv.ImageFormatInfoFormat.Planar ? 'planar' : 'packed'} ${f.compOrder}`);
+
+                // planar first: it is the point of Xv, half the bytes of packed
+                const format = formats.find(f => fourcc(f.id) === 'I420') ||
+                    formats.find(f => fourcc(f.id) === 'YV12') ||
+                    formats.find(f => fourcc(f.id) === 'YUY2') ||
+                    formats[0];
+                const planar = format.format === Xv.ImageFormatInfoFormat.Planar;
+                const uvSwapped = fourcc(format.id) === 'YV12';
+                console.log(`using port ${port}, format ${fourcc(format.id)}`);
+
+                Xv.QueryImageAttributes(port, format.id, WIDTH, HEIGHT, (err, plane) => {
+                    if (err)
+                        throw err;
+                    console.log(`frame ${plane.width}x${plane.height}: ${plane.dataSize} bytes, pitches ${plane.pitches}, offsets ${plane.offsets}`);
+                    console.log(`(core PutImage would be ${plane.width * plane.height * 4} bytes for the same frame)`);
+
+                    const wid = X.AllocID();
+                    X.CreateWindow(wid, screen.root, 0, 0, WIDTH, HEIGHT, 0, 0, 0, 0, {
+                        backgroundPixel: screen.black_pixel,
+                        eventMask: x11.eventMask.Exposure | x11.eventMask.StructureNotify
+                    });
+                    X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, 'Xv test pattern');
+                    X.MapWindow(wid);
+                    const gc = X.AllocID();
+                    X.CreateGC(gc, wid);
+
+                    let frames = 0;
+                    let bytes = 0;
+                    let since = Date.now();
+                    const stats = () => {
+                        const dt = (Date.now() - since) / 1000;
+                        if (dt < 1)
+                            return;
+                        console.log(`${(frames / dt).toFixed(1)} fps, ${(bytes / dt / (1 << 20)).toFixed(1)} MiB/s`);
+                        frames = bytes = 0;
+                        since = Date.now();
+                    };
+
+                    const geometry = () => ({
+                        srcX: 0, srcY: 0, srcWidth: plane.width, srcHeight: plane.height,
+                        drwX: 0, drwY: 0, drwWidth: WIDTH, drwHeight: HEIGHT,
+                        width: plane.width, height: plane.height
+                    });
+
+                    const start = shmSegment => {
+                        // two buffers when sending over the wire: the request
+                        // queues `data` by reference, so the one in flight must
+                        // not be touched. With SHM the ShmCompletion event says
+                        // when the single segment is free again.
+                        const buffers = shmSegment ? [shmSegment.buffer] :
+                            [Buffer.alloc(plane.dataSize), Buffer.alloc(plane.dataSize)];
+                        let n = 0;
+                        const render = () => {
+                            const buf = buffers[n % buffers.length];
+                            drawFrame(buf, 0, plane, planar, uvSwapped, (n % 60) / 60);
+                            n++;
+                            frames++;
+                            bytes += plane.dataSize;
+                            if (shmSegment) {
+                                shmSegment.commit(0);
+                                Xv.ShmPutImage(port, wid, gc, shmSegment.shmseg, format.id,
+                                    Object.assign({ offset: 0, sendEvent: true }, geometry()));
+                            } else {
+                                Xv.PutImage(port, wid, gc, format.id,
+                                    Object.assign({ data: buf }, geometry()));
+                                X.flush();
+                            }
+                            stats();
+                        };
+                        if (shmSegment) {
+                            // one frame in flight at a time: the next goes out
+                            // when the server is done reading the segment
+                            shmSegment.on('complete', () => setImmediate(render));
+                            render();
+                        } else {
+                            setInterval(render, 1000 / 60);
+                        }
+                    };
+
+                    if (!USE_SHM)
+                        return start(null);
+
+                    X.require('shm', (err, Shm) => {
+                        if (err) {
+                            console.log('no MIT-SHM on this server, sending over the wire');
+                            return start(null);
+                        }
+                        Shm.usable((err, ok) => {
+                            if (!ok) {
+                                console.log('no usable shared-memory provider, sending over the wire');
+                                return start(null);
+                            }
+                            Shm.createSegment(plane.dataSize, (err, segment) => {
+                                if (err) {
+                                    console.log('createSegment failed, sending over the wire:', err.message);
+                                    return start(null);
+                                }
+                                console.log(`using MIT-SHM segment ${segment.shmseg} (${segment.zeroCopy ? 'zero-copy' : 'copied'})`);
+                                start(segment);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/lib/ext/xv.js
+++ b/lib/ext/xv.js
@@ -170,6 +170,66 @@ exports.requireExt = (display, callback) => {
             X.pack_stream.submit();
         }
 
+        // Stops video (or a still image) the port is putting into `drawable`
+        // and releases the association between the two - the teardown half of
+        // PutImage/PutStill, and what makes the server send an XvVideoNotify
+        // with reason Stopped. Void request; `cb` is checked as for
+        // SelectVideoNotify below.
+        ext.StopVideo = (port, drawable, cb) => {
+            X.seq_num++;
+            const seq = X.seq_num;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(9, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt32LE(drawable >>> 0, 8);
+            if (cb) {
+                X.replies[seq] = [null, cb];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.submit();
+        }
+
+        // Ask for XvVideoNotify events on `drawable`. Void request; with a
+        // callback it fires cb(null) once the server has processed it (forced
+        // by a round trip) or cb(err) if it errored.
+        ext.SelectVideoNotify = (drawable, onoff, cb) => {
+            X.seq_num++;
+            const seq = X.seq_num;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(10, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(drawable >>> 0, 4);
+            b.writeUInt8(onoff ? 1 : 0, 8);
+            if (cb) {
+                X.replies[seq] = [null, cb];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.submit();
+        }
+
+        // Ask for XvPortNotify events (attribute changes) on `port`.
+        ext.SelectPortNotify = (port, onoff, cb) => {
+            X.seq_num++;
+            const seq = X.seq_num;
+            const b = Buffer.alloc(12);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(11, 1);
+            b.writeUInt16LE(3, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt8(onoff ? 1 : 0, 8);
+            if (cb) {
+                X.replies[seq] = [null, cb];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.submit();
+        }
+
         ext.QueryBestSize = (port, vidW, vidH, drwW, drwH, motion, cb) => {
             X.seq_num++;
             const b = Buffer.alloc(20);
@@ -302,6 +362,157 @@ exports.requireExt = (display, callback) => {
                 cb
             ];
             X.pack_stream.submit(true);
+        }
+
+        // Plane layout of image format `id` at `width` x `height` on `port`.
+        // cb(err, {numPlanes, dataSize, width, height, pitches, offsets}) --
+        // the server may round the size up, so use the width/height it
+        // answers (and its pitches/offsets) to lay the image out for PutImage.
+        ext.QueryImageAttributes = (port, id, width, height, cb) => {
+            X.seq_num++;
+            const b = Buffer.alloc(16);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(17, 1);
+            b.writeUInt16LE(4, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt32LE(id >>> 0, 8);
+            b.writeUInt16LE(width, 12);
+            b.writeUInt16LE(height, 14);
+            X.pack_stream.put(b);
+            X.replies[X.seq_num] = [
+                (buf, opt) => {
+                    const numPlanes = buf.readUInt32LE(0);
+                    const pitches = [];
+                    const offsets = [];
+                    for (let i = 0; i < numPlanes; ++i) {
+                        pitches.push(buf.readUInt32LE(24 + i * 4));
+                        offsets.push(buf.readUInt32LE(24 + numPlanes * 4 + i * 4));
+                    }
+                    return {
+                        numPlanes: numPlanes,
+                        dataSize: buf.readUInt32LE(4),
+                        width: buf.readUInt16LE(8),
+                        height: buf.readUInt16LE(10),
+                        pitches: pitches,
+                        offsets: offsets
+                    };
+                },
+                cb
+            ];
+            X.pack_stream.submit(true);
+        }
+
+        // img: { srcX, srcY, srcWidth, srcHeight, drwX, drwY, drwWidth,
+        //        drwHeight, width, height, data }
+        // `width`/`height` describe the image in `data` (laid out per
+        // QueryImageAttributes); src* selects the part of it to show, drw*
+        // the destination rectangle in `drawable`. The adaptor scales and
+        // color-converts. `id` is an id from ListImageFormats.
+        //
+        // Void request: pass `cb` to have it checked (costs a round trip, so
+        // not per frame in a playback loop).
+        ext.PutImage = (port, drawable, gc, id, img, cb) => {
+            const data = img.data;
+            const padded = pad4(data.length);
+            // 40-byte header (10 words) + padded image data
+            const reqLen = 10 + padded / 4;
+            // A frame the connection cannot carry has to be refused here:
+            // sent anyway, the server rejects the length and drops the
+            // connection rather than just this request.
+            const maxLen = display.max_request_length || 0xffff;
+            if (reqLen + (reqLen > 0xffff ? 1 : 0) > maxLen) {
+                const err = new Error(
+                    `Xv PutImage: frame of ${data.length} bytes exceeds this connection's ` +
+                    `maximum request length (${maxLen * 4} bytes). Send a smaller image ` +
+                    'and let the adaptor scale it up, or use ShmPutImage.');
+                if (cb)
+                    return process.nextTick(() => cb(err));
+                throw err;
+            }
+            let b;
+            if (reqLen <= 0xffff) {
+                // fits the 16-bit length field: plain encoding, valid whether
+                // or not BIG-REQUESTS was negotiated
+                b = Buffer.alloc(40);
+                b.writeUInt8(ext.majorOpcode, 0);
+                b.writeUInt8(18, 1);
+                b.writeUInt16LE(reqLen, 2);
+            } else {
+                // too large for a 16-bit length: BIG-REQUESTS encoding (length
+                // field 0, then a CARD32 holding the real length + 1 for the
+                // extra word). Needs BIG-REQUESTS enabled at connect (the
+                // default) and a server max_request_length that fits the frame.
+                b = Buffer.alloc(44);
+                b.writeUInt8(ext.majorOpcode, 0);
+                b.writeUInt8(18, 1);
+                b.writeUInt16LE(0, 2);
+                b.writeUInt32LE((reqLen + 1) >>> 0, 4);
+            }
+            const o = b.length - 36; // first field after the length encoding
+            b.writeUInt32LE(port >>> 0, o);
+            b.writeUInt32LE(drawable >>> 0, o + 4);
+            b.writeUInt32LE(gc >>> 0, o + 8);
+            b.writeUInt32LE(id >>> 0, o + 12);
+            b.writeInt16LE(img.srcX, o + 16);
+            b.writeInt16LE(img.srcY, o + 18);
+            b.writeUInt16LE(img.srcWidth, o + 20);
+            b.writeUInt16LE(img.srcHeight, o + 22);
+            b.writeInt16LE(img.drwX, o + 24);
+            b.writeInt16LE(img.drwY, o + 26);
+            b.writeUInt16LE(img.drwWidth, o + 28);
+            b.writeUInt16LE(img.drwHeight, o + 30);
+            b.writeUInt16LE(img.width, o + 32);
+            b.writeUInt16LE(img.height, o + 34);
+            X.seq_num++;
+            const seq = X.seq_num;
+            if (cb) {
+                X.replies[seq] = [null, cb];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.put(data);
+            if (padded !== data.length)
+                X.pack_stream.put(Buffer.alloc(padded - data.length));
+            X.pack_stream.submit();
+        }
+
+        // Same as PutImage, with the pixels already in a shared segment
+        // (MIT-SHM) at `offset` instead of on the wire.
+        // img: { srcX, srcY, srcWidth, srcHeight, drwX, drwY, drwWidth,
+        //        drwHeight, width, height, offset, sendEvent }
+        // With sendEvent the server sends a ShmCompletion event once it has
+        // finished reading the segment, which is what lets a caller recycle
+        // the buffer safely (see lib/ext/shm.js).
+        ext.ShmPutImage = (port, drawable, gc, shmseg, id, img, cb) => {
+            X.seq_num++;
+            const seq = X.seq_num;
+            const b = Buffer.alloc(52);
+            b.writeUInt8(ext.majorOpcode, 0);
+            b.writeUInt8(19, 1);
+            b.writeUInt16LE(13, 2);
+            b.writeUInt32LE(port >>> 0, 4);
+            b.writeUInt32LE(drawable >>> 0, 8);
+            b.writeUInt32LE(gc >>> 0, 12);
+            b.writeUInt32LE(shmseg >>> 0, 16);
+            b.writeUInt32LE(id >>> 0, 20);
+            b.writeUInt32LE((img.offset || 0) >>> 0, 24);
+            b.writeInt16LE(img.srcX, 28);
+            b.writeInt16LE(img.srcY, 30);
+            b.writeUInt16LE(img.srcWidth, 32);
+            b.writeUInt16LE(img.srcHeight, 34);
+            b.writeInt16LE(img.drwX, 36);
+            b.writeInt16LE(img.drwY, 38);
+            b.writeUInt16LE(img.drwWidth, 40);
+            b.writeUInt16LE(img.drwHeight, 42);
+            b.writeUInt16LE(img.width, 44);
+            b.writeUInt16LE(img.height, 46);
+            b.writeUInt8(img.sendEvent ? 1 : 0, 48);
+            if (cb) {
+                X.replies[seq] = [null, cb];
+                X._scheduleVoidSync(seq);
+            }
+            X.pack_stream.put(b);
+            X.pack_stream.submit();
         }
 
         ext.events = {

--- a/test/xserver/xv-adaptor.js
+++ b/test/xserver/xv-adaptor.js
@@ -1,0 +1,504 @@
+'use strict';
+
+// A minimal XVideo adaptor for the pure-JS X server (lib/xserver), used by
+// test/xserver/xv.js to exercise the client's image path end to end.
+//
+// Real Xv adaptors only exist on hardware: Xvfb and XQuartz advertise the
+// extension and answer "no adaptors present", so nothing in CI can accept a
+// frame. This registers one image adaptor with two formats - YUY2 (packed)
+// and I420 (planar) - decodes XvPutImage/XvShmPutImage into the target
+// drawable, and sends XvVideoNotify/XvPortNotify to clients that selected
+// them. The wire layouts come from autogen/proto/xv.xml, not from the
+// client's encoder.
+//
+// Deliberate liberties, all noted where they happen:
+//  - scaling is nearest-neighbour, so a test can predict every pixel;
+//  - a PutImage starts a "stream" on its drawable and StopVideo ends one, so
+//    VideoNotify Started/Stopped follow those transitions rather than a real
+//    video timeline;
+//  - ShmPutImage reads from a segment the test registers directly on the
+//    extension, because the JS server has no MIT-SHM.
+
+const { XError, codes } = require('../../lib/xserver/errors');
+
+const pad4 = n => (n + 3) & ~3;
+
+// image adaptor: takes images from client memory (Type.ImageMask | InputMask)
+const ADAPTOR_TYPE = 16 | 1;
+const BASE_PORT = 0x1f00;
+const NUM_PORTS = 2;
+const ENCODING = 0x1f10;
+
+const PACKED = 0, PLANAR = 1;
+const YUV = 1;
+
+const guid = hex => Buffer.from(hex.replace(/ /g, ''), 'hex');
+
+const FORMATS = [
+    {
+        id: 0x32595559, // 'YUY2'
+        type: YUV,
+        byteOrder: 0,
+        guid: guid('59 55 59 32 00 00 10 00 80 00 00 aa 00 38 9b 71'),
+        bpp: 16,
+        numPlanes: 1,
+        depth: 24,
+        format: PACKED,
+        compOrder: 'YUYV',
+        scanlineOrder: 0
+    },
+    {
+        id: 0x30323449, // 'I420'
+        type: YUV,
+        byteOrder: 0,
+        guid: guid('49 34 32 30 00 00 10 00 80 00 00 aa 00 38 9b 71'),
+        bpp: 12,
+        numPlanes: 3,
+        depth: 24,
+        format: PLANAR,
+        compOrder: 'YUV',
+        scanlineOrder: 0
+    }
+];
+
+const ATTRIBUTES = [
+    { name: 'XV_BRIGHTNESS', flags: 3, min: -1000, max: 1000, value: 0 },
+    { name: 'XV_CONTRAST', flags: 3, min: -1000, max: 1000, value: 0 }
+];
+
+// Plane layout, following the xf86 XvQueryImageAttributes convention:
+// dimensions round up to even, every pitch rounds up to 4 bytes.
+function layout(format, width, height) {
+    const w = (width + 1) & ~1;
+    const h = (height + 1) & ~1;
+    if (format.format === PACKED) {
+        const pitch = pad4(w * 2);
+        return { width: w, height: h, pitches: [pitch], offsets: [0], size: pitch * h };
+    }
+    const yPitch = pad4(w);
+    const ySize = yPitch * h;
+    const uvPitch = pad4(w >> 1);
+    const uvSize = uvPitch * (h >> 1);
+    return {
+        width: w,
+        height: h,
+        pitches: [yPitch, uvPitch, uvPitch],
+        offsets: [0, ySize, ySize + uvSize],
+        size: ySize + uvSize * 2
+    };
+}
+
+// BT.601 limited range, the conversion an adaptor does in hardware.
+function yuvToRgb(y, u, v) {
+    const c = y - 16, d = u - 128, e = v - 128;
+    const clamp = n => n < 0 ? 0 : (n > 255 ? 255 : n | 0);
+    const r = clamp((298 * c + 409 * e + 128) >> 8);
+    const g = clamp((298 * c - 100 * d - 208 * e + 128) >> 8);
+    const b = clamp((298 * c + 516 * d + 128) >> 8);
+    return ((r << 16) | (g << 8) | b) >>> 0;
+}
+
+// One pixel of a decoded frame, as 0x00RRGGBB.
+function samplePixel(format, plane, data, base, x, y) {
+    if (format.format === PACKED) {
+        // YUY2: Y0 U Y1 V per two pixels
+        const row = base + plane.offsets[0] + y * plane.pitches[0];
+        const pair = row + (x >> 1) * 4;
+        const yv = data[pair + ((x & 1) ? 2 : 0)];
+        return yuvToRgb(yv, data[pair + 1], data[pair + 3]);
+    }
+    const yv = data[base + plane.offsets[0] + y * plane.pitches[0] + x];
+    const uv = base + plane.offsets[1] + (y >> 1) * plane.pitches[1] + (x >> 1);
+    const vv = base + plane.offsets[2] + (y >> 1) * plane.pitches[2] + (x >> 1);
+    return yuvToRgb(yv, data[uv], data[vv]);
+}
+
+module.exports = function createXvAdaptor() {
+    const state = {
+        firstEvent: 0,
+        firstError: 0,
+        grabs: new Map(),          // port -> client
+        attributes: new Map(),     // port -> {name: value}
+        videoNotify: new Map(),    // drawable -> Set(client)
+        portNotify: new Map(),     // port -> Set(client)
+        segments: new Map(),       // shmseg -> Buffer (the test fills this in)
+        streaming: new Map(),      // drawable -> port currently putting to it
+        putImages: [],             // decoded PutImage headers, for assertions
+        shmPutImages: []           // decoded ShmPutImage headers
+    };
+
+    const badPort = port => new XError(state.firstError + 0, port);
+
+    const checkPort = port => {
+        if (port < BASE_PORT || port >= BASE_PORT + NUM_PORTS)
+            throw badPort(port);
+        return port;
+    };
+
+    const findFormat = id => {
+        const f = FORMATS.find(f => f.id === id);
+        if (!f)
+            throw new XError(codes.Match, id);
+        return f;
+    };
+
+    const attrValues = port => {
+        let v = state.attributes.get(port);
+        if (!v) {
+            v = {};
+            for (const a of ATTRIBUTES)
+                v[a.name] = a.value;
+            state.attributes.set(port, v);
+        }
+        return v;
+    };
+
+    const select = (map, key, client, onoff) => {
+        let set = map.get(key);
+        if (onoff) {
+            if (!set)
+                map.set(key, set = new Set());
+            set.add(client);
+        } else if (set) {
+            set.delete(client);
+        }
+    };
+
+    // A real adaptor reports Started when a stream begins on a drawable and
+    // Stopped when it ends, not once per frame - so only transitions notify.
+    const startStream = (server, drawable, port) => {
+        if (state.streaming.get(drawable) === port)
+            return;
+        state.streaming.set(drawable, port);
+        sendVideoNotify(server, drawable, port, 0 /* Started */);
+    };
+
+    const stopStream = (server, drawable, port) => {
+        if (state.streaming.get(drawable) === undefined)
+            return;
+        state.streaming.delete(drawable);
+        sendVideoNotify(server, drawable, port, 1 /* Stopped */);
+    };
+
+    const sendVideoNotify = (server, drawable, port, reason) => {
+        const set = state.videoNotify.get(drawable);
+        if (!set)
+            return;
+        const b = Buffer.alloc(32);
+        b[0] = state.firstEvent + 0;
+        b[1] = reason;
+        b.writeUInt32LE(server.now() >>> 0, 4);
+        b.writeUInt32LE(drawable >>> 0, 8);
+        b.writeUInt32LE(port >>> 0, 12);
+        for (const c of set)
+            c.sendEvent(b);
+    };
+
+    const sendPortNotify = (server, port, attribute, value) => {
+        const set = state.portNotify.get(port);
+        if (!set)
+            return;
+        const b = Buffer.alloc(32);
+        b[0] = state.firstEvent + 1;
+        b.writeUInt32LE(server.now() >>> 0, 4);
+        b.writeUInt32LE(port >>> 0, 8);
+        b.writeUInt32LE(attribute >>> 0, 12);
+        b.writeInt32LE(value, 16);
+        for (const c of set)
+            c.sendEvent(b);
+    };
+
+    // The shared half of PutImage / ShmPutImage: decode `data` at `base` per
+    // the format's plane layout and blit it, nearest-neighbour scaled, into
+    // the drawable.
+    const blit = (server, req, data, base) => {
+        const format = findFormat(req.id);
+        const plane = layout(format, req.width, req.height);
+        if (base + plane.size > data.length)
+            throw new XError(codes.Length, plane.size);
+        const drawable = server.getDrawable(req.drawable);
+        const gc = server.getGC(req.gc);
+        const raster = drawable.raster;
+        const rgc = gc.rasterGC();
+        for (let dy = 0; dy < req.drwHeight; dy++) {
+            const sy = req.srcY + Math.floor(dy * req.srcHeight / req.drwHeight);
+            if (sy < 0 || sy >= plane.height)
+                continue;
+            for (let dx = 0; dx < req.drwWidth; dx++) {
+                const sx = req.srcX + Math.floor(dx * req.srcWidth / req.drwWidth);
+                if (sx < 0 || sx >= plane.width)
+                    continue;
+                raster.setPixel(rgc, req.drwX + dx, req.drwY + dy,
+                    samplePixel(format, plane, data, base, sx, sy));
+            }
+        }
+    };
+
+    // 40-byte PutImage header (36 bytes past the request header), or the
+    // same fields at the same offsets for the 52-byte ShmPutImage.
+    const readGeometry = (body, off) => ({
+        srcX: body.readInt16LE(off),
+        srcY: body.readInt16LE(off + 2),
+        srcWidth: body.readUInt16LE(off + 4),
+        srcHeight: body.readUInt16LE(off + 6),
+        drwX: body.readInt16LE(off + 8),
+        drwY: body.readInt16LE(off + 10),
+        drwWidth: body.readUInt16LE(off + 12),
+        drwHeight: body.readUInt16LE(off + 14),
+        width: body.readUInt16LE(off + 16),
+        height: body.readUInt16LE(off + 18)
+    });
+
+    return {
+        name: 'XVideo',
+        eventsCount: 2,
+        errorsCount: 3,
+        state,
+        layout,
+        yuvToRgb,
+        formats: FORMATS,
+        basePort: BASE_PORT,
+        numPorts: NUM_PORTS,
+
+        init(server, ext) {
+            state.firstEvent = ext.firstEvent;
+            state.firstError = ext.firstError;
+        },
+
+        handleRequest(server, client, minor, body) {
+            switch (minor) {
+                case 0: { // QueryExtension (version)
+                    const b = client.startReply(0, 0);
+                    b.writeUInt16LE(2, 8);
+                    b.writeUInt16LE(2, 10);
+                    client.send(b);
+                    break;
+                }
+
+                case 1: { // QueryAdaptors
+                    server.getWindow(body.readUInt32LE(0));
+                    const name = 'JS Test Video';
+                    const infoLen = 12 + pad4(name.length) + 8;
+                    const b = client.startReply(infoLen / 4, 0);
+                    b.writeUInt16LE(1, 8);          // num_adaptors
+                    let o = 32;
+                    b.writeUInt32LE(BASE_PORT, o);
+                    b.writeUInt16LE(name.length, o + 4);
+                    b.writeUInt16LE(NUM_PORTS, o + 6);
+                    b.writeUInt16LE(1, o + 8);      // num_formats
+                    b.writeUInt8(ADAPTOR_TYPE, o + 10);
+                    o += 12;
+                    b.write(name, o, 'latin1');
+                    o += pad4(name.length);
+                    b.writeUInt32LE(server.rootVisual >>> 0, o);
+                    b.writeUInt8(24, o + 4);
+                    client.send(b);
+                    break;
+                }
+
+                case 2: { // QueryEncodings
+                    checkPort(body.readUInt32LE(0));
+                    const name = 'XV_IMAGE';
+                    const b = client.startReply((20 + pad4(name.length)) / 4, 0);
+                    b.writeUInt16LE(1, 8);          // num_encodings
+                    let o = 32;
+                    b.writeUInt32LE(ENCODING, o);
+                    b.writeUInt16LE(name.length, o + 4);
+                    b.writeUInt16LE(2048, o + 6);   // max width
+                    b.writeUInt16LE(2048, o + 8);   // max height
+                    b.writeInt32LE(0, o + 12);      // rate numerator
+                    b.writeInt32LE(1, o + 16);      // rate denominator
+                    o += 20;
+                    b.write(name, o, 'latin1');
+                    client.send(b);
+                    break;
+                }
+
+                case 3: { // GrabPort
+                    const port = checkPort(body.readUInt32LE(0));
+                    const owner = state.grabs.get(port);
+                    const status = (owner && owner !== client) ? 2 /* AlreadyGrabbed */ : 0;
+                    if (status === 0)
+                        state.grabs.set(port, client);
+                    client.send(client.startReply(0, status));
+                    break;
+                }
+
+                case 4: { // UngrabPort
+                    const port = checkPort(body.readUInt32LE(0));
+                    if (state.grabs.get(port) === client)
+                        state.grabs.delete(port);
+                    break;
+                }
+
+                case 9: { // StopVideo
+                    const port = checkPort(body.readUInt32LE(0));
+                    const drawable = body.readUInt32LE(4);
+                    server.getDrawable(drawable);
+                    stopStream(server, drawable, port);
+                    break;
+                }
+
+                case 10: { // SelectVideoNotify
+                    const drawable = body.readUInt32LE(0);
+                    server.getDrawable(drawable);
+                    select(state.videoNotify, drawable, client, body.readUInt8(4) !== 0);
+                    break;
+                }
+
+                case 11: { // SelectPortNotify
+                    const port = checkPort(body.readUInt32LE(0));
+                    select(state.portNotify, port, client, body.readUInt8(4) !== 0);
+                    break;
+                }
+
+                case 12: { // QueryBestSize
+                    checkPort(body.readUInt32LE(0));
+                    const b = client.startReply(0, 0);
+                    // this adaptor scales freely: the requested size is best
+                    b.writeUInt16LE(body.readUInt16LE(8), 8);
+                    b.writeUInt16LE(body.readUInt16LE(10), 10);
+                    client.send(b);
+                    break;
+                }
+
+                case 13: { // SetPortAttribute
+                    const port = checkPort(body.readUInt32LE(0));
+                    const atom = body.readUInt32LE(4);
+                    const value = body.readInt32LE(8);
+                    const name = server.atomsById.get(atom);
+                    const attr = ATTRIBUTES.find(a => a.name === name);
+                    if (!attr)
+                        throw new XError(codes.Match, atom);
+                    if (value < attr.min || value > attr.max)
+                        throw new XError(codes.Value, value);
+                    attrValues(port)[name] = value;
+                    sendPortNotify(server, port, atom, value);
+                    break;
+                }
+
+                case 14: { // GetPortAttribute
+                    const port = checkPort(body.readUInt32LE(0));
+                    const atom = body.readUInt32LE(4);
+                    const name = server.atomsById.get(atom);
+                    const attr = ATTRIBUTES.find(a => a.name === name);
+                    if (!attr)
+                        throw new XError(codes.Match, atom);
+                    const b = client.startReply(0, 0);
+                    b.writeInt32LE(attrValues(port)[name], 8);
+                    client.send(b);
+                    break;
+                }
+
+                case 15: { // QueryPortAttributes
+                    checkPort(body.readUInt32LE(0));
+                    // text_size counts the name strings (each NUL-terminated
+                    // and padded), not the fixed part of the structs
+                    let textSize = 0;
+                    for (const a of ATTRIBUTES)
+                        textSize += pad4(a.name.length + 1);
+                    const b = client.startReply((ATTRIBUTES.length * 16 + textSize) / 4, 0);
+                    b.writeUInt32LE(ATTRIBUTES.length, 8);
+                    b.writeUInt32LE(textSize, 12);
+                    let o = 32;
+                    for (const a of ATTRIBUTES) {
+                        b.writeUInt32LE(a.flags, o);
+                        b.writeInt32LE(a.min, o + 4);
+                        b.writeInt32LE(a.max, o + 8);
+                        b.writeUInt32LE(a.name.length + 1, o + 12);
+                        b.write(a.name, o + 16, 'latin1');
+                        o += 16 + pad4(a.name.length + 1);
+                    }
+                    client.send(b);
+                    break;
+                }
+
+                case 16: { // ListImageFormats
+                    checkPort(body.readUInt32LE(0));
+                    const b = client.startReply(FORMATS.length * 32, 0);
+                    b.writeUInt32LE(FORMATS.length, 8);
+                    let o = 32;
+                    for (const f of FORMATS) {
+                        b.writeUInt32LE(f.id, o);
+                        b.writeUInt8(f.type, o + 4);
+                        b.writeUInt8(f.byteOrder, o + 5);
+                        f.guid.copy(b, o + 8);
+                        b.writeUInt8(f.bpp, o + 24);
+                        b.writeUInt8(f.numPlanes, o + 25);
+                        b.writeUInt8(f.depth, o + 28);
+                        b.writeUInt8(f.format, o + 44);
+                        b.writeUInt32LE(8, o + 48);   // y_sample_bits
+                        b.writeUInt32LE(8, o + 52);   // u_sample_bits
+                        b.writeUInt32LE(8, o + 56);   // v_sample_bits
+                        // chroma subsampling: 4:2:2 packed, 4:2:0 planar
+                        const vertUV = f.format === PLANAR ? 2 : 1;
+                        b.writeUInt32LE(1, o + 60);   // horz_y_period
+                        b.writeUInt32LE(2, o + 64);   // horz_u_period
+                        b.writeUInt32LE(2, o + 68);   // horz_v_period
+                        b.writeUInt32LE(1, o + 72);   // vert_y_period
+                        b.writeUInt32LE(vertUV, o + 76);
+                        b.writeUInt32LE(vertUV, o + 80);
+                        b.write(f.compOrder, o + 84, 'latin1');
+                        b.writeUInt8(f.scanlineOrder, o + 116);
+                        o += 128;
+                    }
+                    client.send(b);
+                    break;
+                }
+
+                case 17: { // QueryImageAttributes
+                    checkPort(body.readUInt32LE(0));
+                    const format = findFormat(body.readUInt32LE(4));
+                    const plane = layout(format, body.readUInt16LE(8), body.readUInt16LE(10));
+                    const b = client.startReply(plane.pitches.length * 2, 0);
+                    b.writeUInt32LE(plane.pitches.length, 8);
+                    b.writeUInt32LE(plane.size, 12);
+                    b.writeUInt16LE(plane.width, 16);
+                    b.writeUInt16LE(plane.height, 18);
+                    for (let i = 0; i < plane.pitches.length; i++) {
+                        b.writeUInt32LE(plane.pitches[i], 32 + i * 4);
+                        b.writeUInt32LE(plane.offsets[i], 32 + plane.pitches.length * 4 + i * 4);
+                    }
+                    client.send(b);
+                    break;
+                }
+
+                case 18: { // PutImage
+                    const req = Object.assign({
+                        port: checkPort(body.readUInt32LE(0)),
+                        drawable: body.readUInt32LE(4),
+                        gc: body.readUInt32LE(8),
+                        id: body.readUInt32LE(12)
+                    }, readGeometry(body, 16));
+                    req.dataLength = body.length - 36;
+                    state.putImages.push(req);
+                    blit(server, req, body, 36);
+                    startStream(server, req.drawable, req.port);
+                    break;
+                }
+
+                case 19: { // ShmPutImage
+                    const req = Object.assign({
+                        port: checkPort(body.readUInt32LE(0)),
+                        drawable: body.readUInt32LE(4),
+                        gc: body.readUInt32LE(8),
+                        shmseg: body.readUInt32LE(12),
+                        id: body.readUInt32LE(16),
+                        offset: body.readUInt32LE(20)
+                    }, readGeometry(body, 24));
+                    req.sendEvent = body.readUInt8(44) !== 0;
+                    state.shmPutImages.push(req);
+                    const segment = state.segments.get(req.shmseg);
+                    if (!segment)
+                        throw new XError(codes.Value, req.shmseg);
+                    blit(server, req, segment, req.offset);
+                    startStream(server, req.drawable, req.port);
+                    break;
+                }
+
+                default:
+                    throw new XError(codes.Implementation, minor);
+            }
+        }
+    };
+};

--- a/test/xserver/xv.js
+++ b/test/xserver/xv.js
@@ -1,0 +1,519 @@
+// XVideo image path against the JS X server with a test adaptor
+// (xv-adaptor.js). Xvfb and XQuartz advertise Xv with zero adaptors, so this
+// is the only place the client's PutImage/ShmPutImage/QueryImageAttributes
+// and the VideoNotify/PortNotify parsers are driven end to end; test/xv.js
+// covers what a real (adaptorless) server can answer.
+const assert = require('assert');
+const xserver = require('../../lib/xserver');
+const { boot, sync } = require('./boot');
+const createXvAdaptor = require('./xv-adaptor');
+
+const YUY2 = 0x32595559;
+const I420 = 0x30323449;
+
+// BT.601 limited range, the same colours a hardware adaptor would produce
+const COLORS = {
+    black: { yuv: [16, 128, 128], rgb: [0, 0, 0] },
+    white: { yuv: [235, 128, 128], rgb: [255, 255, 255] },
+    red: { yuv: [81, 90, 240], rgb: [255, 0, 0] },
+    green: { yuv: [145, 54, 34], rgb: [0, 255, 0] },
+    blue: { yuv: [41, 240, 110], rgb: [0, 0, 255] }
+};
+
+// pack width x height of per-pixel [y, u, v] into the format's plane layout
+function packFrame(format, plane, pixels, width, height) {
+    const data = Buffer.alloc(plane.dataSize);
+    const at = (x, y) => pixels[Math.min(y, height - 1) * width + Math.min(x, width - 1)];
+    if (format === YUY2) {
+        for (let y = 0; y < plane.height; y++)
+            for (let x = 0; x < plane.width; x += 2) {
+                const a = at(x, y), b = at(x + 1, y);
+                const o = plane.offsets[0] + y * plane.pitches[0] + (x >> 1) * 4;
+                data[o] = a[0];
+                data[o + 1] = (a[1] + b[1]) >> 1;
+                data[o + 2] = b[0];
+                data[o + 3] = (a[2] + b[2]) >> 1;
+            }
+        return data;
+    }
+    for (let y = 0; y < plane.height; y++)
+        for (let x = 0; x < plane.width; x++)
+            data[plane.offsets[0] + y * plane.pitches[0] + x] = at(x, y)[0];
+    for (let y = 0; y < plane.height >> 1; y++)
+        for (let x = 0; x < plane.width >> 1; x++) {
+            data[plane.offsets[1] + y * plane.pitches[1] + x] = at(x * 2, y * 2)[1];
+            data[plane.offsets[2] + y * plane.pitches[2] + x] = at(x * 2, y * 2)[2];
+        }
+    return data;
+}
+
+// a frame of one flat colour
+function solidFrame(format, plane, color, width, height) {
+    const pixels = new Array(width * height).fill(COLORS[color].yuv);
+    return packFrame(format, plane, pixels, width, height);
+}
+
+function assertColor(actual, name, where) {
+    const [r, g, b] = COLORS[name].rgb;
+    const got = [(actual >> 16) & 0xff, (actual >> 8) & 0xff, actual & 0xff];
+    // the adaptor converts in 8-bit fixed point, so allow a channel of slack
+    for (let i = 0; i < 3; i++)
+        assert.ok(Math.abs(got[i] - [r, g, b][i]) <= 3,
+            `${where}: expected ${name} (${r},${g},${b}), got (${got})`);
+}
+
+describe('xserver: XVideo image path', function() {
+    this.timeout(20000);
+
+    let server, display, X, root, adaptor, xv, port, pixmap, gc;
+    const W = 16, H = 16;
+
+    beforeEach(done => {
+        adaptor = createXvAdaptor();
+        server = xserver.createServer({ width: 256, height: 256 });
+        server.registerExtension('XVideo', adaptor);
+        boot({ server }, (err, ctx) => {
+            if (err) return done(err);
+            ({ display, X } = ctx);
+            root = display.screen[0].root;
+            pixmap = X.AllocID();
+            X.CreatePixmap(pixmap, root, 24, W, H);
+            gc = X.AllocID();
+            X.CreateGC(gc, pixmap, { foreground: 0, background: 0 });
+            X.PolyFillRectangle(pixmap, gc, [0, 0, W, H]);
+            X.require('xv', (err, ext) => {
+                if (err) return done(err);
+                xv = ext;
+                xv.QueryAdaptors(root, (err, adaptors) => {
+                    if (err) return done(err);
+                    port = adaptors[0].baseId;
+                    done();
+                });
+            });
+        });
+    });
+
+    afterEach(() => {
+        X.terminate();
+        server = display = X = xv = null;
+    });
+
+    function readBack(drawable, w, h, cb) {
+        X.GetImage(2, drawable, 0, 0, w, h, 0xffffffff, (err, img) => {
+            assert.ifError(err);
+            cb((x, y) => img.data.readUInt32LE((y * w + x) * 4));
+        });
+    }
+
+    it('advertises an image adaptor with two formats', done => {
+        assert.strictEqual(xv.major, 2);
+        assert.strictEqual(xv.minor, 2);
+        xv.QueryAdaptors(root, (err, adaptors) => {
+            assert.ifError(err);
+            assert.strictEqual(adaptors.length, 1);
+            assert.strictEqual(adaptors[0].name, 'JS Test Video');
+            assert.strictEqual(adaptors[0].numPorts, 2);
+            assert.ok(adaptors[0].type & xv.Type.ImageMask);
+            xv.ListImageFormats(port, (err, formats) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(formats.map(f => f.id), [YUY2, I420]);
+                assert.strictEqual(formats[0].bpp, 16);
+                assert.strictEqual(formats[0].numPlanes, 1);
+                assert.strictEqual(formats[0].format, xv.ImageFormatInfoFormat.Packed);
+                assert.strictEqual(formats[0].compOrder, 'YUYV');
+                assert.strictEqual(formats[0].guid.length, 16);
+                assert.strictEqual(formats[1].bpp, 12);
+                assert.strictEqual(formats[1].numPlanes, 3);
+                assert.strictEqual(formats[1].format, xv.ImageFormatInfoFormat.Planar);
+                assert.strictEqual(formats[1].type, xv.ImageFormatInfoType.YUV);
+                done();
+            });
+        });
+    });
+
+    describe('QueryImageAttributes', () => {
+        it('reports the packed plane layout, rounding the size up', done => {
+            xv.QueryImageAttributes(port, YUY2, 7, 5, (err, attrs) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(attrs, {
+                    numPlanes: 1,
+                    dataSize: 96,
+                    width: 8,      // rounded up to even
+                    height: 6,
+                    pitches: [16], // 8 pixels x 2 bytes
+                    offsets: [0]
+                });
+                done();
+            });
+        });
+
+        it('reports one pitch and one offset per plane for planar formats', done => {
+            xv.QueryImageAttributes(port, I420, 7, 5, (err, attrs) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(attrs, {
+                    numPlanes: 3,
+                    dataSize: 72,
+                    width: 8,
+                    height: 6,
+                    pitches: [8, 4, 4],
+                    offsets: [0, 48, 60]
+                });
+                done();
+            });
+        });
+
+        it('raises XvBadPort for a port the adaptor does not own', done => {
+            xv.QueryImageAttributes(0, YUY2, 8, 8, err => {
+                assert.strictEqual(err.error, xv.errors.BadPort);
+                done();
+                return true;
+            });
+        });
+    });
+
+    describe('PutImage', () => {
+        it('draws a packed YUY2 frame', done => {
+            xv.QueryImageAttributes(port, YUY2, W, H, (err, plane) => {
+                assert.ifError(err);
+                const data = solidFrame(YUY2, plane, 'red', W, H);
+                xv.PutImage(port, pixmap, gc, YUY2, {
+                    srcX: 0, srcY: 0, srcWidth: W, srcHeight: H,
+                    drwX: 0, drwY: 0, drwWidth: W, drwHeight: H,
+                    width: W, height: H, data
+                });
+                readBack(pixmap, W, H, px => {
+                    assertColor(px(0, 0), 'red', 'top left');
+                    assertColor(px(W - 1, H - 1), 'red', 'bottom right');
+                    done();
+                });
+            });
+        });
+
+        it('puts every header field at its own offset', done => {
+            // all-distinct values: any two fields swapped or shifted shows up
+            const geometry = {
+                srcX: 1, srcY: 2, srcWidth: 3, srcHeight: 4,
+                drwX: 5, drwY: 6, drwWidth: 7, drwHeight: 8,
+                width: 9, height: 10
+            };
+            xv.QueryImageAttributes(port, YUY2, geometry.width, geometry.height, (err, plane) => {
+                assert.ifError(err);
+                const data = solidFrame(YUY2, plane, 'white', geometry.width, geometry.height);
+                xv.PutImage(port, pixmap, gc, YUY2, Object.assign({ data }, geometry));
+                sync(X, () => {
+                    assert.deepStrictEqual(adaptor.state.putImages, [Object.assign({
+                        port, drawable: pixmap, gc, id: YUY2, dataLength: plane.dataSize
+                    }, geometry)]);
+                    done();
+                });
+            });
+        });
+
+        it('honours the pitches and offsets of a planar I420 frame', done => {
+            // width 6 pads to a pitch of 8, so a decoder that ignores pitches
+            // reads the wrong bytes from row 1 on
+            const w = 6, h = 6;
+            xv.QueryImageAttributes(port, I420, w, h, (err, plane) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(plane.pitches, [8, 4, 4]);
+                const pixels = [];
+                for (let y = 0; y < h; y++)
+                    for (let x = 0; x < w; x++)
+                        pixels.push(COLORS[y < 2 ? 'red' : (y < 4 ? 'green' : 'blue')].yuv);
+                const data = packFrame(I420, plane, pixels, w, h);
+                xv.PutImage(port, pixmap, gc, I420, {
+                    srcX: 0, srcY: 0, srcWidth: w, srcHeight: h,
+                    drwX: 0, drwY: 0, drwWidth: w, drwHeight: h,
+                    width: w, height: h, data
+                });
+                readBack(pixmap, W, H, px => {
+                    assertColor(px(0, 0), 'red', 'row 0');
+                    assertColor(px(5, 1), 'red', 'row 1');
+                    assertColor(px(0, 2), 'green', 'row 2');
+                    assertColor(px(5, 3), 'green', 'row 3');
+                    assertColor(px(0, 5), 'blue', 'row 5');
+                    done();
+                });
+            });
+        });
+
+        it('scales the source rectangle into the destination rectangle', done => {
+            xv.QueryImageAttributes(port, YUY2, 4, 4, (err, plane) => {
+                assert.ifError(err);
+                // left half white, right half red; U/V are shared per pair, so
+                // the boundary at x = 2 falls between pairs and stays exact
+                const pixels = [];
+                for (let y = 0; y < 4; y++)
+                    for (let x = 0; x < 4; x++)
+                        pixels.push(COLORS[x < 2 ? 'white' : 'red'].yuv);
+                const data = packFrame(YUY2, plane, pixels, 4, 4);
+                // take the right half only and scale it up 2x
+                xv.PutImage(port, pixmap, gc, YUY2, {
+                    srcX: 2, srcY: 0, srcWidth: 2, srcHeight: 4,
+                    drwX: 0, drwY: 0, drwWidth: 8, drwHeight: 8,
+                    width: 4, height: 4, data
+                });
+                readBack(pixmap, W, H, px => {
+                    for (let y = 0; y < 8; y++)
+                        for (let x = 0; x < 8; x++)
+                            assertColor(px(x, y), 'red', `${x},${y}`);
+                    // nothing outside the destination rectangle
+                    assertColor(px(8, 0), 'black', 'right of the destination');
+                    assertColor(px(0, 8), 'black', 'below the destination');
+                    done();
+                });
+            });
+        });
+
+        it('pads a payload that is not a whole number of words', done => {
+            xv.QueryImageAttributes(port, YUY2, 4, 4, (err, plane) => {
+                assert.ifError(err);
+                // one byte past the plane data: the request must still be
+                // framed to a word boundary or the server loses the stream
+                const data = Buffer.concat([solidFrame(YUY2, plane, 'blue', 4, 4), Buffer.from([0])]);
+                assert.strictEqual(data.length % 4, 1);
+                xv.PutImage(port, pixmap, gc, YUY2, {
+                    srcX: 0, srcY: 0, srcWidth: 4, srcHeight: 4,
+                    drwX: 0, drwY: 0, drwWidth: 4, drwHeight: 4,
+                    width: 4, height: 4, data
+                });
+                readBack(pixmap, W, H, px => {
+                    assertColor(px(0, 0), 'blue', 'padded frame');
+                    assert.strictEqual(adaptor.state.putImages.length, 1);
+                    assert.strictEqual(adaptor.state.putImages[0].dataLength, 36);
+                    done();
+                });
+            });
+        });
+
+        it('sends a frame too large for the 16-bit length field', done => {
+            // 512x256 YUY2 is 256 KiB: 65546 words, past the 65535 a plain
+            // request length can hold, so this takes the BIG-REQUESTS encoding
+            const w = 512, h = 256;
+            const big = X.AllocID();
+            X.CreatePixmap(big, root, 24, w, h);
+            xv.QueryImageAttributes(port, YUY2, w, h, (err, plane) => {
+                assert.ifError(err);
+                assert.ok(10 + plane.dataSize / 4 > 0xffff, 'frame should exceed the plain length field');
+                const data = solidFrame(YUY2, plane, 'green', w, h);
+                xv.PutImage(port, big, gc, YUY2, {
+                    srcX: 0, srcY: 0, srcWidth: w, srcHeight: h,
+                    drwX: 0, drwY: 0, drwWidth: w, drwHeight: h,
+                    width: w, height: h, data
+                });
+                sync(X, () => {
+                    assert.deepStrictEqual(adaptor.state.putImages, [{
+                        port, drawable: big, gc, id: YUY2, dataLength: plane.dataSize,
+                        srcX: 0, srcY: 0, srcWidth: w, srcHeight: h,
+                        drwX: 0, drwY: 0, drwWidth: w, drwHeight: h,
+                        width: w, height: h
+                    }]);
+                    X.GetImage(2, big, w - 2, h - 2, 2, 2, 0xffffffff, (err, img) => {
+                        assert.ifError(err);
+                        assertColor(img.data.readUInt32LE(0), 'green', 'last pixels');
+                        X.FreePixmap(big);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('reports XvBadPort through the callback', done => {
+            xv.PutImage(0, pixmap, gc, YUY2, {
+                srcX: 0, srcY: 0, srcWidth: 2, srcHeight: 2,
+                drwX: 0, drwY: 0, drwWidth: 2, drwHeight: 2,
+                width: 2, height: 2, data: Buffer.alloc(16)
+            }, err => {
+                assert.strictEqual(err.error, xv.errors.BadPort);
+                done();
+                return true;
+            });
+        });
+    });
+
+    describe('ShmPutImage', () => {
+        it('draws from a segment at an offset and carries send_event', done => {
+            const shmseg = 0xbeef;
+            xv.QueryImageAttributes(port, YUY2, 4, 4, (err, plane) => {
+                assert.ifError(err);
+                const offset = 64;
+                const segment = Buffer.alloc(offset + plane.dataSize);
+                solidFrame(YUY2, plane, 'white', 4, 4).copy(segment, offset);
+                adaptor.state.segments.set(shmseg, segment);
+                xv.ShmPutImage(port, pixmap, gc, shmseg, YUY2, {
+                    srcX: 0, srcY: 0, srcWidth: 4, srcHeight: 4,
+                    drwX: 2, drwY: 2, drwWidth: 4, drwHeight: 4,
+                    width: 4, height: 4, offset, sendEvent: true
+                });
+                readBack(pixmap, W, H, px => {
+                    assertColor(px(2, 2), 'white', 'destination origin');
+                    assertColor(px(5, 5), 'white', 'destination corner');
+                    assertColor(px(1, 1), 'black', 'outside the destination');
+                    assert.deepStrictEqual(adaptor.state.shmPutImages, [{
+                        port, drawable: pixmap, gc, shmseg, id: YUY2, offset,
+                        srcX: 0, srcY: 0, srcWidth: 4, srcHeight: 4,
+                        drwX: 2, drwY: 2, drwWidth: 4, drwHeight: 4,
+                        width: 4, height: 4, sendEvent: true
+                    }]);
+                    done();
+                });
+            });
+        });
+
+        it('reports XvBadPort through the callback', done => {
+            xv.ShmPutImage(0, pixmap, gc, 0xbeef, YUY2, {
+                srcX: 0, srcY: 0, srcWidth: 2, srcHeight: 2,
+                drwX: 0, drwY: 0, drwWidth: 2, drwHeight: 2,
+                width: 2, height: 2, offset: 0, sendEvent: false
+            }, err => {
+                assert.strictEqual(err.error, xv.errors.BadPort);
+                done();
+                return true;
+            });
+        });
+    });
+
+    describe('event selection', () => {
+        it('SelectVideoNotify delivers XvVideoNotify for a drawable', done => {
+            X.on('event', ev => {
+                if (ev.name !== 'XvVideoNotify')
+                    return;
+                assert.strictEqual(ev.drawable, pixmap);
+                assert.strictEqual(ev.port, port);
+                assert.strictEqual(ev.reason, xv.VideoNotifyReason.Started);
+                assert.ok(ev.time > 0);
+                done();
+            });
+            xv.SelectVideoNotify(pixmap, true, err => {
+                assert.ifError(err);
+                xv.QueryImageAttributes(port, YUY2, 4, 4, (err, plane) => {
+                    assert.ifError(err);
+                    xv.PutImage(port, pixmap, gc, YUY2, {
+                        srcX: 0, srcY: 0, srcWidth: 4, srcHeight: 4,
+                        drwX: 0, drwY: 0, drwWidth: 4, drwHeight: 4,
+                        width: 4, height: 4,
+                        data: solidFrame(YUY2, plane, 'red', 4, 4)
+                    });
+                });
+                return true;
+            });
+        });
+
+        it('StopVideo ends the stream and reports it as XvVideoNotify Stopped', done => {
+            const seen = [];
+            X.on('event', ev => {
+                if (ev.name !== 'XvVideoNotify')
+                    return;
+                seen.push(ev.reason);
+                if (seen.length < 2)
+                    return;
+                assert.deepStrictEqual(seen, [
+                    xv.VideoNotifyReason.Started,
+                    xv.VideoNotifyReason.Stopped
+                ]);
+                assert.strictEqual(ev.drawable, pixmap);
+                assert.strictEqual(ev.port, port);
+                done();
+            });
+            xv.SelectVideoNotify(pixmap, true, err => {
+                assert.ifError(err);
+                xv.QueryImageAttributes(port, YUY2, 4, 4, (err, plane) => {
+                    assert.ifError(err);
+                    xv.PutImage(port, pixmap, gc, YUY2, {
+                        srcX: 0, srcY: 0, srcWidth: 4, srcHeight: 4,
+                        drwX: 0, drwY: 0, drwWidth: 4, drwHeight: 4,
+                        width: 4, height: 4,
+                        data: solidFrame(YUY2, plane, 'blue', 4, 4)
+                    });
+                    // a second frame is the same stream: no further Started
+                    xv.PutImage(port, pixmap, gc, YUY2, {
+                        srcX: 0, srcY: 0, srcWidth: 4, srcHeight: 4,
+                        drwX: 0, drwY: 0, drwWidth: 4, drwHeight: 4,
+                        width: 4, height: 4,
+                        data: solidFrame(YUY2, plane, 'blue', 4, 4)
+                    });
+                    xv.StopVideo(port, pixmap, err => {
+                        assert.ifError(err);
+                        return true;
+                    });
+                });
+                return true;
+            });
+        });
+
+        it('raises XvBadPort for StopVideo on a bogus port', done => {
+            xv.StopVideo(0, pixmap, err => {
+                assert.strictEqual(err.error, xv.errors.BadPort);
+                done();
+                return true;
+            });
+        });
+
+        it('SelectPortNotify delivers XvPortNotify when an attribute changes', done => {
+            X.InternAtom(false, 'XV_BRIGHTNESS', (err, atom) => {
+                assert.ifError(err);
+                X.on('event', ev => {
+                    if (ev.name !== 'XvPortNotify')
+                        return;
+                    assert.strictEqual(ev.port, port);
+                    assert.strictEqual(ev.attribute, atom);
+                    assert.strictEqual(ev.value, -250);
+                    done();
+                });
+                xv.SelectPortNotify(port, true, err => {
+                    assert.ifError(err);
+                    xv.SetPortAttribute(port, atom, -250);
+                    return true;
+                });
+            });
+        });
+
+        it('stops delivering once deselected', done => {
+            X.InternAtom(false, 'XV_CONTRAST', (err, atom) => {
+                assert.ifError(err);
+                let events = 0;
+                X.on('event', ev => {
+                    if (ev.name === 'XvPortNotify')
+                        events++;
+                });
+                xv.SelectPortNotify(port, true, () => {
+                    xv.SetPortAttribute(port, atom, 100);
+                    xv.SelectPortNotify(port, false, () => {
+                        xv.SetPortAttribute(port, atom, 200);
+                        sync(X, () => {
+                            assert.strictEqual(events, 1);
+                            xv.GetPortAttribute(port, atom, (err, value) => {
+                                assert.ifError(err);
+                                assert.strictEqual(value, 200);
+                                done();
+                            });
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+            });
+        });
+
+        it('raises XvBadPort for SelectPortNotify on a bogus port', done => {
+            xv.SelectPortNotify(0, true, err => {
+                assert.strictEqual(err.error, xv.errors.BadPort);
+                done();
+                return true;
+            });
+        });
+    });
+
+    it('grabs and ungrabs a port, and answers QueryBestSize', done => {
+        xv.GrabPort(port, 0, (err, status) => {
+            assert.ifError(err);
+            assert.strictEqual(status, xv.GrabPortStatus.Success);
+            xv.QueryBestSize(port, 320, 240, 640, 480, false, (err, size) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(size, { width: 640, height: 480 });
+                xv.UngrabPort(port, 0);
+                sync(X, () => done());
+            });
+        });
+    });
+});

--- a/test/xv.js
+++ b/test/xv.js
@@ -12,26 +12,39 @@ const BOGUS_PORT = 0;
 describe('XVideo extension', () => {
 
     let X;
+    let display;
     let root;
+    let gc;
     let xv;
     let adaptors;
     let port = null;
+    let imageFormat = null;
     let errorHandler = null;
 
     before(done => {
         const client = x11.createClient((err, dpy) => {
             should.not.exist(err);
+            display = dpy;
             X = dpy.client;
             root = dpy.screen[0].root;
             X.require('xv', (err, ext) => {
                 should.not.exist(err);
                 xv = ext;
+                gc = X.AllocID();
+                X.CreateGC(gc, root);
                 xv.QueryAdaptors(root, (err, list) => {
                     should.not.exist(err);
                     adaptors = list;
-                    if (adaptors.length > 0)
-                        port = adaptors[0].baseId;
-                    done();
+                    if (adaptors.length === 0)
+                        return done();
+                    port = adaptors[0].baseId;
+                    // with a real adaptor, pick a format for the image path
+                    xv.ListImageFormats(port, (err, formats) => {
+                        should.not.exist(err);
+                        if (formats.length > 0)
+                            imageFormat = formats[0];
+                        done();
+                    });
                 });
             });
         });
@@ -44,6 +57,7 @@ describe('XVideo extension', () => {
     });
 
     after(done => {
+        X.FreeGC(gc);
         X.terminate();
         X.on('end', done);
     });
@@ -183,5 +197,145 @@ describe('XVideo extension', () => {
                 return true;
             });
         }
+    });
+
+    // Nothing here can put a frame without an adaptor, so the image-path
+    // requests are checked the other way round: the request must reach the
+    // server well-formed (a controlled XvBadPort rather than BadLength) and
+    // must leave the connection in sync - a wrong length would make the
+    // server read the payload as further requests, so the round trip after
+    // it would come back with the wrong sequence number or not at all.
+    // test/xserver/xv.js drives the same requests to completion against the
+    // JS server's test adaptor.
+    const stillInSync = done => {
+        const seq = X.seq_num;
+        X.GetInputFocus((err, focus) => {
+            should.not.exist(err);
+            focus.should.be.an.Object();
+            X.seq_num.should.equal(seq + 1);
+            done();
+        });
+    };
+
+    it('StopVideo should raise XvBadPort for a bogus port', done => {
+        // always the error path: with a real port this would stop whatever
+        // another client is putting into the root window
+        xv.StopVideo(BOGUS_PORT, root, err => {
+            err.error.should.equal(xv.errors.BadPort);
+            stillInSync(done);
+            return true;
+        });
+    });
+
+    it('SelectVideoNotify should be accepted for any drawable', done => {
+        // takes a drawable, not a port: it works on an adaptorless server
+        xv.SelectVideoNotify(root, true, err => {
+            should.not.exist(err);
+            xv.SelectVideoNotify(root, false, err => {
+                should.not.exist(err);
+                done();
+                return true;
+            });
+            return true;
+        });
+    });
+
+    it('SelectPortNotify should subscribe or raise XvBadPort', done => {
+        if (port !== null) {
+            xv.SelectPortNotify(port, true, err => {
+                should.not.exist(err);
+                xv.SelectPortNotify(port, false);
+                done();
+                return true;
+            });
+        } else {
+            xv.SelectPortNotify(BOGUS_PORT, true, err => {
+                err.error.should.equal(xv.errors.BadPort);
+                done();
+                return true;
+            });
+        }
+    });
+
+    it('QueryImageAttributes should report a plane layout or raise XvBadPort', done => {
+        if (port !== null && imageFormat !== null) {
+            xv.QueryImageAttributes(port, imageFormat.id, 320, 240, (err, attrs) => {
+                should.not.exist(err);
+                attrs.numPlanes.should.equal(imageFormat.numPlanes);
+                attrs.dataSize.should.be.above(0);
+                attrs.width.should.be.aboveOrEqual(320);
+                attrs.height.should.be.aboveOrEqual(240);
+                attrs.pitches.length.should.equal(attrs.numPlanes);
+                attrs.offsets.length.should.equal(attrs.numPlanes);
+                attrs.offsets[0].should.equal(0);
+                done();
+            });
+        } else {
+            xv.QueryImageAttributes(BOGUS_PORT, 0x32595559, 16, 16, err => {
+                err.error.should.equal(xv.errors.BadPort);
+                done();
+                return true;
+            });
+        }
+    });
+
+    it('PutImage should reach the server and keep the connection in sync', done => {
+        const img = {
+            srcX: 0, srcY: 0, srcWidth: 16, srcHeight: 16,
+            drwX: 0, drwY: 0, drwWidth: 16, drwHeight: 16,
+            width: 16, height: 16,
+            data: Buffer.alloc(16 * 16 * 2)
+        };
+        xv.PutImage(BOGUS_PORT, root, gc, 0x32595559, img, err => {
+            err.error.should.equal(xv.errors.BadPort);
+            stillInSync(done);
+            return true;
+        });
+    });
+
+    it('PutImage should use the BIG-REQUESTS encoding past 256 KiB', done => {
+        // 512x512 at 3 bytes/pixel is 786432 bytes: 196618 words, well past
+        // the 65535 a plain request length field can hold
+        const img = {
+            srcX: 0, srcY: 0, srcWidth: 512, srcHeight: 512,
+            drwX: 0, drwY: 0, drwWidth: 512, drwHeight: 512,
+            width: 512, height: 512,
+            data: Buffer.alloc(512 * 512 * 3)
+        };
+        xv.PutImage(BOGUS_PORT, root, gc, 0x32595559, img, err => {
+            err.error.should.equal(xv.errors.BadPort);
+            stillInSync(done);
+            return true;
+        });
+    });
+
+    it('PutImage should refuse a frame the connection cannot carry', done => {
+        const words = (display.max_request_length || 0xffff) + 1;
+        const img = {
+            srcX: 0, srcY: 0, srcWidth: 16, srcHeight: 16,
+            drwX: 0, drwY: 0, drwWidth: 16, drwHeight: 16,
+            width: 16, height: 16,
+            data: Buffer.alloc(words * 4)
+        };
+        const seq = X.seq_num;
+        xv.PutImage(BOGUS_PORT, root, gc, 0x32595559, img, err => {
+            err.message.should.match(/maximum request length/);
+            // nothing went out: the sequence number did not move
+            X.seq_num.should.equal(seq);
+            stillInSync(done);
+            return true;
+        });
+    });
+
+    it('ShmPutImage should reach the server and keep the connection in sync', done => {
+        xv.ShmPutImage(BOGUS_PORT, root, gc, 0 /* any seg */, 0x32595559, {
+            srcX: 0, srcY: 0, srcWidth: 16, srcHeight: 16,
+            drwX: 0, drwY: 0, drwWidth: 16, drwHeight: 16,
+            width: 16, height: 16, offset: 0, sendEvent: false
+        }, err => {
+            err.error.should.equal(xv.errors.BadPort);
+            stillInSync(done);
+            return true;
+        });
     });
 });


### PR DESCRIPTION
Closes #294.

`lib/ext/xv.js` implemented the half of X-Video that asks questions and none of the half that answers with pixels: you could enumerate adaptors, grab a port and list its image formats, and then had no way to show that port a frame. This adds the requests that close the loop.

## New API

| minor | signature |
|---|---|
| 9 | `StopVideo(port, drawable, [cb])` |
| 10 | `SelectVideoNotify(drawable, onoff, [cb])` |
| 11 | `SelectPortNotify(port, onoff, [cb])` |
| 17 | `QueryImageAttributes(port, id, width, height, cb)` → `{numPlanes, dataSize, width, height, pitches, offsets}` |
| 18 | `PutImage(port, drawable, gc, id, img, [cb])` |
| 19 | `ShmPutImage(port, drawable, gc, shmseg, id, img, [cb])` |

```js
Xv.QueryImageAttributes(port, format.id, 640, 480, (err, plane) => {
    const frame = Buffer.alloc(plane.dataSize);
    // fill plane i at plane.offsets[i], plane.pitches[i] bytes per row
    Xv.PutImage(port, win, gc, format.id, {
        srcX: 0, srcY: 0, srcWidth: plane.width, srcHeight: plane.height,
        drwX: 0, drwY: 0, drwWidth: 1280, drwHeight: 960,
        width: plane.width, height: plane.height, data: frame
    });
});
```

`10` and `11` are what makes the `XvVideoNotify` / `XvPortNotify` parsers reachable — they have been registered since extension coverage landed, with no way to ask a server to send the events they parse. `StopVideo` is filed with the capture-side requests in the protocol but belongs here: it is how an image client releases a drawable, and it is what produces `XvVideoNotify` with reason `Stopped`.

Three things about `PutImage` a caller has to know, all in [docs/ext/xv.md](docs/ext/xv.md):

- **The frame is queued by reference, not copied.** Core `PutImage` copies its data into the request buffer; this one does not, because copying 3 MiB per frame defeats the purpose. Do not overwrite the buffer until the server has read it — alternate two buffers, wait for `cb`, or use `ShmPutImage` with `sendEvent` and let `ShmCompletion` pace the reuse.
- **Frames past 256 KiB take the BIG-REQUESTS encoding**, which the request selects on its own (enabled by default at connect).
- **A frame past `max_request_length` is refused before anything is sent**, through `cb` or as a thrown `Error`. A server that reads a length it cannot accept drops the whole connection rather than just the request, so this is worth catching client-side.

## Testing, given that adaptors need hardware

An Xv adaptor comes from a driver with a video path. **Xvfb and XQuartz both advertise `X-Video Extension version 2.2` and answer "no adaptors present"**, so nothing in CI can accept a frame. Coverage is therefore in two tiers.

**Against the real server** ([test/xv.js](test/xv.js), 17 tests). A bogus port on its own turns out to be a weak framing check — Xorg validates the port before the length, so a malformed `XvPutImage` still comes back `XvBadPort` while its payload desyncs the stream. The tests assert `XvBadPort` *and* that the connection is still in step afterwards. Verified by mutation: with the length field written to ignore the payload, five tests fail and the connection dies. `SelectVideoNotify` takes a drawable rather than a port, so it exercises a real success path even with no adaptors; the port-based requests take their success paths automatically wherever an adaptor does exist.

**Against a test adaptor** ([test/xserver/xv.js](test/xserver/xv.js), 20 tests). Following the `glx-emu` precedent, [test/xserver/xv-adaptor.js](test/xserver/xv-adaptor.js) registers a YUY2 + I420 image adaptor on the pure-JS X server, decoded from `autogen/proto/xv.xml` rather than from this client's encoder. That runs the image path to completion with no hardware: frames converted and compared pixel by pixel, plane pitches and offsets honoured, `src`→`drw` scaling, odd-length payload padding, the BIG-REQUESTS path at 512x256, every `ShmPutImage` field, and both notify events delivered including the Started/Stopped pair around `StopVideo`. Mutation-checked as well — a shifted `drw_x` or a wrong pitch offset each fail three tests.

```
npm run lint    clean
npm test        523 passing (Xvfb)
test:xserver    309 passing
test:bun         10 passing
```

## Example

[`examples/xv/testpattern.js`](examples/xv/testpattern.js) puts 75% colour bars through an adaptor, over the wire or through a MIT-SHM segment with `--shm`, printing fps, MiB/s and what core `PutImage` would have sent for the same picture. On a machine with no adaptor it prints the adaptor list and exits, which is the fallback any Xv client needs.

## Scope and what is still unproven

Not implemented: `PutVideo` (5), `PutStill` (6), `GetVideo` (7), `GetStill` (8). They drive a video *input* port — a capture card scanning into a drawable — which no current driver ships and nothing in CI could exercise.

Everything here was developed and verified on macOS plus the JS server, which means the following still wants a run on a box with a real adaptor: a real driver's plane alignment (drivers pad pitches to 8/16/64), a frame actually on screen, `XvShmPutImage` against a real `SHMSEG` with `ShmCompletion` routing (the JS server has no MIT-SHM, and `AttachFd` is Linux-only), and `XvVideoNotify` from a server that means it. `npm test` on such a machine covers the first of those on its own, and `examples/xv/testpattern.js --width 1920 --height 1080` covers the rest by eye.
